### PR TITLE
feat(BNavItem): adds linkClasses property.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
@@ -1,7 +1,7 @@
 <template>
   <li class="nav-item">
     <b-link
-      class="nav-link"
+      :class="computedLinkClasses"
       v-bind="$props"
       active-class="active"
       :tabindex="disabledBoolean ? -1 : undefined"
@@ -16,7 +16,7 @@
 import BLink, {BLINK_PROPS} from '../BLink/BLink.vue'
 import {omit} from '../../utils'
 import {useBooleanish} from '../../composables'
-import {defineComponent, type SlotsType} from 'vue'
+import {computed, defineComponent, type SlotsType} from 'vue'
 
 export default defineComponent({
   slots: Object as SlotsType<{
@@ -25,11 +25,14 @@ export default defineComponent({
   components: {BLink},
   props: {
     ...omit(BLINK_PROPS, ['event', 'routerTag'] as const),
+    linkClasses: {type: String, default: null},
   },
   setup(props) {
     const disabledBoolean = useBooleanish(() => props.disabled)
 
-    return {disabledBoolean}
+    const computedLinkClasses = computed(() => ['nav-link', props.linkClasses])
+
+    return {disabledBoolean, computedLinkClasses}
   },
 })
 </script>

--- a/packages/bootstrap-vue-next/src/components/BNav/nav-item.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BNav/nav-item.spec.ts
@@ -23,6 +23,17 @@ describe('nav-item', () => {
     expect($blink.classes()).toContain('nav-link')
   })
 
+  it("blink has custom-class class when prop link-classes='custom-class'", () => {
+    const wrapper = mount(BNavItem, {
+      props: {
+        linkClasses: 'custom-class',
+      },
+    })
+    const $blink = wrapper.findComponent(BLink)
+
+    expect($blink.classes()).toContain('custom-class')
+  })
+
   it('blink has tabindex -1 when prop disabled', () => {
     const wrapper = mount(BNavItem, {
       props: {


### PR DESCRIPTION
# Describe the PR

Adds `linkClasses` as property in `BNavItem` to pass classes to `BLink`. Solves issue #1183 reported as bug.

## Small replication

```html
<b-nav-item link-classes="shadow">
  ...
</b-nav-item>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
