### PR TITLE
fix(VBTooltip): don't render a BTooltip when is disabled by code usin…

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BTooltip.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip.ts
@@ -11,6 +11,8 @@ import {
 export default {
   mounted(el, binding) {
     const isActive = resolveActiveStatus(binding.value)
+    if (!isActive) return
+
     const text = resolveContent(binding.value, el)
 
     el.$__state = ref({
@@ -22,6 +24,8 @@ export default {
   },
   updated(el, binding) {
     const isActive = resolveActiveStatus(binding.value)
+    if (!isActive) return
+
     const text = resolveContent(binding.value, el)
     if (!el.$__state) return
     el.$__state.value = {


### PR DESCRIPTION
# Describe the PR

 don't render a BTooltip when is disabled by code using the directive.
My previous MR was doing the work for the directive "v-b-popover", but I didn't notice that, It's missing the same for the directive "v-b-tooltip".

## Small replication

If the change is large enough, a small replication can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
