### PR TITLE
fix(BTable): support multi select mode for macOS users

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -441,7 +441,7 @@ const headerClicked = (field: TableField, event: MouseEvent, isFooter = false) =
 const onRowClick = (row: TableItem, index: number, e: MouseEvent) => {
   emit('rowClicked', row, index, e)
 
-  handleRowSelection(row, index, e.shiftKey, e.ctrlKey)
+  handleRowSelection(row, index, e.shiftKey, e.ctrlKey, e.metaKey)
 }
 const onRowDblClick = (row: TableItem, index: number, e: MouseEvent) =>
   emit('rowDblClicked', row, index, e)
@@ -476,7 +476,8 @@ const handleRowSelection = (
   row: TableItem,
   index: number,
   shiftClicked = false,
-  ctrlClicked = false
+  ctrlClicked = false,
+  metaClicked = false
 ) => {
   if (!selectableBoolean.value) return
 
@@ -491,7 +492,7 @@ const handleRowSelection = (
         emit('rowSelected', item)
       }
     })
-  } else if (ctrlClicked) {
+  } else if (ctrlClicked || metaClicked) {
     if (selectedItems.value.has(row)) {
       selectedItems.value.delete(row)
       emit('rowUnselected', row)


### PR DESCRIPTION
# Describe the PR

Fixes `multi` select mode on Table rows for macOS users, which is currently hard coded to only work with the Control key. On Macs, the Control key is a modifier for right click, and cannot be used to select files, table rows, etc. Instead on Macs the Command key is used for most cases that would use the Control key on Windows. The event property name for the Command key is `metaKey`:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey

For reference, here is where the old BootstrapVue version uses `metaKey`:
https://github.com/bootstrap-vue/bootstrap-vue/blob/master/src/components/table/helpers/mixin-selectable.js#L229

## Small replication

I'm not certain how to demo the issue without using a Mac computer, however I've tested the change on both macOS and Windows and both now work as expected.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
