### PR TITLE
Docs Updates: TOC anchors

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -88,35 +88,28 @@
       </client-only>
     </aside>
     <main class="bd-main">
-      <div class="bd-content">
-        <b-row v-if="page.isNotFound">
-          <b-col>
-            <b-container class="text-center my-auto p-5">
-              <b-row>
-                <b-col>
-                  <h1>Oh No!</h1>
-                </b-col>
-              </b-row>
-              <b-row>
-                <b-col>
-                  <h2>File Not Found</h2>
-                </b-col>
-              </b-row>
-            </b-container>
-          </b-col>
-        </b-row>
-        <b-row v-else>
-          <b-col>
-            <b-container>
-              <b-row>
-                <b-col>
-                  <Content class="doc-content" />
-                </b-col>
-              </b-row>
-            </b-container>
-          </b-col>
-        </b-row>
-      </div>
+      <b-row v-if="page.isNotFound">
+        <b-col>
+          <b-container class="text-center my-auto p-5">
+            <b-row>
+              <b-col>
+                <h1>Oh No!</h1>
+              </b-col>
+            </b-row>
+            <b-row>
+              <b-col>
+                <h2>File Not Found</h2>
+              </b-col>
+            </b-row>
+          </b-container>
+        </b-col>
+      </b-row>
+      <b-row v-else>
+        <div class="bd-content">
+          <div class="bd-toc" />
+          <Content class="doc-content" />
+        </div>
+      </b-row>
     </main>
   </b-container>
 </template>
@@ -352,7 +345,7 @@ const globalData = inject(appInfoKey, {
     text-decoration: none;
   }
   // Navbar.
-  .navbar {
+  > .navbar {
     color: var(--white);
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15), inset 0 -1px 0 rgba(255, 255, 255, 0.15);
     .nav-link,
@@ -483,25 +476,62 @@ const globalData = inject(appInfoKey, {
       }
     }
     .bd-main {
-      display: grid;
-      grid-area: main;
-      grid-template-areas: 'content toc';
-      grid-template-rows: auto 1fr;
-      grid-template-columns: 4fr 1fr;
       .bd-content {
-        grid-area: content;
-        min-width: 1px;
+        display: grid;
+        grid-area: main;
+        grid-template-areas: 'intro toc' 'content toc';
+        grid-template-rows: auto 1fr;
+        grid-template-columns: 4fr 1fr;
+        gap: inherit;
+        .doc-content {
+          grid-area: content;
+          min-width: 1px;
+        }
+        .bd-toc {
+          &::before {
+            content: 'On this page';
+            display: block;
+            margin: 0 0 0.5rem 0.8rem;
+            padding-bottom: 0.5rem;
+            border-bottom: var(--bs-border-width) solid rgba(255, 255, 255, 0.2);
+          }
+          margin-left: 1.25rem;
+          grid-area: toc;
+          position: -webkit-sticky;
+          position: sticky;
+          top: 5rem;
+          right: 0;
+          z-index: 2;
+          height: calc(100vh - 7rem);
+          overflow-y: auto;
+          .table-of-contents {
+            font-size: 0.875rem;
+            ul {
+              padding-left: 0;
+              margin-bottom: 0;
+              list-style: none;
+              a {
+                display: block;
+                padding: 0.125rem 0 0.125rem 0.75rem;
+                color: inherit;
+                text-decoration: none;
+                border-left: 0.125rem solid transparent;
+                &.active {
+                  color: var(--bd-toc-color);
+                  border-left-color: var(--bd-toc-color);
+                }
+                &:hover {
+                  color: var(--bd-toc-color);
+                  border-left-color: var(--bd-toc-color);
+                }
+              }
+              ul {
+                padding-left: 1rem;
+              }
+            }
+          }
+        }
       }
-    }
-    .bd-toc {
-      grid-area: toc;
-      position: -webkit-sticky;
-      position: sticky;
-      top: 5rem;
-      right: 0;
-      z-index: 2;
-      height: calc(100vh - 7rem);
-      overflow-y: auto;
     }
   }
 }

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -28,6 +28,7 @@
           <b-nav-item :to="withBase('/docs')">Getting Started</b-nav-item>
           <b-nav-item :to="withBase('/docs/icons')">Icons</b-nav-item>
           <b-nav-item :to="withBase('/docs/types')">Types</b-nav-item>
+          <b-nav-item :to="withBase('/docs/reference')">Reference</b-nav-item>
           <b-nav-item :to="withBase('/docs/migration-guide')">Migrate</b-nav-item>
         </b-nav>
       </b-navbar-nav>

--- a/apps/docs/src/components/TableOfContentsNav.vue
+++ b/apps/docs/src/components/TableOfContentsNav.vue
@@ -12,6 +12,9 @@
         <b-link :to="withBase('/docs/types')">Types</b-link>
       </b-list-group-item>
       <b-list-group-item>
+        <b-link :to="withBase('/docs/reference')">Reference</b-link>
+      </b-list-group-item>
+      <b-list-group-item>
         <b-link :to="withBase('/docs/migration-guide')">Migrate</b-link>
       </b-list-group-item>
     </b-list-group>

--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -1,5 +1,13 @@
 # Introduction
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead">
 
 Get started with BootstrapVueNext and Bootstrap `v5`, the world’s most popular framework for building responsive, mobile-first sites.
@@ -201,7 +209,7 @@ app.mount('#app')
 
 </b-card>
 
-### Installation - Nuxt.js 3 <a id="nuxtjs" class="anchorjs-link"></a>
+### Installation - Nuxt.js 3
 
 In your Nuxt3 application, install the necessary packages for `bootstrap-vue-next`.
 

--- a/apps/docs/src/docs/components/accordion.md
+++ b/apps/docs/src/docs/components/accordion.md
@@ -1,5 +1,13 @@
 # Accordion
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Build vertically collapsing accordions in combination with `<b-collapse>` component.

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -1,5 +1,13 @@
 # Alert
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages.

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -1,5 +1,13 @@
 # Avatar
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Avatars are a custom component, and are typically used to display a user profile as a

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -1,5 +1,13 @@
 # Badge
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Documentation and examples for badges, our small count and labeling component.

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -1,5 +1,13 @@
 # Breadcrumb
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Indicate the current page's location within a navigational hierarchy. Separators are automatically added in CSS through `::before` and `content`.

--- a/apps/docs/src/docs/components/button-group.md
+++ b/apps/docs/src/docs/components/button-group.md
@@ -1,5 +1,13 @@
 # Button Group
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Group a series of buttons together on a single line or stack them in a vertical column with `<b-button-group>`.

--- a/apps/docs/src/docs/components/button-toolbar.md
+++ b/apps/docs/src/docs/components/button-toolbar.md
@@ -1,5 +1,13 @@
 # Button Toolbar
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Group a series of button-groups and/or input-groups together on a single line.

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -1,5 +1,13 @@
 # Button
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Use Bootstrap's custom `b-button` component for actions in forms, dialogs, and more. Includes support for a handful of contextual variations, sizes, states, and more.

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -1,5 +1,13 @@
 # Card
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 A card is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options.

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -1,5 +1,13 @@
 # Carousel
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 The Carousel is a slideshow for cycling through a series of content.

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -1,5 +1,13 @@
 # Collapse
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Easily toggle visibility of almost any content on your pages in a vertically collapsing container.

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -1,5 +1,13 @@
 # Dropdown
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Dropdowns are toggleable, contextual overlays for displaying lists of links and actions in a dropdown menu format.

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -1,5 +1,13 @@
 # Form Checkbox
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 For cross browser consistency, `<b-form-checkbox-group>` and `<b-form-checkbox>` use Bootstrap's custom checkbox input to replace the browser default checkbox input. It is built on top of semantic and accessible markup, so it is a solid replacement for the default checkbox input.

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -1,5 +1,13 @@
 # Form Group
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 The `<b-form-group>` component is the easiest way to add some structure to forms. Its purpose is to pair form controls with a legend or label, and to provide help text and invalid/valid feedback text, as well as visual (color) contextual state feedback.

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -1,5 +1,13 @@
 # Form Input
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Create various type inputs such as: `text`, `password`, `number`, `url`, `email`, `search`, `range`, `date` and more.

--- a/apps/docs/src/docs/components/form-radio.md
+++ b/apps/docs/src/docs/components/form-radio.md
@@ -1,5 +1,13 @@
 # Form Radio
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 For cross browser consistency, `<b-form-radio-group>` and `<b-form-radio>` uses Bootstrap's custom radio input to replace the browser default radio input. It is built on top of semantic and accessible markup, so it is a solid replacement for the default radio input.

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -1,5 +1,13 @@
 # Form Select
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Bootstrap custom `<select>` using custom styles. Optionally specify options based on an array, array of objects, or an object.

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -1,8 +1,26 @@
 # Form Tags
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+Lightweight custom tagged input form control, with options for customized interface rendering, duplicate tag detection and optional tag validation.
+
+</div>
+
+Tags are arrays of short strings, used in various ways such as assigning categories. Use the default user interface, or create your own custom interface via the use of the default scoped slot.
+
 ## Docs to be written
 
 ## Example
+
+<b-card class="bg-body-tertiary">
 
 ```vue
 <template>
@@ -15,3 +33,9 @@
 const value = ref<string[]>(['apple', 'orange'])
 </script>
 ```
+
+</b-card>
+
+<script setup lang="ts">
+import {BCard} from 'bootstrap-vue-next'
+</script>

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -1,5 +1,13 @@
 # Form Textarea
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Create multi-line text inputs with support for auto height sizing, minimum and maximum number of rows, and contextual states.

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -1,5 +1,13 @@
 # Form
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 BootstrapVueNext form component and helper components that optionally support inline form styles and

--- a/apps/docs/src/docs/components/grid-system.md
+++ b/apps/docs/src/docs/components/grid-system.md
@@ -1,5 +1,13 @@
 # Grid System
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Bootstrap Vue offers several utility components to assist in building your grid layout.

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -1,5 +1,13 @@
 # Image
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Documentation and examples for opting images (via `<b-img>` component) into responsive behavior (so they never become larger than their parent elements), optionally adding lightweight styles to them — all via props.

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -1,5 +1,13 @@
 # Input Group
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Easily extend form controls by adding text, buttons, or button groups on either side of textual inputs.

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -1,5 +1,19 @@
 # Link
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+Use BootstrapVue's custom b-link component for generating a standard `<a>` link or `<router-link>`. `<b-link>` supports the disabled state and click event propagation.
+
+</div>
+
 ## Links without Router
 
 By defaut links with no options will default to # location.

--- a/apps/docs/src/docs/components/list-group.md
+++ b/apps/docs/src/docs/components/list-group.md
@@ -1,5 +1,13 @@
 # List Group
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 List Groups are a flexible and powerful component for displaying a series of content. List Group items can be modified to support just about any content within. They can also be used as navigation via various props.

--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -1,5 +1,19 @@
 # Modal
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+Modals are streamlined, but flexible dialog prompts powered by JavaScript and CSS. They support a number of use cases from user notification to completely custom content and feature a handful of helpful sub-components, sizes, variants, accessibility, and more.
+
+</div>
+
 ## Usage
 
 <HighlightCard>

--- a/apps/docs/src/docs/components/nav.md
+++ b/apps/docs/src/docs/components/nav.md
@@ -1,5 +1,13 @@
 # Nav
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Bootstrap's vue nav component is a simple wrapper for building navigation components.

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -87,8 +87,6 @@ The component `<b-navbar>` is a wrapper that positions branding, navigation, and
   </template>
 </HighlightCard>
 
-## Docs to be written
-
 ## Color schemes
 
 `<b-navbar>` supports the standard Bootstrap v4 available background color variants. Set the variant prop to one of the following values to change the background color: primary, success, info, warning, danger, dark, or light.

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -1,10 +1,452 @@
 # Navbar
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+The component `<b-navbar>` is a wrapper that positions branding, navigation, and other elements into a concise header. It's easily extensible and thanks to the `<b-collapse>` component, it can easily integrate responsive behaviors.
+
+</div>
+
+<HighlightCard>
+  <b-navbar toggleable="lg" type="dark" variant="dark">
+    <b-navbar-brand href="#">NavBar</b-navbar-brand>
+    <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
+    <b-collapse id="nav-collapse" is-nav>
+      <b-navbar-nav>
+        <b-nav-item href="#">Link</b-nav-item>
+        <b-nav-item href="#" disabled>Disabled</b-nav-item>
+      </b-navbar-nav>
+      <!-- Right aligned nav items -->
+      <b-navbar-nav class="me-auto mb-2 mb-lg-0">
+        <b-nav-item-dropdown text="Lang" right>
+          <b-dropdown-item href="#">EN</b-dropdown-item>
+          <b-dropdown-item href="#">ES</b-dropdown-item>
+          <b-dropdown-item href="#">RU</b-dropdown-item>
+          <b-dropdown-item href="#">FA</b-dropdown-item>
+        </b-nav-item-dropdown>
+        <b-nav-item-dropdown right>
+          <!-- Using 'button-content' slot -->
+          <template #button-content>
+            <em>User</em>
+          </template>
+          <b-dropdown-item href="#">Profile</b-dropdown-item>
+          <b-dropdown-item href="#">Sign Out</b-dropdown-item>
+        </b-nav-item-dropdown>
+      </b-navbar-nav>
+      <b-nav-form class="d-flex">
+        <b-form-input class="me-2" placeholder="Search"></b-form-input>
+        <b-button type="submit" variant="outline-success">Search</b-button>
+      </b-nav-form>
+    </b-collapse>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar toggleable="lg" type="dark" variant="dark">
+    <b-navbar-brand href="#">NavBar</b-navbar-brand>
+    <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
+    <b-collapse id="nav-collapse" is-nav>
+      <b-navbar-nav>
+        <b-nav-item href="#">Link</b-nav-item>
+        <b-nav-item href="#" disabled>Disabled</b-nav-item>
+      </b-navbar-nav>
+      <!-- Right aligned nav items -->
+      <b-navbar-nav class="me-auto mb-2 mb-lg-0">
+        <b-nav-item-dropdown text="Lang" right>
+          <b-dropdown-item href="#">EN</b-dropdown-item>
+          <b-dropdown-item href="#">ES</b-dropdown-item>
+          <b-dropdown-item href="#">RU</b-dropdown-item>
+          <b-dropdown-item href="#">FA</b-dropdown-item>
+        </b-nav-item-dropdown>
+        <b-nav-item-dropdown right>
+          <!-- Using 'button-content' slot -->
+          <template #button-content>
+            <em>User</em>
+          </template>
+          <b-dropdown-item href="#">Profile</b-dropdown-item>
+          <b-dropdown-item href="#">Sign Out</b-dropdown-item>
+        </b-nav-item-dropdown>
+      </b-navbar-nav>
+      <b-nav-form class="d-flex">
+        <b-form-input class="me-2" placeholder="Search"></b-form-input>
+        <b-button type="submit" variant="outline-success">Search</b-button>
+      </b-nav-form>
+    </b-collapse>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
 ## Docs to be written
+
+## Color schemes
+
+`<b-navbar>` supports the standard Bootstrap v4 available background color variants. Set the variant prop to one of the following values to change the background color: primary, success, info, warning, danger, dark, or light.
+
+Control the text color by setting `type` prop to `light` for use with light background color variants, or dark for dark background color variants.
+
+## Placement
+
+Control the placement of the navbar by setting one of two props:
+
+Notes:
+
+- Fixed positioning uses CSS `position: fixed`. You may need to adjust your document top/bottom padding or margin.
+- CSS `position: sticky` (used for `sticky`) is not fully supported in every browser. For browsers that do not support `position: sticky`, it will fallback natively to `position: relative`.
+
+## Supported content
+
+Navbars come with built-in support for a handful of sub-components. Choose from the following as needed:
+
+- `<b-navbar-brand>` for your company, product, or project name.
+- `<b-navbar-toggle>` for use with the `<b-collapse is-nav>` component.
+- `<b-collapse is-nav>` for grouping and hiding navbar contents by a parent breakpoint.
+- `<b-navbar-nav>` for a full-height and lightweight navigation (including support for dropdowns). The following sub-components inside `<b-navbar-nav>` are supported:
+  -- `<b-nav-item>` for link (and router-link) action items
+  -- `<b-nav-item-dropdown>` for nav dropdown menus
+  -- `<b-nav-text>` for adding vertically centered strings of text.
+  -- `<b-nav-form>` for any form controls and actions.
+
+## `<b-navbar-brand>`
+
+The `<b-navbar-brand>` generates a link if href is provided, or a `<router-link>` if to is provided. If neither is given it renders as a `<div>` tag. You can override the tag type by setting the tag prop to the element you would like rendered:
+
+<HighlightCard>
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">BootstrapVueNext</b-navbar-brand>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <!-- As a link -->
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">BootstrapVueNext</b-navbar-brand>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+<HighlightCard>
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand tag="h1" class="mb-0">BootstrapVue</b-navbar-brand>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <!-- As a heading -->
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand tag="h1" class="mb-0">BootstrapVue</b-navbar-brand>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+Adding images to the `<b-navbar-brand>` will likely always require custom styles or utilities to properly size. Here are some examples to demonstrate:
+
+<HighlightCard>
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">
+      <img src="https://placekitten.com/g/30/30" alt="Kitten">
+    </b-navbar-brand>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <!-- Just an image -->
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">
+      <img src="https://placekitten.com/g/30/30" alt="Kitten">
+    </b-navbar-brand>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+<HighlightCard>
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">
+      <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
+      BootstrapVue
+    </b-navbar-brand>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <!-- Image and text -->
+  <b-navbar variant="faded" type="light">
+    <b-navbar-brand href="#">
+      <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
+      BootstrapVue
+    </b-navbar-brand>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## `<b-navbar-nav>`
+
+Navbar navigation links build on the `<b-navbar-nav>` parent component and requires the use of `<b-collapse is-nav>` and `<b-nav-toggle>` toggler for proper responsive styling. Navigation in navbars will also grow to occupy as much horizontal space as possible to keep your navbar contents securely aligned.
+
+`<b-navbar-nav>` supports the following child components:
+
+- `<b-nav-item>` for link (and router-link) action items
+- `<b-nav-text>` for adding vertically centered strings of text.
+- `<b-nav-item-dropdown>` for navbar dropdown menus
+- `<b-nav-form>` for adding simple forms to the navbar.
+
+## `<b-nav-item>`
+
+`<b-nav-item>` is the primary link (and `<router-link>`) component. Providing a to prop value will generate a `<router-link>` while providing an href prop value will generate a standard link.
+
+Set the `<b-nav-item>` active prop will highlight the item as being the active page, Disable a `<b-nav-item>` by setting the prop disabled to true.
+
+Handle click events by specifying a handler for the @click event on `<b-nav-item>`.
+
+## `<b-nav-text>`
+
+Navbars may contain bits of text with the help of `<b-nav-text>`. This component adjusts vertical alignment and horizontal spacing for strings of text.
+
+<HighlightCard>
+  <b-navbar toggleable="sm" type="light" variant="light">
+    <b-navbar-toggle target="nav-text-collapse"></b-navbar-toggle>
+    <b-navbar-brand>BootstrapVue</b-navbar-brand>
+    <b-collapse id="nav-text-collapse" is-nav>
+      <b-navbar-nav>
+        <b-nav-text>Navbar text</b-nav-text>
+      </b-navbar-nav>
+    </b-collapse>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar toggleable="sm" type="light" variant="light">
+    <b-navbar-toggle target="nav-text-collapse"></b-navbar-toggle>
+
+    <b-navbar-brand>BootstrapVue</b-navbar-brand>
+
+    <b-collapse id="nav-text-collapse" is-nav>
+      <b-navbar-nav>
+        <b-nav-text>Navbar text</b-nav-text>
+      </b-navbar-nav>
+    </b-collapse>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## `<b-nav-item-dropdown>`
+
+For `<b-nav-item-dropdown>` usage, see the `<b-dropdown>` docs. Note split dropdowns are not supported in `<b-navbar>` and `<b-navbar-nav>`.
+
+<HighlightCard>
+  <b-navbar type="dark" variant="dark">
+    <b-navbar-nav>
+      <b-nav-item href="#">Home</b-nav-item>
+      <b-nav-item-dropdown text="Lang" right>
+        <b-dropdown-item href="#">EN</b-dropdown-item>
+        <b-dropdown-item href="#">ES</b-dropdown-item>
+        <b-dropdown-item href="#">RU</b-dropdown-item>
+        <b-dropdown-item href="#">FA</b-dropdown-item>
+      </b-nav-item-dropdown>
+      <b-nav-item-dropdown text="User" right>
+        <b-dropdown-item href="#">Account</b-dropdown-item>
+        <b-dropdown-item href="#">Settings</b-dropdown-item>
+      </b-nav-item-dropdown>
+    </b-navbar-nav>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar type="dark" variant="dark">
+    <b-navbar-nav>
+      <b-nav-item href="#">Home</b-nav-item>
+
+      <!-- Navbar dropdowns -->
+      <b-nav-item-dropdown text="Lang" right>
+        <b-dropdown-item href="#">EN</b-dropdown-item>
+        <b-dropdown-item href="#">ES</b-dropdown-item>
+        <b-dropdown-item href="#">RU</b-dropdown-item>
+        <b-dropdown-item href="#">FA</b-dropdown-item>
+      </b-nav-item-dropdown>
+
+      <b-nav-item-dropdown text="User" right>
+        <b-dropdown-item href="#">Account</b-dropdown-item>
+        <b-dropdown-item href="#">Settings</b-dropdown-item>
+      </b-nav-item-dropdown>
+    </b-navbar-nav>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## `<b-nav-form>`
+
+Use `<b-nav-form>` to place inline form controls into your navbar
+
+<HighlightCard>
+  <b-navbar type="light" variant="light">
+    <b-nav-form>
+      <b-form-input class="me-sm-2" placeholder="Search"></b-form-input>
+      <b-button variant="outline-success" class="my-2 my-sm-0" type="submit">Search</b-button>
+    </b-nav-form>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar type="light" variant="light">
+    <b-nav-form>
+      <b-form-input class="me-sm-2" placeholder="Search"></b-form-input>
+      <b-button variant="outline-success" class="my-2 my-sm-0" type="submit">Search</b-button>
+    </b-nav-form>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+Input Groups work as well:
+
+<HighlightCard>
+  <b-navbar type="light" variant="light">
+    <b-nav-form>
+      <b-input-group prepend="@">
+        <b-form-input placeholder="Username"></b-form-input>
+      </b-input-group>
+    </b-nav-form>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar type="light" variant="light">
+    <b-nav-form>
+      <b-input-group prepend="@">
+        <b-form-input placeholder="Username"></b-form-input>
+      </b-input-group>
+    </b-nav-form>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## `<b-navbar-toggle>` and `<b-collapse is-nav>`
+
+Navbars are not responsive by default, but you can easily modify them to change that. Responsive behavior depends on our `<b-collapse>` component.
+
+Wrap `<b-navbar-nav>` components in a `<b-collapse is-nav>` (remember to set the is-nav prop!) to specify content that will collapse based on a particular breakpoint. Assign a document unique id value on the `<b-collapse>`.
+
+Use the `<b-navbar-toggle>` component to control the collapse component, and set the target prop of `<b-navbar-toggle>` to the id of `<b-collapse>`.
+
+Set the toggleable prop on `<b-navbar>` to the desired breakpoint you would like content to automatically expand at. Possible toggleable values are sm, md, lg and xl. Setting toggleable to true (or an empty string) will set the navbar to be always collapsed, while setting it to false (the default) will disable collapsing (always expanded).
+
+`<b-navbar-toggle>` components are left-aligned by default, but should they follow a sibling element like `<b-navbar-brand>`, they'll automatically be aligned to the far right. Reversing your markup will reverse the placement of the toggler.
+
+See the first example on this page for reference, and also refer to `<b-collapse>` for details on the collapse component.
+
+Besides being used to control a collapse, the `<b-navbar-toggle>` can also be used to toggle visibility of the `<b-sidebar>` component. Just specify the ID of the `<b-sidebar>` via the target prop.
+
+Internally, `<b-navbar-toggle>` uses the v-b-toggle directive.
+
+### Custom navbar toggle
+
+`<b-navbar-toggle>` renders the default Bootstrap v4 hamburger (which is a background SVG image). You can supply your own content (such as an icon) via the optionally scoped default slot. The default slot scope contains the property expanded, which will be true when the collapse is expanded, or false when the collapse is collapsed.
+
+Note that the expanded scope property only works when supplying the target prop as a string, and not an array.
+
+<HighlightCard>
+  <b-navbar toggleable type="dark" variant="dark">
+    <b-navbar-brand href="#">NavBar</b-navbar-brand>
+    <b-navbar-toggle target="navbar-toggle-collapse">
+      <template #default="{ expanded }">
+        <b-icon v-if="expanded" icon="chevron-bar-up"></b-icon>
+        <b-icon v-else icon="chevron-bar-down"></b-icon>
+      </template>
+    </b-navbar-toggle>
+    <b-collapse id="navbar-toggle-collapse" is-nav>
+      <b-navbar-nav class="ml-auto">
+        <b-nav-item href="#">Link 1</b-nav-item>
+        <b-nav-item href="#">Link 2</b-nav-item>
+        <b-nav-item href="#" disabled>Disabled</b-nav-item>
+      </b-navbar-nav>
+    </b-collapse>
+  </b-navbar>
+  <template #html>
+
+```vue-html
+<template>
+  <b-navbar toggleable type="dark" variant="dark">
+    <b-navbar-brand href="#">NavBar</b-navbar-brand>
+
+    <b-navbar-toggle target="navbar-toggle-collapse">
+      <template #default="{ expanded }">
+        <b-icon v-if="expanded" icon="chevron-bar-up"></b-icon>
+        <b-icon v-else icon="chevron-bar-down"></b-icon>
+      </template>
+    </b-navbar-toggle>
+
+    <b-collapse id="navbar-toggle-collapse" is-nav>
+      <b-navbar-nav class="ml-auto">
+        <b-nav-item href="#">Link 1</b-nav-item>
+        <b-nav-item href="#">Link 2</b-nav-item>
+        <b-nav-item href="#" disabled>Disabled</b-nav-item>
+      </b-navbar-nav>
+    </b-collapse>
+  </b-navbar>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## Printing
+
+Navbars are hidden by default when printing. Force them to be printed by setting the print prop.
+
+## See also
+
+- `<b-collapse>` component
+- `<b-sidebar>` component
+- v-b-toggle directive
+- `<b-nav>` documentation for additional components and sub-component aliases
+  Refer to the Router support reference page for router-link specific props.
 
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
 import {data} from '../../data/components/navbar.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import HighlightCard from '../../components/HighlightCard.vue'
+import {BNavbar, BNavbarBrand, BNavbarToggle, BCollapse, BNavbarNav, BNavForm, BNavItem, BFormInput, BNavbarItem, BNavItemDropdown, BDropdownItem, BButton} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/offcanvas.md
+++ b/apps/docs/src/docs/components/offcanvas.md
@@ -1,5 +1,13 @@
 # Offcanvas
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Build hidden sidebars into your project. Sidebars can aid in enhancing user interaction or preventing further interaction.

--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -1,5 +1,13 @@
 # Overlay
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 BootstrapVueNext's custom `b-overlay` component is used to _visually obscure_ a particular element or component and its content. It signals to the user of a state change within the element or component and can be used for creating loaders, warnings/alerts, prompts, and more.

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -1,5 +1,13 @@
 # Pagination
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Quick first, previous, next, last, and page buttons for pagination control of another component

--- a/apps/docs/src/docs/components/placeholder.md
+++ b/apps/docs/src/docs/components/placeholder.md
@@ -1,5 +1,13 @@
 # Placeholder
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Placeholders are components that indicate that something may still be loading.

--- a/apps/docs/src/docs/components/popover.md
+++ b/apps/docs/src/docs/components/popover.md
@@ -1,5 +1,13 @@
 # Popover
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 ## Docs to be written
 
 <ComponentReference :data="data" />

--- a/apps/docs/src/docs/components/progress.md
+++ b/apps/docs/src/docs/components/progress.md
@@ -1,5 +1,13 @@
 # Placeholder
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Placeholders are components that indicate that something may still be loading.

--- a/apps/docs/src/docs/components/spin-button.md
+++ b/apps/docs/src/docs/components/spin-button.md
@@ -1,5 +1,13 @@
 # Form Spinbutton
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 The Form SpinButton allows the user to adjusting a numeric range with finite control.

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -1,5 +1,13 @@
 # Spinners
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 Indicate the loading state of a component or page with Bootstrap spinners, built entirely with HTML, CSS, and no JavaScript.

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -1,5 +1,13 @@
 # Tables
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 For displaying tabular data, `<b-table>` supports pagination, filtering, sorting, custom rendering, various style options, events, and asynchronous data. For simple display of tabular data without all the fancy features, BootstrapVueNext provides two lightweight alternative components `<b-table-lite>` and `<b-table-simple>`.

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -1,5 +1,13 @@
 # Tabs
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 ## Docs to be written
 
 <ComponentReference :data="data" />

--- a/apps/docs/src/docs/components/toast.md
+++ b/apps/docs/src/docs/components/toast.md
@@ -1,5 +1,13 @@
 # Toast
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 ## To be implemented
 
 <ComponentReference :data="data" />

--- a/apps/docs/src/docs/components/toast.md
+++ b/apps/docs/src/docs/components/toast.md
@@ -8,11 +8,28 @@
   </Teleport>
 </ClientOnly>
 
-## To be implemented
+<div class="lead mb-5">
+
+Push notifications to your visitors with a `<b-toast>` and `<b-toaster>`, lightweight components which are easily customizable for generating alert messages.
+
+</div>
+
+Toasts are lightweight notifications designed to mimic the push notifications that have been popularized by mobile and desktop operating systems.
+
+Toasts are intended to be small interruptions to your visitors or users, and therefore should contain minimal, to-the-point, non-interactive content. Please refer to the Accessibility tips section below for important usage information.
+
+## Overview
+
+To encourage extensible and predictable toasts, we recommend providing a header (title) and body. Toast headers use the style `display: flex`, allowing easy alignment of content thanks to Bootstrap's margin and flexbox utility classes.
+
+Toasts are slightly translucent, too, so they blend over whatever they might appear over. For browsers that support the `backdrop-filter` CSS property, they also attempt to blur the elements under the toast.
+
+## Docs to be completed
 
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
 import {data} from '../../data/components/toast.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import {BButtonGroup, BButton, BToast} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/composables/useBreadcrumb.md
+++ b/apps/docs/src/docs/composables/useBreadcrumb.md
@@ -1,5 +1,13 @@
 # useBreadcrumb
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 'useBreadcrumb' is a helper utility for the 'b-breadcrumb' component. It provides a **globally** changable context so you can modify a breadcrumb. It should be noted that the breacrumb component will automatically use the global context by default. 'useBreadcrumb' is shared globally, one modification to the state will be recognized throughout the app. As noted in the BBreadcrumb documentation, the items prop for the component takes precedence over 'useBreadcrumb'.

--- a/apps/docs/src/docs/composables/useColorMode.md
+++ b/apps/docs/src/docs/composables/useColorMode.md
@@ -1,5 +1,13 @@
 # useColorMode
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 'useColorMode' provides a convenient utility to adjust the global color theme of your application. You can also use it to target specific components. Bootstrap's default behavior dictates that color modes are applied to all children in the branch. `useColorMode` is simply a wrapper for the [vueuse](https://vueuse.org/core/useColorMode/#usecolormode) utility.

--- a/apps/docs/src/docs/directives/BColorMode.md
+++ b/apps/docs/src/docs/directives/BColorMode.md
@@ -1,5 +1,13 @@
 # BColorMode
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 'BColorMode' is similar to [useColorMode](../composables/useColorMode.md) but provides a more low level directive for placement on individual components

--- a/apps/docs/src/docs/directives/BTooltip.md
+++ b/apps/docs/src/docs/directives/BTooltip.md
@@ -1,5 +1,13 @@
 # Tooltip
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <b-card class="bg-body-tertiary">
 
 ```vue-html

--- a/apps/docs/src/docs/icons.md
+++ b/apps/docs/src/docs/icons.md
@@ -1,5 +1,13 @@
 # Icons
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <b-alert variant="danger" :model-value="true" class="my-5">
 
 The icon components from BootstrapVue are deprecated. While migrating to BootstrapVueNext the icon components will not be supported as there are better, more modern solutions to incorporating icon packages into your application. Continue reading BootstrapVueNext's suggestion on how to incorporate Bootstrap-icons into your application! This documentation only serves as a reference, BootstrapVueNext has no part in the mentioned libraries and some content may be out of date.

--- a/apps/docs/src/docs/reference.md
+++ b/apps/docs/src/docs/reference.md
@@ -1,0 +1,86 @@
+# Reference - Table of Contents
+
+<div class="lead mb-5">
+
+BootstrapVueNext and Bootstrap reference, and additional resources documentation.
+
+</div>
+
+<table-of-contents-card v-for="component in computedComponentsList" :key="component.name" class="my-3" :name="component.name" :description="component.description" :route="component.route" />
+
+<script setup lang="ts">
+import {withBase} from 'vitepress'
+import {computed} from 'vue'
+import TableOfContentsCard from '../components/TableOfContentsCard.vue'
+
+const routeLocation = (name: string): string => withBase(`/docs/reference/${name.toLowerCase()}`).trim().replaceAll(/\s+/g, '-')
+
+const componentList: {name: string; description: string}[] = [
+  {
+    name: 'Accessibility',
+    description:
+      `A brief overview of BootstrapVueNext's features and limitations for the creation of accessible content`,
+  },
+  {
+    name: 'Color Variants',
+    description:
+      'Color variants available when using the default Bootstrap v5 CSS and their mappings to CSS classes',
+  },
+  {
+    name: 'Contributing',
+    description:
+      'Information on contributing to the BootstrapVueNext project',
+  },
+  {
+    name: 'Router Links',
+    description: 'Several BootstrapVueNext components support rendering `<router-link>` components compatible with Vue Router and Nuxt.js',
+  },
+  {
+    name: 'Settings',
+    description: 'BootstrapVue provides a few options for customizing component default values, and more',
+  },
+  {
+    name: 'Size props and classes',
+    description: 'Bootstrap v5 CSS provides several classes that control the sizing of elements, of which some of these have been translated into props on components',
+  },
+  {
+    name: 'Spacing classes',
+    description: `Bootstrap v5 CSS includes a wide range of shorthand responsive margin and padding utility classes to modify an element's appearance`,
+  },
+  {
+    name: 'Starter Templates',
+    description:
+      'There are several ways you can create your app, from basic client side HTML all the way up to using a build system and compilers',
+  },
+  {
+    name: 'Theming Bootstrap',
+    description:
+      `Theming is accomplished by SASS variables, SASS maps, and custom CSS. There's no dedicated theme stylesheet; instead, you can enable the built-in theme to add gradients, shadows, and more.`,
+  },
+  {
+    name: 'Third party libraries',
+    description:
+      'There are several 3rd party libraries that you can use to add additional functionality and features to your BootstrapVue project',
+  },
+  {
+    name: 'Utility Classes',
+    description:
+      'Bootstrap v5 CSS provides various utility classes to control color, spacing, flex-box, text alignment, floating, position, responsive display/hiding and much more',
+  },
+  {
+    name: 'Form Validation',
+    description:
+      'BootstrapVueNext does not include form validation by default; we leave that up to the many existing form validation plugins. Included here are some examples of validation plugins and how they may be integrated',
+  },
+]
+
+const computedComponentsList = computed(() =>
+  [...componentList]
+    .map((el) => ({
+      name: el.name,
+      description: el.description,
+      route: routeLocation(el.name),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+)
+</script>

--- a/apps/docs/src/docs/reference/accessibility.md
+++ b/apps/docs/src/docs/reference/accessibility.md
@@ -1,0 +1,100 @@
+# Accessibility
+
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+A brief overview of BootstrapVueNext's features and limitations for the creation of accessible content.
+
+</div>
+
+## Overview and Limitations
+
+BootstrapVue will automatically add in the appropriate accessibility markup for most interactive components. But the overall accessibility of any project built with Bootstrap and BootstrapVue depends in large part on the author's markup, additional styling, and scripting they've included. However, provided that these have been implemented correctly, it should be perfectly possible to create websites and applications with BootstrapVue that fulfill [WCAG 2.0](https://www.w3.org/TR/WCAG20/) (A/AA/AAA), [Section 508](https://www.section508.gov) and similar accessibility standards and requirements.
+
+## Structural markup
+
+BootstrapVue's custom components have been optimized for accessible/semantic generated HTML markup out of the box. This documentation aims to provide developers with best practice examples to demonstrate the use of Bootstrap itself and illustrate appropriate semantic markup, including ways in which potential accessibility concerns can be addressed.
+
+Most component documentation pages include an accessibility section (or sections) noting best practices and limitations.
+
+## Interactive components
+
+BootstrapVue's interactive components — such as modal dialogs, dropdown menus and custom tooltips — are designed to work for touch, mouse and keyboard users. Through the use of relevant [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) roles and attributes, these components should also be understandable and operable using assistive technologies (such as screen readers).
+
+Because BootstrapVue's components are purposely designed to be fairly generic, authors may need to include further ARIA roles and attributes, as well as JavaScript behavior, to more accurately convey the precise nature and functionality of their component. This is usually noted in the documentation.
+
+## Color contrast
+
+Most colors that currently make up Bootstrap V4's default palette — used throughout the framework for things such as button variations, alert variations, form validation indicators — lead to insufficient color contrast (below the recommended [WCAG 2.0 color contrast ratio of 4.5:1)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) when used against a light background. Authors will need to manually modify/extend these default colors to ensure adequate color contrast ratios.
+
+Refer to the Theming section for customizing Bootstrap's SCSS.
+
+## Visually hidden content
+
+Content which should be visually hidden, but remain accessible to assistive technologies such as screen readers, can be styled using the `.visually-hidden` class. This can be useful in situations where additional visual information or cues (such as meaning denoted through the use of color) need to also be conveyed to non-visual users.
+
+<b-card class="bg-body-tertiary">
+
+```vue-html
+<p class="text-danger mb-0">
+  <span class="visually-hidden">Danger: </span>
+  This action is not reversible
+</p>
+```
+
+</b-card>
+
+For visually hidden interactive controls, such as traditional “skip” links, use the `.visually-hidden-focusable` class. This will ensure that the control becomes visible once focused (for sighted keyboard users). Watch out, compared to the equivalent `.sr-only` and `.sr-only-focusable` classes in past versions, Bootstrap 5’s `.visually-hidden-focusable` is a standalone class, and must not be used in combination with the `.visually-hidden` class.
+
+<b-card class="bg-body-tertiary">
+
+```vue-html
+<a class="visually-hidden-focusable" href="#content">Skip to main content</a>
+```
+
+</b-card>
+
+## Reduced motion
+
+Bootstrap includes support for the [prefers-reduced-motion media feature](https://www.w3.org/TR/mediaqueries-5/#prefers-reduced-motion). In browsers/environments that allow the user to specify their preference for reduced motion, most CSS transition effects in Bootstrap (for instance, when a modal dialog is opened or closed, or the sliding animation in carousels) will be disabled, and meaningful animations (such as spinners) will be slowed down.
+
+On browsers that support `prefers-reduced-motion`, and where the user has not explicitly signaled that they’d prefer reduced motion (i.e. where `prefers-reduced-motion: no-preference`), Bootstrap enables smooth scrolling using the `scroll-behavior` property.
+
+## Testing your application for accessibility
+
+It is highly recommended to test your app for accessibility before deployment. Note that some countries even have laws [requiring all websites to be accessible](https://webaim.org/articles/laws/world/).
+
+There are just two main things to think about when making your web app accessible:
+
+- Defining the right keyboard behavior. BootstrapVue provides keyboard control for most of our components, but you should make sure your custom components are also keyboard accessible.
+- Making it possible for screen readers to understand your app. Bootstrap, in most situations, will automatically set the correct `role` and `aria-*` attributes on our components. You should also make sure that all of your custom components provide the correct roles and attributes (use semantic HTML elements and markup where possible).
+
+Steps you should do for testing:
+
+-Try using the keyboard only to see if all interactive components can be reached and controlled. Ensure that controls have focus styling so that the user knows which interactive element they are on. Remember, keyboard user cannot trigger an element's `hover` state.
+
+- Use a screen reader (combined with keyboard only) to navigate and interact with your app. There are several free screen readers available for various operating systems and browsers. Remember that screen reader users can only "see" what they hear.
+- See how your app looks and works when increasing the zoom level (and/or font size) of your browser.
+
+## Additional resources
+
+- [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/WCAG/)
+- [The A11Y Project](https://www.a11yproject.com)
+- [MDN accessibility documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+- [Tenon.io Accessibility Checker](https://tenon.io)
+- [Color Contrast Analyser (CCA)](https://www.tpgi.com/color-contrast-checker/)
+- [“HTML Codesniffer” bookmarklet for identifying accessibility issues](https://github.com/squizlabs/HTML_CodeSniffer)
+- [Microsoft Accessibility Insights](https://accessibilityinsights.io)
+- [Deque Axe testing tools](https://www.deque.com/axe/)
+- [Introduction to Web Accessibility](https://www.w3.org/WAI/fundamentals/accessibility-intro/)
+
+<script setup lang="ts">
+import {BCard} from 'bootstrap-vue-next'
+</script>

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -1,0 +1,251 @@
+# Color variants and CSS class mapping
+
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+Below are the variants available when using the default Bootstrap v5 CSS. When using BootstrapVueNext components, the variants are referred to by their variant name, rather than by the underlying CSS classname.
+
+</div>
+
+## Base variants
+
+<b-card class="bg-body-tertiary">
+
+<p class="text-primary">.text-primary</p>
+<p class="text-secondary">.text-secondary</p>
+<p class="text-success">.text-success</p>
+<p class="text-danger">.text-danger</p>
+<p class="text-warning bg-dark">.text-warning</p>
+<p class="text-info bg-dark">.text-info</p>
+<p class="text-light bg-dark">.text-light</p>
+<p class="text-dark bg-white">.text-dark</p>
+
+</b-card>
+
+The base variants will translate to various Bootstrap v5 contextual class names based on the component (and variant purpose) where they are used. See the sections below for details.
+
+## Background and border variants
+
+<b-card class="bg-body-tertiary">
+
+  <div class="gap-2">
+    <span class="border border-primary"></span>
+    <span class="border border-primary-subtle"></span>
+    <span class="border border-secondary"></span>
+    <span class="border border-secondary-subtle"></span>
+    <span class="border border-success"></span>
+    <span class="border border-success-subtle"></span>
+    <span class="border border-danger"></span>
+    <span class="border border-danger-subtle"></span>
+    <span class="border border-warning"></span>
+    <span class="border border-warning-subtle"></span>
+    <span class="border border-info"></span>
+    <span class="border border-info-subtle"></span>
+    <span class="border border-light"></span>
+    <span class="border border-light-subtle"></span>
+    <span class="border border-dark"></span>
+    <span class="border border-dark-subtle"></span>
+    <span class="border border-black"></span>
+    <span class="border border-white"></span>
+  </div>
+
+</b-card>
+
+All the base variants plus:
+
+- `white`
+- `transparent`
+
+These translate to class names `bg-{variant}` for backgrounds and `border-{variant}` for borders.
+
+These variants are used by components (such as `<b-card>`, `<b-modal>`, etc.) that provide `bg-variant`, `_-bg-variant`, `border-variant` and `_-border-variant` props.
+
+## Text variants
+
+All the base variants plus:
+
+- `muted`
+- `white`
+- `black`
+
+<b-card class="bg-body-tertiary">
+
+<p class="text-primary">.text-primary</p>
+<p class="text-primary-emphasis">.text-primary-emphasis</p>
+<p class="text-secondary">.text-secondary</p>
+<p class="text-secondary-emphasis">.text-secondary-emphasis</p>
+<p class="text-success">.text-success</p>
+<p class="text-success-emphasis">.text-success-emphasis</p>
+<p class="text-danger">.text-danger</p>
+<p class="text-danger-emphasis">.text-danger-emphasis</p>
+<p class="text-warning bg-dark">.text-warning</p>
+<p class="text-warning-emphasis">.text-warning-emphasis</p>
+<p class="text-info bg-dark">.text-info</p>
+<p class="text-info-emphasis">.text-info-emphasis</p>
+<p class="text-light bg-dark">.text-light</p>
+<p class="text-light-emphasis">.text-light-emphasis</p>
+<p class="text-dark bg-white">.text-dark</p>
+<p class="text-dark-emphasis">.text-dark-emphasis</p>
+
+<p class="text-body">.text-body</p>
+<p class="text-body-emphasis">.text-body-emphasis</p>
+<p class="text-body-secondary">.text-body-secondary</p>
+<p class="text-body-tertiary">.text-body-tertiary</p>
+
+<p class="text-black bg-white">.text-black</p>
+<p class="text-white bg-dark">.text-white</p>
+<p class="text-black-50 bg-white">.text-black-50</p>
+<p class="text-white-50 bg-dark">.text-white-50</p>
+
+</b-card>
+
+These translate to class names `text-{variant}`
+
+These variants are used by components (such as `<b-card>`, `<b-modal>`, etc.) that provide `text-variant` and `*-text-variant` props.
+
+## Component specific variants
+
+Some Bootstrap v5 components require additional CSS styling, or additional pseudo selector styling (i.e buttons), and hence have their own underlying variant CSS classes.
+
+### Alert variants
+
+All the base variants
+
+These translate to class names `alert-{variant}`.
+
+### Badge variants
+
+All the base variants
+
+These translate to class names `badge-{variant}`.
+
+### Button variants
+
+All the base variants plus:
+
+- `outline-{base variant}` which generates an outline button version of the base variant
+- `link` which renders the button with the look of a link but retains button padding and margins
+
+These translate to class names `btn-{variant}` and `btn-outline-{variant}`.
+
+Note the `link` variant does not have an outline version.
+
+### Table variants
+
+All the base variants plus:
+
+- `active`
+
+These variants translate to class names `table-{variant}`.
+
+When the table has the `dark` prop set, the variants translate to the `bg-{variant}` classes.
+
+Note that the `active` variant is only applicable to `<tr>` elements within the `<tbody>`, and can not be applied to individual table cells or used as the `table-variant`.
+
+### Popover variants
+
+All the base variants
+
+These translate to BootstrapVueNext custom class names `b-popover-{variant}`.
+
+### Tooltip variants
+
+All the base variants
+
+These translate to BootstrapVueNext custom class names `b-tooltip-{variant}`.
+
+### Toast variants
+
+All the base variants
+
+These translate to BootstrapVueNext custom class names `b-toast-{variant}`.
+
+## Using variant classes
+
+You may also use the underlying class names directly on elements (and some components) via the standard HTML `class="..."` attribute.
+
+## Creating custom variants
+
+When creating custom variants, follow the Bootstrap v4 variant CSS class naming scheme and they will become available to the various components that use that scheme (i.e. create a custom CSS class `btn-purple` and `purple` becomes a valid variant to use on `<b-button>`).
+
+Alternatively, you can create new variant theme colors by supplying custom Bootstrap SCSS theme color maps. The default theme color map is (from `bootstrap/scss/\_variables.scss`):
+
+<HighlightCard>
+  Base grayscale colors definitions
+  <template #html>
+
+```scss
+$white: #fff;
+$gray-100: #f8f9fa;
+$gray-200: #e9ecef;
+$gray-300: #dee2e6;
+$gray-400: #ced4da;
+$gray-500: #adb5bd;
+$gray-600: #6c757d;
+$gray-700: #495057;
+$gray-800: #343a40;
+$gray-900: #212529;
+$black: #000;
+```
+
+  </template>
+</HighlightCard>
+
+<HighlightCard>
+  Base colors definitions
+  <template #html>
+
+```scss
+$blue: #0d6efd;
+$indigo: #6610f2;
+$purple: #6f42c1;
+$pink: #d63384;
+$red: #dc3545;
+$orange: #fd7e14;
+$yellow: #ffc107;
+$green: #198754;
+$teal: #20c997;
+$cyan: #0dcaf0;
+```
+
+  </template>
+</HighlightCard>
+
+<HighlightCard>
+  Theme color default definitions
+  <template #html>
+
+```scss
+$primary: $blue;
+$secondary: $gray-600;
+$success: $green;
+$info: $cyan;
+$warning: $yellow;
+$danger: $red;
+$light: $gray-100;
+$dark: $gray-900;
+```
+
+  </template>
+</HighlightCard>
+
+<script setup lang="ts">
+import {BCard} from 'bootstrap-vue-next'
+import HighlightCard from '../../components/HighlightCard.vue'
+</script>
+
+<style lang="scss">
+.bg-body-tertiary [class^="border"] {
+  display: inline-block;
+  width: 5rem;
+  height: 5rem;
+  margin: .25rem;
+}
+</style>

--- a/apps/docs/src/docs/reference/contributing.md
+++ b/apps/docs/src/docs/reference/contributing.md
@@ -1,0 +1,114 @@
+# Contributing
+
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+👍🎉 First off, thanks for taking the time to contribute! 🎉👍
+
+</div>
+
+Conventional commits are required for the automation of changelog and tag releases. Information on how to write commits can be found at <https://www.conventionalcommits.org/>. Additional information on how to do things like introduce multiple fixes in a single commit, or fixing release notes can be found at <https://github.com/googleapis/release-please#how-should-i-write-my-commits>
+
+## Setting Up Your Workspace
+
+Setting up your workspace follows traditional open-source flows, if you are already familiar with the process, you can most likely skip this section:
+
+<b-alert variant="danger" :model-value="true" class="my-5">
+
+**Only pnpm is allowed**, attempting to run any other package manager tool will cause a warning error. View pnpm installation at <https://pnpm.io/installation>
+
+</b-alert>
+
+1. Go to the <https://github.com/bootstrap-vue-next/bootstrap-vue-next>
+2. Click **Fork** at the top
+3. On your IDE of choice, clone your own, new, forked repository
+
+This repository is where you will make your changes to. You can safely run `git push ...` and other commands in this repository
+
+When opening your repository, it is usually best to open the **root** folder, not a subdirectory such as `./packages/bootstrap-vue-next`. Eslint rules can sometimes get lost when opening a subdirectory of a workspace. If you do not have the recommended IDE extensions, it will usually suggest that you install them, but this is technically optional. You can finally run at the root:
+
+<b-card class="bg-body-tertiary">
+
+```bash
+pnpm install
+pnpm dev
+```
+
+</b-card>
+
+Finally, after you have made sufficient changes and you are ready to publish your changes to the main repository, you will:
+
+1. Go to your forked repository on <https://github.com/>
+2. Switch to the correct branch that you have been working on, this is usually the `main` branch, for simplicity
+3. Click the **Contribute** button near the top of the page
+4. Click **Open pull request**
+
+This will begin the process to merge your changes into the upstream repository's main branch
+
+## Developing
+
+The project uses a monorepo architecture. The main source files for the package exist in `./packages/bootstrap-vue-next`, this is primarily where developing is done. You can then run `pnpm dev` and it will start all possible development environments. When developing the main package, you will want to open the **bootstrap-vue-next:dev** host. This has hot-reloading to make developing easier. You can use the `./packages/bootstrap-vue-next/src/app.vue` file as a test area for any changes that you make
+
+You can also make use of the `./apps/playground` directory. The `./apps/playground` directory mimics a user's library and can demonstrate some bugs that may not be visible in the main package. However, it does not contain native hot-reloading and makes for a poor development experience since it requires a built dist copy of the main package (simply run `pnpm build`). The playground is not typically used for development. It is more of a place to view the full behavior of a component
+
+You can also use `pnpm dev --filter bootstrap-vue-next` to only open the main host
+
+## Registering New Components
+
+For adding a new component, there are some notes...
+
+- They should only exist in the `./packages/bootstrap-vue-next/src/components` directory
+- You should first review the `./packages/bootstrap-vue-next/src/types` directory and get familiar with the internal types that you can use
+- They should follow `<script setup lang="ts">` syntax, to ensure uniformity, there are _some_ exceptions to this rule regarding Vue SFC being unable to import or extend types
+- If the component is a native [Bootstrap](https://getbootstrap.com/) component, you will need to read about that component and have a thorough understanding of how it works and appears
+- If the component is custom, or taken from [Bootstrap-vue](https://bootstrap-vue.org/) you will need to read the component documentation, then attempt to recreate that component using `<template>` and `<script setup lang="ts">` syntax. If a Bootstrap-vue component is based on a native Bootstrap component, then you should read Bootstrap's implementation first, and ensure any changes are made to correct for the v5 release of Bootstrap
+- All Props and Emits should be fully written as TypeScript interfaces, the more strongly typed, the better
+
+After the implementation of the component, based on Bootstrap's details, you can finally begin introducing the component to be exported by the main package, and usable by users of the library. To do that you will need to:
+
+1. Add the component to the import/export list, located in `./packages/bootstrap-vue-next/src/components/index.ts`
+2. Next, it must be imported into `./packages/bootstrap-vue-next/BootstrapVue.ts` _please ensure that your import is made directly to the component, and not to the previous index.ts file_
+3. After that, export it in the `export {}` list that contains the other components to be exported
+4. Finally, it must be included in the exported interface of **GlobalComponents**, following the pattern of `BComponent: typeof BComponent`
+
+That is it!
+
+## Fixing or Adding Features to Components
+
+To fix an already made component, or to add a new feature to a component is a bit easier. You will need to identify a need for the fix, understand the file in question, then apply the change. It is not as complex as making an entirely new component. After you are finished with your change and are making a pull request, it can sometimes be very beneficial to include a code reproduction that shows the changes visually but is not required
+
+## Ask for Help
+
+Working on the app is not a solo job. It is always fine to ask how something should be done, or how something can be improved. Ask for help when you are stuck!
+
+## Safety Information
+
+In general, always be careful when clicking external links. As programmers, it should be obvious that any links opened should be scanned for authenticity. No malicious intent has ever been found anywhere in the documentation, issues, or pull requests, but always be aware. If you have noticed anything that may be malicious in this repository, open an issue **immediately**. At this time, the repository does not have a dedicated security policy
+
+## For Collaborators: Making a New Release
+
+Bootstrap Vue 3 uses <https://github.com/googleapis/release-please> to automate releases using workflows. The `.github/workflows/release-please.yaml` workflow will auto-generate releases when using conventional commits. We encourage all commit messages to follow conventional commit guidelines to keep commits clean and automate releases
+
+The workflow `.github/workflows/npm-publish.yaml` will then auto-publish at <https://www.npmjs.com/package/bootstrap-vue-next>
+
+## For Collaborators: Manual Releases
+
+One could also manually create a release PR using the CLI, directions at <https://github.com/googleapis/release-please/blob/main/docs/cli.md#running-release-please-cli>. Follow the directions for bootstrapping and creating a release, then it will auto-generate a PR containing the new release notes
+
+It will then auto-publish as stated before
+
+Collaborators can also manually release by:
+
+increase version in package.json, commit
+<https://github.com/bootstrap-vue-next/bootstrap-vue-next/releases/new> (create new tag)
+
+<script setup lang="ts">
+import {BCard, BAlert} from 'bootstrap-vue-next'
+</script>

--- a/apps/docs/src/docs/reference/router-links.md
+++ b/apps/docs/src/docs/reference/router-links.md
@@ -1,0 +1,206 @@
+# Router link support
+
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+<div class="lead mb-5">
+
+Several BootstrapVue components support rendering `<router-link>` components compatible with Vue Router and Nuxt.js. For more information, see the official [Vue Router docs](https://router.vuejs.org) and official [Nuxt.js docs](https://nuxt.com/docs/api/components/nuxt-link#props).
+
+</div>
+
+## Common router link props
+
+In the following sections, we are using the `<b-link>` component to render router links. `<b-link>` is the building block of most of BootstrapVue's actionable components. You could use any other component that supports link generation such as `<b-link>`, `<b-button>`, `<b-avatar>`, `<b-breadcrumb-item>`, `<b-list-group-item>`, `<b-nav-item>`, `<b-dropdown-item>`, and `<b-pagination-nav>`. Note that not all props are available on all components. Refer to the respective component documentation for details.
+
+### `to`
+
+- type: `string | Location`
+- required to generate a `<router-link>`
+
+Denotes the target route of the link. When clicked, the value of the `to` prop will be passed to `router.push()` internally, so the value can be either a string or a location descriptor object.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<!-- Literal string -->
+<b-link to="home">Home</b-link>
+
+<!-- Renders to -->
+<a href="home">Home</a>
+
+<!-- JavaScript expression using `v-bind` -->
+<b-link v-bind:to="'home'">Home</b-link>
+
+<!-- Omitting `v-bind` is fine, just as binding any other prop -->
+<b-link :to="'home'">Home</b-link>
+
+<!-- Same as above -->
+<b-link :to="{path: 'home'}">Home</b-link>
+
+<!-- Named route -->
+<b-link :to="{name: 'user', params: {userId: 123}}">User</b-link>
+
+<!-- With query, resulting in `/register?plan=private` -->
+<b-link :to="{path: 'register', query: {plan: 'private'}}">Register</b-link>
+
+<!-- Render a non-router link by omitting `to` and specifying an `href` -->
+<b-link href="/home">Home</b-link>
+```
+
+</b-card>
+
+### `replace`
+
+- type: `boolean`
+- default: `false`
+
+Setting replace prop will call `router.replace()` instead of `router.push()` when clicked, so the navigation will not leave a history record.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<b-link :to="{path: '/abc'}" replace></b-link>
+```
+
+</b-card>
+
+### `append`
+
+- type: `boolean`
+- default: `false`
+
+Setting `append` prop always appends the relative path to the current path. For example, assuming we are navigating from `/a` to a relative link `b`, without `append` we will end up at `/b`, but with `append` we will end up at `/a/b`.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<b-link :to="{path: 'relative/path'}" append></b-link>
+```
+
+</b-card>
+
+### `router-tag`
+
+- type: `string`
+- default: 'a'
+
+Sometimes we want `<router-link>` to render as another tag, e.g `<li>`. Then we can use `router-tag` prop to specify which tag to render to, and it will still listen to click events for navigation. `router-tag` translates to the `tag` prop on the final rendered `<router-link>`.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<b-link to="/foo" router-tag="li">foo</b-link>
+
+<!-- Renders as -->
+<li>foo</li>
+```
+
+</b-card>
+
+<b-alert variant="info" :model-value="true" class="my-5">
+
+Note: Changing the tag from anything other than `<a>` is discouraged, as it hinders accessibility of keyboard and/or screen-reader users, and is also not very SEO friendly.
+
+</b-alert>
+
+### `active-class`
+
+- type: `string`
+- default: `router-link-active` (`nuxt-link-active` when using Nuxt.js)
+
+Configure the active CSS class applied when the link is active. Note the default value can also be configured globally via the `linkActiveClass` [router constructor option](https://router.vuejs.org/api/#linkactiveclass).
+
+With components that support router links (have a `to` prop), you will want to set this to the class `active` (or a space separated string that includes 'active') to apply Bootstrap's `active` styling on the component when the current route matches the `to` prop.
+
+### `exact`
+
+- type: `boolean`
+- default: `false`
+
+The default active class matching behavior is inclusive match. For example, `<b-link to="/a">` will get this class applied as long as the current path starts with `/a/` or is `/a`.
+
+One consequence of this is that `<b-link to="/">` will be active for every route! To force the link into "exact match mode", use the `exact` prop:
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<!-- This link will only be active at `/` -->
+<b-link to="/" exact></b-link>
+```
+
+</b-card>
+
+### `exact-active-class`
+
+- type: `string`
+- default: `router-link-exact-active` (`nuxt-link-exact-active` when using Nuxt.js)
+- availability: Vue Router 2.5.0+
+
+Configure the active CSS class applied when the link is active with exact match. Note the default value can also be configured globally via the `linkExactActiveClass` [router constructor option](https://router.vuejs.org/api/#linkexactactiveclass).
+
+With components that support router links (have a `to` prop), you will want to set this to the class `active` (or a space separated string that includes `active`) to apply Bootstrap's active styling on the component when the current route matches the `to` prop.
+
+### `exact-path`
+
+- type: `boolean`
+- default: `false`
+- availability: Vue Router 3.5.0+
+
+Allows matching only using the `path` section of the url, effectively ignoring the `query` and the `hash` sections.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+<!-- this link will also be active at `/search?page=2` or `/search#filters` -->
+<router-link to="/search" exact-path> </router-link>
+```
+
+</b-card>
+
+### `exact-path-active-class`
+
+- type: `string`
+- default: `router-link-exact-path-active`
+- availability: Vue Router 2.5.0+
+
+Configure the active CSS class applied when the link is active with exact path match. Note the default value can also be configured globally via the `linkExactActiveClass` [router constructor option](https://router.vuejs.org/api/#linkexactactiveclass).
+
+With components that support router links (have a `to` prop), you will want to set this to the class `active` (or a space separated string that includes `active`) to apply Bootstrap's active styling on the component when the current route matches the `to` prop.
+
+## Nuxt.js specific router link props
+
+When BootstrapVue detects that your app is running under [Nuxt.js](https://nuxt.com), it will render a [`<nuxt-link>`](https://nuxt.com/docs/api/components/nuxt-link#nuxtlink) sub component instead of a `<router-link>`. `<nuxt-link>` supports all of the above router link props, plus the following additional Nuxt.js specific props.
+
+### `prefetch`
+
+- type: `boolean`
+- default: `null`
+- availability: Nuxt.js 3+
+
+To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `prefetch` to `true` or `false` will overwrite the default value of `router.prefetchLinks` configured in the `nuxt.config.js` configuration file.
+
+### `no-prefetch`
+
+- type: `boolean`
+- default: `true`
+- availability: Nuxt.js 3+
+
+To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `no-prefetch` will disabled this feature for the specific link.
+
+<b-card class="bg-body-tertiary">
+
+```vue
+router: { prefetchLinks: false }
+```
+
+</b-card>
+
+<script setup lang="ts">
+import {BCard, BAlert} from 'bootstrap-vue-next'
+</script>

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -1,5 +1,13 @@
 # Types
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 `BootstrapVueNext` is a complete rewrite that strives for full TypeScript compatibility. This is a list of types we use in this library and that you can use too.

--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -1,5 +1,13 @@
 # Introduction
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
 <div class="lead mb-5">
 
 With BootstrapVueNext you can build fast, responsive, and ARIA accessible projects on the web using Vue.js and Bootstrap v5.
@@ -47,7 +55,7 @@ With more than 35 components, several directives and composibles (and growing), 
 
 Easily integrate BootstrapVueNext into your Nuxt.js projects using our included Nuxt.js module. You can optionally specify only the components, directives and/or plugins you require.
 
-<b-button variant="secondary" :to="withBase('/docs#nuxtjs')" class="mt-3">BootstrapVueNext Nuxt.js module</b-button>
+<b-button variant="secondary" :to="withBase('/docs#installation-nuxt-js-3')" class="mt-3">BootstrapVueNext Nuxt.js module</b-button>
 
 <script setup lang="ts">
 import {


### PR DESCRIPTION
I have gone ahead and added TOC anchors for the doc pages. It may not be the best approach but it works pretty cleanly:

- utilizes vitepress [[toc]], which pulls from the headers
- wrap the [[toc]] with `<Teleport>`
- wrap teleport with `<ClientOnly>`

```
<ClientOnly>
  <Teleport to=".bd-toc">

[[toc]]

  </Teleport>
</ClientOnly>
```

I also updated the docs:

- Navbar
- and some other intros

Let me know your thoughts.