### PR TITLE
fix(BFormGroup): allow Booleanish and null for state prop

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -66,7 +66,7 @@ export default defineComponent({
     labelFor: {type: String, default: undefined},
     labelSize: {type: String, default: undefined},
     labelSrOnly: {type: [Boolean, String] as PropType<Booleanish>, default: false},
-    state: {type: [Boolean, String] as PropType<Booleanish>, default: null},
+    state: {type: [Boolean, String] as PropType<Booleanish | null>, default: null},
     tooltip: {type: [Boolean, String] as PropType<Booleanish>, default: false},
     validFeedback: {type: String, default: undefined},
     validated: {type: [Boolean, String] as PropType<Booleanish>, default: false},

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -31,6 +31,14 @@ describe('form-group', () => {
     expect(wrapper.classes()).toContain('is-invalid')
   })
 
+  it('does not contain a valid class when prop state is null', () => {
+    const wrapper = mount(BFormGroup, {
+      props: {state: null},
+    })
+    expect(wrapper.classes()).not.toContain('is-valid')
+    expect(wrapper.classes()).not.toContain('is-invalid')
+  })
+
   it('does not contain a valid class when prop state is undefined', () => {
     const wrapper = mount(BFormGroup, {
       props: {state: undefined},


### PR DESCRIPTION
# Describe the PR

This fixes the types to allow the `state` property of `BFormGroup` / `b-form-group` to have a `Booleanish` or `null` value as written in the docs.

Fixes: #1167

## Small replication

See #1167

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
