### PR TITLE
fix(BOffcanvas): respect manually set property id.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -15,6 +15,7 @@
     >
       <div
         v-show="modelValue"
+        :id="computedId"
         ref="element"
         aria-modal="true"
         role="dialog"


### PR DESCRIPTION
# Describe the PR

`b-offcanvas` ignores manually set property id. This PR adds manually set property `id` to the offcanvas node.

Solves issue #1180.

## Small replication

```html
<b-offcanvas id="main-menu">
  ...
</b-offcanvas>

<b-nav-item v-b-toggle.main-menu>
  ...
</b-nav-item>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
