### PR TITLE
feat: adapt close button of BOffcanvas, BModal and BAlert to BCloseButton and better custom button.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAlert/alert.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAlert/alert.spec.ts
@@ -2,7 +2,6 @@ import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import BAlert from './BAlert.vue'
 import BCloseButton from '../BButton/BCloseButton.vue'
-import BButton from '../BButton/BButton.vue'
 import BTransition from '../BTransition/BTransition.vue'
 
 describe('alert', () => {
@@ -146,89 +145,24 @@ describe('alert', () => {
     expect($bclosebutton.exists()).toBe(false)
   })
 
-  it('nested div does not have BCloseButton when prop dismissible but also slot close', () => {
+  it('nested div does have BCloseButton when prop dismissible but also slot close', () => {
     const wrapper = mount(BAlert, {
       props: {modelValue: true, dismissible: true},
       slots: {close: 'foobar'},
     })
     const $div = wrapper.get('div')
     const $bclosebutton = $div.findComponent(BCloseButton)
-    expect($bclosebutton.exists()).toBe(false)
+    expect($bclosebutton.exists()).toBe(true)
   })
 
-  it('nested div does not have BCloseButton when prop dismissible but also prop closeContent', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bclosebutton = $div.findComponent(BCloseButton)
-    expect($bclosebutton.exists()).toBe(false)
-  })
-
-  it('nested div has BButton when prop dismissible but also prop closeContent', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.findComponent(BButton)
-    expect($bbutton.exists()).toBe(true)
-  })
-
-  it('nested div has BButton when prop dismissible but also slot close', () => {
+  it('nested div BCloseButton renders slot close', () => {
     const wrapper = mount(BAlert, {
       props: {modelValue: true, dismissible: true},
       slots: {close: 'foobar'},
     })
     const $div = wrapper.get('div')
-    const $bbutton = $div.findComponent(BButton)
-    expect($bbutton.exists()).toBe(true)
-  })
-
-  it('nested div does not have BButton when prop dismissible and nothing else', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.findComponent(BButton)
-    expect($bbutton.exists()).toBe(false)
-  })
-
-  it('nested div BButton has static attr type to be button', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    expect($bbutton.attributes('type')).toBe('button')
-  })
-
-  it('nested div BButton renders prop closeContent', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    expect($bbutton.text()).toBe('foobar')
-  })
-
-  it('nested div BButton renders slot close', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true},
-      slots: {close: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    expect($bbutton.text()).toBe('foobar')
-  })
-
-  it('nested div BButton renders slot over props', () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'props'},
-      slots: {close: 'slots'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    expect($bbutton.text()).toBe('slots')
+    const $bclosebutton = $div.getComponent(BCloseButton)
+    expect($bclosebutton.text()).toBe('foobar')
   })
 
   it('nested div BCloseButton has aria-label to be Close by default', () => {
@@ -249,7 +183,6 @@ describe('alert', () => {
     expect($bclosebutton.attributes('aria-label')).toBe('foobar')
   })
 
-  // BCloseButton variant
   it('nested div BCloseButton emits update:modelValue when clicked when modelValue boolean', async () => {
     const wrapper = mount(BAlert, {
       props: {modelValue: true, dismissible: true},
@@ -292,66 +225,32 @@ describe('alert', () => {
     expect(emitted[0][0]).toBe(0)
   })
 
-  it('nested div BCloseButton clicked emits closed', async () => {
+  it('nested div BCloseButton clicked emits close', async () => {
     const wrapper = mount(BAlert, {
       props: {modelValue: 5, dismissible: true},
     })
     const $div = wrapper.get('div')
     const $bclosebutton = $div.getComponent(BCloseButton)
     await $bclosebutton.trigger('click')
-    expect(wrapper.emitted()).toHaveProperty('closed')
-  })
-  // BButton variant
-  it('nested div BButton emits update:modelValue when clicked when modelValue boolean', async () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    await $bbutton.trigger('click')
-    expect(wrapper.emitted()).toHaveProperty('update:modelValue')
+    expect(wrapper.emitted()).toHaveProperty('close')
   })
 
-  it('nested div BButton clicked update:modelValue emits arg false when modelValue boolean', async () => {
+  it('nested div BCloseButton has class when prop close-class', () => {
     const wrapper = mount(BAlert, {
-      props: {modelValue: true, dismissible: true, closeContent: 'foobar'},
+      props: {'modelValue': true, 'dismissible': true, 'close-class': 'foobar'},
     })
     const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    await $bbutton.trigger('click')
-    const emitted = wrapper.emitted('update:modelValue') ?? []
-    expect(emitted[0][0]).toBe(false)
+    const $bclosebutton = $div.getComponent(BCloseButton)
+    expect($bclosebutton.classes()).toContain('foobar')
   })
 
-  it('nested div BButton emits update:modelValue when clicked when modelValue number > 0', async () => {
+  it('nested div BCloseButton has class when prop close-white', () => {
     const wrapper = mount(BAlert, {
-      props: {modelValue: 5, dismissible: true, closeContent: 'foobar'},
+      props: {'modelValue': true, 'dismissible': true, 'close-white': true},
     })
     const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    await $bbutton.trigger('click')
-    expect(wrapper.emitted()).toHaveProperty('update:modelValue')
-  })
-
-  it('nested div BButton clicked update:modelValue emits arg 0 when modelValue number > 0', async () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: 5, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    await $bbutton.trigger('click')
-    const emitted = wrapper.emitted('update:modelValue') ?? []
-    expect(emitted[0][0]).toBe(0)
-  })
-
-  it('nested div BButton clicked emits closed', async () => {
-    const wrapper = mount(BAlert, {
-      props: {modelValue: 5, dismissible: true, closeContent: 'foobar'},
-    })
-    const $div = wrapper.get('div')
-    const $bbutton = $div.getComponent(BButton)
-    await $bbutton.trigger('click')
-    expect(wrapper.emitted()).toHaveProperty('closed')
+    const $bclosebutton = $div.getComponent(BCloseButton)
+    expect($bclosebutton.classes()).toContain('btn-close-white')
   })
 
   // TODO try to test countdown items

--- a/packages/bootstrap-vue-next/src/components/BButton/BCloseButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BCloseButton.vue
@@ -1,18 +1,20 @@
 <template>
   <button
     :type="type"
-    class="btn-close"
     :disabled="disabledBoolean"
     :class="computedClasses"
     :aria-label="ariaLabel"
     @click="emit('click', $event)"
-  />
+  >
+    <slot />
+  </button>
 </template>
 
 <script setup lang="ts">
-import {computed} from 'vue'
+import {computed, useSlots} from 'vue'
 import type {Booleanish, ButtonType} from '../../types'
 import {useBooleanish} from '../../composables'
+import {isEmptySlot} from '../../utils'
 
 interface BCloseButtonProps {
   ariaLabel?: string
@@ -34,10 +36,16 @@ interface BCloseButtonEmits {
 
 const emit = defineEmits<BCloseButtonEmits>()
 
+const slots = useSlots()
+
 const disabledBoolean = useBooleanish(() => props.disabled)
 const whiteBoolean = useBooleanish(() => props.white)
 
+const hasDefaultSlot = computed<boolean>(() => !isEmptySlot(slots.default))
+
 const computedClasses = computed(() => ({
+  'btn-close-custom': hasDefaultSlot.value,
+  'btn-close': !hasDefaultSlot.value,
   'btn-close-white': whiteBoolean.value,
 }))
 </script>

--- a/packages/bootstrap-vue-next/src/components/BButton/close-button.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BButton/close-button.spec.ts
@@ -31,6 +31,19 @@ describe('close-button', () => {
     expect(wrapper.attributes('aria-label')).toBe('Close')
   })
 
+  it('has class btn-close when no default slot', () => {
+    const wrapper = mount(BCloseButton)
+    expect(wrapper.classes()).toContain('btn-close')
+  })
+
+  it('has class btn-close-custom when renders custom default slot', () => {
+    const wrapper = mount(BCloseButton, {
+      props: {white: true},
+      slots: {default: 'foobar'},
+    })
+    expect(wrapper.classes()).toContain('btn-close-custom')
+  })
+
   it('has class btn-close-white when prop white', () => {
     const wrapper = mount(BCloseButton, {
       props: {white: true},

--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -36,16 +36,17 @@
                   </slot>
                 </component>
                 <template v-if="!hideHeaderCloseBoolean">
-                  <button v-if="hasHeaderCloseSlot" type="button" @click="hide('close')">
-                    <slot name="header-close" />
-                  </button>
                   <b-close-button
-                    v-else
                     ref="closeButton"
+                    :class="headerCloseClasses"
                     :aria-label="headerCloseLabel"
                     :white="headerCloseWhite"
                     @click="hide('close')"
-                  />
+                  >
+                    <template v-if="hasHeaderCloseSlot" #default>
+                      <slot name="header-close" />
+                    </template>
+                  </b-close-button>
                 </template>
               </slot>
             </div>
@@ -131,6 +132,7 @@ interface BModalProps {
   headerBgVariant?: ColorVariant | null
   headerBorderVariant?: ColorVariant | null
   headerClass?: ClassValue
+  headerCloseClass?: ClassValue
   headerCloseLabel?: string
   headerCloseWhite?: Booleanish
   headerTextVariant?: ColorVariant | null
@@ -171,6 +173,9 @@ const props = withDefaults(defineProps<BModalProps>(), {
   headerBgVariant: null,
   headerBorderVariant: null,
   headerClass: undefined,
+  headerCloseClass: undefined,
+  headerCloseLabel: 'Close',
+  headerCloseWhite: false,
   footerBgVariant: null,
   footerBorderVariant: null,
   footerClass: undefined,
@@ -189,8 +194,6 @@ const props = withDefaults(defineProps<BModalProps>(), {
   cancelVariant: 'secondary',
   centered: false,
   fullscreen: false,
-  headerCloseLabel: 'Close',
-  headerCloseWhite: false,
   hideBackdrop: false,
   hideFooter: false,
   hideHeader: false,
@@ -250,7 +253,7 @@ const slots = useSlots()
 
 const computedId = useId(() => props.id, 'modal')
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const busyBoolean = useBooleanish(() => props.busy)
 const lazyBoolean = useBooleanish(() => props.lazy)
@@ -335,6 +338,8 @@ const headerClasses = computed(() => [
     [`text-${props.headerTextVariant}`]: props.headerTextVariant !== null,
   },
 ])
+
+const headerCloseClasses = computed(() => [props.headerCloseClass])
 
 const footerClasses = computed(() => [
   props.footerClass,

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/offcanvas.spec.ts
@@ -178,6 +178,24 @@ describe.skip('offcanvas', () => {
     expect($closebutton.classes()).toContain('text-reset')
   })
 
+  it('first child div child BCloseButton has class when prop header-close-class', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {'header-close-class': 'foobar'},
+    })
+    const [, $div] = wrapper.findAll('div')
+    const $closebutton = $div.getComponent(BCloseButton)
+    expect($closebutton.classes()).toContain('foobar')
+  })
+
+  it('first child div child BCloseButton has class when prop header-close-white', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {'header-close-white': true},
+    })
+    const [, $div] = wrapper.findAll('div')
+    const $closebutton = $div.getComponent(BCloseButton)
+    expect($closebutton.classes()).toContain('btn-close-white')
+  })
+
   it('second child div has static class offcanvas-body', () => {
     const wrapper = mount(BOffcanvas)
     const offcanvas = wrapper.find('.offcanvas')
@@ -192,5 +210,14 @@ describe.skip('offcanvas', () => {
     const offcanvas = wrapper.find('.offcanvas')
     const [, $body] = offcanvas.findAll('div')
     expect($body.text()).toBe('foobar')
+  })
+
+  it('content of BCloseButton renders close slot', () => {
+    const wrapper = mount(BOffcanvas, {
+      props: {teleportDisabled: true},
+      slots: {close: 'foobar'},
+    })
+    const $closebutton = wrapper.getComponent(BCloseButton)
+    expect($closebutton.text()).toBe('foobar')
   })
 })

--- a/packages/bootstrap-vue-next/src/components/modal.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/modal.spec.ts
@@ -1,6 +1,7 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 import BModal from './BModal.vue'
+import BCloseButton from './BButton/BCloseButton.vue'
 // import BTransition from './BTransition/BTransition.vue'
 
 describe('modal', () => {
@@ -311,6 +312,26 @@ describe('modal', () => {
     const $div2 = $div.get('div')
     const $div3 = $div2.find('div')
     expect($div3.exists()).toBe(true)
+  })
+
+  it('nested div BCloseButton has class when prop header-close-class', () => {
+    const wrapper = mount(BModal, {
+      global: {stubs: {teleport: true}},
+      props: {'header-close-class': 'foobar'},
+    })
+    const $div = wrapper.get('div')
+    const $bclosebutton = $div.getComponent(BCloseButton)
+    expect($bclosebutton.classes()).toContain('foobar')
+  })
+
+  it('nested div BCloseButton has class when prop header-close-white', () => {
+    const wrapper = mount(BModal, {
+      global: {stubs: {teleport: true}},
+      props: {'header-close-white': true},
+    })
+    const $div = wrapper.get('div')
+    const $bclosebutton = $div.getComponent(BCloseButton)
+    expect($bclosebutton.classes()).toContain('btn-close-white')
   })
 
   // Test isActive states


### PR DESCRIPTION
# Describe the PR

Unify `BCloseButton` on  close button of `BOffcanvas`, `BModal` and `BAlert` and better custom button handling.

## Small replication

Component `BOffcanvas`:

```vue
<template>
  ...
  <b-link v-b-toggle:my-offcanvas>Open Offcanvas</b-link>
  <b-offcanvas id="my-offcanvas" header-close-class="foobar">
    <template #header-close>Close</template>
    My offcanvas content.
  </b-offcanvas>
  ...
</template>
```
Component `BModal`:

```vue
<template>
  ...
  <b-link v-b-toggle:my-modal>Open Modal</b-link>
  <b-modal id="my-modal" header-close-class="foobar">
    <template #header-close>Close</template>
    My modal content.
  </b-modal>

  <b-link v-b-toggle:my-modal-dark>Open Modal</b-link>
  <b-modal id="my-modal-dark" header-bg-variant="dark" header-close-white="true" header-close-class="foobar">
    My modal content.
  </b-modal>
  ...
</template>
```
Component `BAlert`:

```vue
<template>
  ...
  <b-alert v-model="dismissibleAlert" close-class="foobar" dismissible>
    <template #close>Close</template>
    My alert content.
  </b-alert>

  <b-alert v-model="dismissibleAlert" variant="dark" close-white="true" close-class="foobar" dismissible>
    My alert content.
  </b-alert>
  ...
</template>

<script setup lang="ts">
import {ref} from 'vue'
const dismissibleAlert = ref(true)
</script>
```

Custom close buttons get style class `btn-close-custom` instead of `btn-close` and can be freely customized. Adding property `header-close-class` (for `BOffcanvas` and `BModal`) and `close-class` (for `BAlert`) with e.g. Bootstrap button classes can help to style the custom close button. Adding property `header-close-white` (for `BOffcanvas` and `BModal`) and `close-white` (for `BAlert`). Slot `header-close` was added to get same functionalities as in bootstrap-vue for Vue2.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
