### PR TITLE
feat: defineExpose reset on BFormFile input

### DIFF
--- a/apps/docs/src/docs/components/form-file.md
+++ b/apps/docs/src/docs/components/form-file.md
@@ -220,6 +220,14 @@ You can use the `state` prop to provide visual feedback on the state of the inpu
 
 With inputs that are of type `file`, the value is strictly `uni-directional`. Meaning that you cannot change the value of the input via JavaScript. You can change the value of the `v-model`, and this will work for an "outside view", however, the actual `input` element will not have its [FileList](https://developer.mozilla.org/en-US/docs/Web/API/FileList) changed. This is for security reasons as a malicious script could attempt to read and steal documents
 
+## Exposed functions
+
+The BFormFile exposes functions to control the component: `focus(), blur(), reset()`. These are accessed through the [template ref](https://vuejs.org/guide/essentials/template-refs.html#template-refs).
+
+1. Focus: focuses the file input
+2. Blur: blurs the file input focus
+3. Reset: Resets the file selection so that no file is selected
+
 <ComponentReference :data="data" />
 
 <script setup lang="ts">

--- a/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
@@ -144,6 +144,15 @@ const onDrop = (e: Event) => {
   }
 }
 
+/**
+ * Reset the form input
+ */
+const reset = () => {
+  if (input.value !== null) {
+    input.value.value = ''
+  }
+}
+
 defineExpose({
   focus: () => {
     focused.value = true
@@ -151,5 +160,6 @@ defineExpose({
   blur: () => {
     focused.value = false
   },
+  reset,
 })
 </script>


### PR DESCRIPTION
# Describe the PR

Add `reset` method to the `BFormFile` component similar to [bootstrap-vue's reset method](https://bootstrap-vue.org/docs/components/form-file#clearing-the-file-selection)
* Allows to reset the input on the BFormFile component through a template ref
* Add documentation for previously added focus, blur exposed methods

## Small replication

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
