### PR TITLE
fix(VBTooltip): don't render a BPopover when is disabled by code the …

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BPopover.ts
+++ b/packages/bootstrap-vue-next/src/directives/BPopover.ts
@@ -2,6 +2,7 @@ import {type Directive, ref} from 'vue'
 import {
   bind,
   type ElementWithPopper,
+  resolveActiveStatus,
   resolveContent,
   resolveDirectiveProps,
   unbind,
@@ -9,6 +10,9 @@ import {
 
 export default {
   mounted(el, binding) {
+    const isActive = resolveActiveStatus(binding.value)
+    if (!isActive) return
+
     const text = resolveContent(binding.value, el)
 
     el.$__state = ref({
@@ -18,6 +22,9 @@ export default {
     bind(el, binding)
   },
   updated(el, binding) {
+    const isActive = resolveActiveStatus(binding.value)
+    if (!isActive) return
+
     const text = resolveContent(binding.value, el)
 
     if (!el.$__state) return


### PR DESCRIPTION
# Describe the PR

A clear and concise description of what the pull request does.

## Small replication

don't render a BPopover when is disabled by code the "v-b-tooltip",

So, if we provide an object with property active as false, we don't want to use the v-b-tooltip and we should not display the little arrow when the mouse is over the element.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
