### PR TITLE
feat(BOffcanvas): adds teleport to property.

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -79,7 +79,7 @@
       <client-only>
         <b-offcanvas
           v-model="sidebar"
-          static="true"
+          teleport-disabled="true"
           backdrop="false"
           title="Browse docs"
           class="h-100"

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport :to="props.teleportTo" :disabled="teleportDisabledBoolean">
+  <teleport :to="teleportTo" :disabled="teleportDisabledBoolean">
     <b-transition
       :no-fade="true"
       :trans-props="{

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport :to="props.to" :disabled="staticBoolean">
+  <teleport :to="props.teleportTo" :disabled="teleportDisabledBoolean">
     <b-transition
       :no-fade="true"
       :trans-props="{
@@ -93,9 +93,9 @@ interface BOffcanvasProps {
   lazy?: Booleanish
   id?: string
   noFocus?: Booleanish
-  static?: Booleanish
   backdropVariant?: ColorVariant | null
-  to?: string | RendererElement | null | undefined
+  teleportDisabled?: Booleanish
+  teleportTo?: string | RendererElement | null | undefined
   // TODO responsive doesn't work
   // responsive?: Breakpoint
 }
@@ -105,7 +105,6 @@ const props = withDefaults(defineProps<BOffcanvasProps>(), {
   id: undefined,
   title: undefined,
   modelValue: false,
-  static: false,
   backdropVariant: 'dark',
   noFocus: false,
   bodyScrolling: false,
@@ -116,7 +115,8 @@ const props = withDefaults(defineProps<BOffcanvasProps>(), {
   placement: 'start',
   noHeaderClose: false,
   noHeader: false,
-  to: 'body',
+  teleportDisabled: false,
+  teleportTo: 'body',
 })
 
 interface BOffcanvasEmits {
@@ -167,7 +167,7 @@ const noFocusBoolean = useBooleanish(() => props.noFocus)
 const noCloseOnBackdropBoolean = useBooleanish(() => props.noCloseOnBackdrop)
 const noCloseOnEscBoolean = useBooleanish(() => props.noCloseOnEsc)
 const lazyBoolean = useBooleanish(() => props.lazy)
-const staticBoolean = useBooleanish(() => props.static)
+const teleportDisabledBoolean = useBooleanish(() => props.teleportDisabled)
 
 const computedId = useId(() => props.id, 'offcanvas')
 

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -94,6 +94,9 @@ interface BOffcanvasProps {
   id?: string
   noFocus?: Booleanish
   backdropVariant?: ColorVariant | null
+  headerClass?: string
+  bodyClass?: string
+  footerClass?: string
   teleportDisabled?: Booleanish
   teleportTo?: string | RendererElement | null | undefined
   // TODO responsive doesn't work
@@ -115,6 +118,9 @@ const props = withDefaults(defineProps<BOffcanvasProps>(), {
   placement: 'start',
   noHeaderClose: false,
   noHeader: false,
+  headerClass: undefined,
+  bodyClass: undefined,
+  footerClass: undefined,  
   teleportDisabled: false,
   teleportTo: 'body',
 })

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport to="body" :disabled="staticBoolean">
+  <teleport :to="props.to" :disabled="staticBoolean">
     <b-transition
       :no-fade="true"
       :trans-props="{
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, nextTick, ref, useSlots} from 'vue'
+import {computed, nextTick, ref, type RendererElement, useSlots} from 'vue'
 import {useEventListener, useFocus, useVModel} from '@vueuse/core'
 import {useBooleanish, useId} from '../../composables'
 import type {Booleanish, ColorVariant} from '../../types'
@@ -94,6 +94,7 @@ interface BOffcanvasProps {
   noFocus?: Booleanish
   static?: Booleanish
   backdropVariant?: ColorVariant | null
+  to?: string | RendererElement | null | undefined
   // TODO responsive doesn't work
   // responsive?: Breakpoint
 }
@@ -114,6 +115,7 @@ const props = withDefaults(defineProps<BOffcanvasProps>(), {
   placement: 'start',
   noHeaderClose: false,
   noHeader: false,
+  to: 'body',
 })
 
 interface BOffcanvasEmits {

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -120,7 +120,7 @@ const props = withDefaults(defineProps<BOffcanvasProps>(), {
   noHeader: false,
   headerClass: undefined,
   bodyClass: undefined,
-  footerClass: undefined,  
+  footerClass: undefined,
   teleportDisabled: false,
   teleportTo: 'body',
 })

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
@@ -19,10 +19,10 @@ describe.skip('offcanvas', () => {
     if (el) document.body.removeChild(el)
   })
 
-  it('has body teleports element set by to property', () => {
+  it('has body teleports element set by teleportTo property', () => {
     const wrapper = mount(BOffcanvas, {
       props: {
-        to: '#body-teleports',
+        teleportTo: '#body-teleports',
         modelValue: true,
       },
     })

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
@@ -1,5 +1,5 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
-import {afterEach, describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import BOffcanvas from './BOffcanvas.vue'
 import BCloseButton from '../BButton/BCloseButton.vue'
 import BOverlay from '../BOverlay/BOverlay.vue'
@@ -7,6 +7,29 @@ describe.skip('offcanvas', () => {
   enableAutoUnmount(afterEach)
 
   // TODO afaik these tests are not finished
+
+  beforeEach(() => {
+    const el = document.createElement('div')
+    el.id = 'body-teleports'
+    document.body.appendChild(el)
+  })
+
+  afterEach(() => {
+    document.body.outerHTML = ''
+  })
+
+  it('has body teleports element set by to property', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {
+        to: '#body-teleports',
+        modelValue: true,
+      },
+      global: {stubs: {teleport: true}},
+    })
+    const div = wrapper.find('#body-teleports')
+    const offcanvas = div.find('.offcanvas')
+    expect(offcanvas.exists()).toBe(true)
+  })
 
   it('has static class offcanvas', () => {
     const wrapper = mount(BOffcanvas, {

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
@@ -15,7 +15,8 @@ describe.skip('offcanvas', () => {
   })
 
   afterEach(() => {
-    document.body.outerHTML = ''
+    const el = document.getElementById('body-teleports')
+    if (el) document.body.removeChild(el)
   })
 
   it('has body teleports element set by to property', () => {
@@ -24,11 +25,9 @@ describe.skip('offcanvas', () => {
         to: '#body-teleports',
         modelValue: true,
       },
-      global: {stubs: {teleport: true}},
     })
-    const div = wrapper.find('#body-teleports')
-    const offcanvas = div.find('.offcanvas')
-    expect(offcanvas.exists()).toBe(true)
+    expect(wrapper.exists()).toBe(true)
+    expect(document.getElementById('body-teleports')?.querySelector('.offcanvas')).not.toBe(null)
   })
 
   it('has static class offcanvas', () => {


### PR DESCRIPTION
# Describe the PR

Like described in the official [documentation of vue](https://vuejs.org/guide/scaling-up/ssr.html#teleports), SSR deployments should consider to use an own DOM node for teleports:

_Avoid targeting body when using Teleports and SSR together - usually, `<body>` will contain other server-rendered content which makes it impossible for Teleports to determine the correct starting location for hydration. Instead, prefer a dedicated container, e.g. `<div id="teleported"></div>` which contains only teleported content._

Every bootstrap-vue component, that uses teleport, cannot be configured with `:to=` property. Default is `body` and SSR deployments need to set teleport `:to=` to e.g. `#body-teleports`.

**This PR introduces `to` property for `BOffcanvas`.**

Solves issue #1178 for `BOffcanvas`.

Teleport Interface: [src/components/Teleport.ts#L19](https://github.com/vuejs/core/blob/60cd23c7520f9098bf31fc2d0c09d58ded75f173/packages/runtime-core/src/components/Teleport.ts#L19)

## Small replication

Required SSR rendering of teleport components, by using a unique DOM node outside app node (solves hydration node mismatch).

```html
<b-offcanvas to="#body-teleports">
  ...
</b-offcanvas>
```

with `index.html` like:

```html
...
<body>
  <div id="body-teleports"></div>
  <div id="app"></div>
</body>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
