### PR TITLE
fix(BDropdown): using manual control to display/hide the popover it s…

### DIFF
--- a/apps/playground/src/components/Comps/TPopover.vue
+++ b/apps/playground/src/components/Comps/TPopover.vue
@@ -119,6 +119,17 @@
         </b-popover>
       </b-col>
       <b-col>
+        <b-button ref="popoverManualButtonRef" @click="manualClickPopoverExample = !manualClickPopoverExample" >Manual popover showing</b-button>
+        <b-popover
+          :target="() => popoverManualButtonRef"
+          manual
+          :model-value="manualClickPopoverExample"
+          placement="right"
+        >
+          simple content
+        </b-popover>
+      </b-col>
+      <b-col>
         <b-popover placement="auto">
           <template #title>
             Auto placement
@@ -220,6 +231,8 @@ const popoverInput = ref('foo')
 const popoverRef = ref(null)
 const popoverContainerRef = ref(null)
 const value = ref(true)
+const manualClickPopoverExample = ref(false)
+const popoverManualButtonRef = ref(null)
 
 const textValue = ref('test <b onmouseover="alert(\'XSS testing!\')">with html</b>')
 const popoverPlacemet = ref<BPopoverPlacement>('left')

--- a/packages/bootstrap-vue-next/src/components/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover.vue
@@ -397,6 +397,7 @@ const hide = (e: Event) => {
   setTimeout(() => {
     if (
       e?.type === 'click' ||
+      (e?.type === 'update:modelValue' && manualBoolean.value) ||
       (isOutside.value &&
         triggerIsOutside.value &&
         !element.value?.contains(document?.activeElement))


### PR DESCRIPTION
# Describe the PR

It's not possible to hide the popover using the manual configuration with :model-value, doing a infinite loop with the hide function mean while it's waiting for a new click outside of our component. I guess the event "update:modelValue" generated from watching the variable modelValueBoolean it should hide directly the popover.

## Small replication

If the change is large enough, a small replication can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
