### PR TITLE
fix(BFormRadio): update value with empty string.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -122,7 +122,7 @@ const localValue = computed({
       ? JSON.stringify(parentData.modelValue.value) === JSON.stringify(props.value)
       : JSON.stringify(modelValue.value) === JSON.stringify(props.value),
   set: (newValue: string | boolean | unknown[] | Record<string, unknown> | number | null) => {
-    const updateValue = newValue || newValue === 0 ? props.value : false
+    const updateValue = newValue || newValue === '' || newValue === 0 ? props.value : false
 
     emit('input', updateValue)
     modelValue.value = updateValue


### PR DESCRIPTION
# Describe the PR

Like in `bootstrap-vue` v2.23.1 and before, the value should also accept an empty string. Clicking on `All` radio button the value does not change from e.g. old value `b` to empty string. This PR fixes this bug.

## Small replication

```vue
<template>
  <b-container>
    <b-row>
      <b-col>
        <b-form-radio-group
          id="radio-group-1"
          v-model="groupedSelected"
          :options="groupedOptions"
          name="radio-options"
        ></b-form-radio-group>
      </b-col>
    </b-row>
  </b-container>
</template>

<script setup lang="ts">
import { ref } from 'vue'

const groupedOptions = [
  {text: 'All', value: ''},
  {text: 'Group A', value: 'a'},
  {text: 'Group B', value: 'b'},
]

const groupedSelected = ref()
</script>
```


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
