### PR TITLE
feat(BDropdown): allow define aria-label to b-button

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -93,8 +93,8 @@ export default defineComponent({
     ])
 
     const computedAttrs = computed(() => ({
-      'aria-disabled': props.ariaLabel,
-      'aria-label': nonStandardTag.value ? disabledBoolean.value : null,
+      'aria-disabled': nonStandardTag.value ? disabledBoolean.value : null,
+      'aria-label': props.ariaLabel,
       'aria-pressed': isToggle.value ? pressedBoolean.value : null,
       'autocomplete': isToggle.value ? 'off' : null,
       'disabled': isButton.value ? disabledBoolean.value : null,

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -41,7 +41,6 @@ export default defineComponent({
   components: {BLink, BSpinner},
   props: {
     ...BLINK_PROPS,
-    ariaLabel: {type: String, default: null},
     active: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     disabled: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     href: {type: String, default: undefined},
@@ -94,7 +93,6 @@ export default defineComponent({
 
     const computedAttrs = computed(() => ({
       'aria-disabled': nonStandardTag.value ? disabledBoolean.value : null,
-      'aria-label': props.ariaLabel,
       'aria-pressed': isToggle.value ? pressedBoolean.value : null,
       'autocomplete': isToggle.value ? 'off' : null,
       'disabled': isButton.value ? disabledBoolean.value : null,

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -41,6 +41,7 @@ export default defineComponent({
   components: {BLink, BSpinner},
   props: {
     ...BLINK_PROPS,
+    ariaLabel: {type: String, default: null},
     active: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     disabled: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     href: {type: String, default: undefined},
@@ -92,7 +93,8 @@ export default defineComponent({
     ])
 
     const computedAttrs = computed(() => ({
-      'aria-disabled': nonStandardTag.value ? disabledBoolean.value : null,
+      'aria-disabled': props.ariaLabel,
+      'aria-label': nonStandardTag.value ? disabledBoolean.value : null,
       'aria-pressed': isToggle.value ? pressedBoolean.value : null,
       'autocomplete': isToggle.value ? 'off' : null,
       'disabled': isButton.value ? disabledBoolean.value : null,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -73,6 +73,7 @@ defineOptions({
 // TODO standardize keydown vs keyup events globally
 
 interface BDropdownProps {
+  ariaLabel?: string
   id?: string
   menuClass?: ClassValue
   size?: Size
@@ -109,6 +110,7 @@ interface BDropdownProps {
 }
 
 const props = withDefaults(defineProps<BDropdownProps>(), {
+  ariaLabel: undefined,
   id: undefined,
   menuClass: undefined,
   size: 'md',
@@ -256,6 +258,7 @@ const dropdownMenuClasses = computed(() => [
 ])
 
 const buttonAttr = computed(() => ({
+  'aria-label': props.ariaLabel,
   'aria-expanded': splitBoolean.value ? undefined : modelValueBoolean.value,
   'aria-haspopup': splitBoolean.value ? undefined : 'menu',
   'href': splitBoolean.value ? props.splitHref : undefined,


### PR DESCRIPTION
# Describe the PR

allow define aria-label to b-button (and same using b-dropdown)

## Small replication

If the change is large enough, a small replication can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


BEGIN_COMMIT_OVERRIDE
feat(BDropdown): allow define aria-label to b-button
END_COMMIT_OVERRIDE
