### PR TITLE
feat(BNavItemDropdown): adds open, close and toggle methods.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
@@ -89,7 +89,7 @@ defineSlots<{
   'button-content'?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const modelValueBoolean = useBooleanish(modelValue)
 
@@ -100,4 +100,20 @@ const dropdownValue = computed({
   },
 })
 const usableProps = computed(() => omit(props, ['modelValue'] as const))
+
+const close = () => {
+  modelValue.value = false
+}
+const open = () => {
+  modelValue.value = true
+}
+const toggle = () => {
+  modelValue.value = !modelValueBoolean.value
+}
+
+defineExpose({
+  close,
+  open,
+  toggle,
+})
 </script>

--- a/packages/bootstrap-vue-next/src/components/BNav/nav-item-dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BNav/nav-item-dropdown.spec.ts
@@ -1,6 +1,7 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import BNavItemDropdown from './BNavItemDropdown.vue'
+import BButton from '../BButton/BButton.vue'
 import BDropdown from '../BDropdown/BDropdown.vue'
 
 describe('nav-item-dropdown', () => {
@@ -20,6 +21,30 @@ describe('nav-item-dropdown', () => {
     const wrapper = mount(BNavItemDropdown)
     const $bdropdown = wrapper.findComponent(BDropdown)
     expect($bdropdown.exists()).toBe(true)
+  })
+
+  it('is opened if open called', async () => {
+    const wrapper = mount(BNavItemDropdown)
+    const $bbutton = wrapper.findComponent(BButton)
+    await wrapper.vm.open()
+    expect($bbutton.classes()).toContain('show')
+  })
+
+  it('is closed if close called', async () => {
+    const wrapper = mount(BNavItemDropdown)
+    const $bbutton = wrapper.findComponent(BButton)
+    await wrapper.vm.open()
+    await wrapper.vm.close()
+    expect($bbutton.classes()).not.toContain('show')
+  })
+
+  it('is toggled if toggle called', async () => {
+    const wrapper = mount(BNavItemDropdown)
+    const $bbutton = wrapper.findComponent(BButton)
+    await wrapper.vm.toggle()
+    expect($bbutton.classes()).toContain('show')
+    await wrapper.vm.toggle()
+    expect($bbutton.classes()).not.toContain('show')
   })
 
   // There are more tests here, but the component seems broken


### PR DESCRIPTION
# Describe the PR

Programmatically open, close and toggle `BNavItemDropdown` like in `BDropdown` component.

## Small replication

```html
<b-nav>
  <b-nav-item-dropdown ref="mainDropdown">
    <template #button-content>My Button</template>
    <b-nav-item>Item 1</b-nav-item>
    <b-nav-item>Item 2</b-nav-item>
  </b-nav-item-dropdown>
</b-nav>
```
Control the dropdown e.g.:

```js
 this.$refs.mainDropdown.open()
 this.$refs.mainDropdown.close()
 this.$refs.mainDropdown.toggle()
```

Solves #1184.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
