### PR TITLE
feat(BOffcanvas): expose hide and show to programmatically control BOffcanvas.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -278,4 +278,9 @@ const OnAfterLeave = () => {
 useEventListener(element, 'bv-toggle', () => {
   modelValueBoolean.value ? hide() : show()
 })
+
+defineExpose({
+  hide,
+  show,
+})
 </script>


### PR DESCRIPTION
# Describe the PR

Expose hide and show to programmatically control `BOffcanvas`.

## Small replication

```vue
<template>
 ...
  <b-offcanvas id="my-offcanvas" ref="offcanvas">
    <b-link @click="hide">
      Hide Offcanvas
    </b-link>
  </b-offcanvas>

  <b-link v-b-toggle.my-offcanvas>
    Show Offcanvas
  </b-link>
  ...
</template>

<script setup lang="ts">
import {ref} from 'vue'
import {BOffcanvas} from './components'

const offcanvas = ref(BOffcanvas)

const hide = (): void => {
  offcanvas.value.hide()
}
</script>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
