### PR TITLE
feat(BDropdown): support `boundary` prop.

### DIFF
--- a/apps/docs/src/data/components/dropdown.data.ts
+++ b/apps/docs/src/data/components/dropdown.data.ts
@@ -43,7 +43,7 @@ export default {
         },
         {
           prop: 'boundary',
-          type: 'Popper.Boundary',
+          type: 'FloatingUI.Boundary | FloatingUI.RootBoundary',
         },
         {
           prop: 'dark',

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -324,14 +324,13 @@ const show = ref(false)
   </template>
 </HighlightCard>
 
-<!-- TODO build this system -->
-<!-- ### Boundary constraint
+### Boundary constraint
 
-By default, dropdowns are visually constrained to their scroll parent, which will suffice in most situations. However, if you place a dropdown inside an element that has `overflow: scroll` (or similar) set, the dropdown menu may - in some situations - get cut off. To get around this, you can specify a boundary element via the `boundary` prop. Supported values are `'scrollParent'` (the
-default), `'viewport'`, `'window'`, or a reference to an HTML element. The boundary value is passed directly to Popper.js's `boundariesElement` configuration option
+By default, dropdowns are visually constrained to their clipping ancestors, which will suffice in most situations. However, if you place a dropdown inside an element that has `overflow: scroll` (or similar) set, the dropdown menu may - in some situations - get cut off. To get around this, you can specify a boundary element via the `boundary` prop. Supported values are `'clippingAncestors'` (the
+default), `'viewport'`, `'document'`, or a reference to an HTML element.
 
-**Note:** When `boundary` is any value other than the default of `'scrollParent'`, the style `position: static` is applied to the dropdown component's root element to allow the menu to "break out" of its scroll container. In some situations, this may affect your layout or positioning of the dropdown trigger button. In these cases, you may need to wrap your dropdown inside
-another element -->
+**Note:** When `boundary` is any value other than the default of `'clippingAncestors'`, the style `position: static` is applied to the dropdown component's root element to allow the menu to "break out" of its scroll container. In some situations, this may affect your layout or positioning of the dropdown trigger button. In these cases, you may need to wrap your dropdown inside
+another element
 
 ### Dropdown auto close behavior
 

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -34,33 +34,35 @@
         </slot>
       </span>
     </BButton>
+    <ul
+      v-if="!lazyBoolean || modelValueBoolean"
+      v-show="lazyBoolean || modelValueBoolean"
+      ref="floating"
+      :style="{
+        position: strategy === 'absolute' ? undefined : 'fixed',
+        top: `${y}px`,
+        left: `${x}px`,
+        width: 'max-content',
+      }"
+      class="dropdown-menu show"
+      :class="dropdownMenuClasses"
+      :aria-labelledby="computedId"
+      :role="role"
+      @click="onClickInside"
+    >
+      <slot />
+    </ul>
   </div>
-  <ul
-    v-if="!lazyBoolean || modelValueBoolean"
-    v-show="lazyBoolean || modelValueBoolean"
-    ref="floating"
-    :style="{
-      position: strategy === 'absolute' ? undefined : 'fixed',
-      top: `${y}px`,
-      left: `${x}px`,
-      width: 'max-content',
-    }"
-    class="dropdown-menu show"
-    :class="dropdownMenuClasses"
-    :aria-labelledby="computedId"
-    :role="role"
-    @click="onClickInside"
-  >
-    <slot />
-  </ul>
 </template>
 
 <script setup lang="ts">
 import {
   autoUpdate,
+  type Boundary,
   flip,
   offset as floatingOffset,
   type Middleware,
+  type RootBoundary,
   shift,
   type Strategy,
   useFloating,
@@ -119,6 +121,7 @@ const props = withDefaults(
     strategy?: Strategy
     floatingMiddleware?: Middleware[]
     splitTo?: RouteLocationRaw
+    boundary?: Boundary | RootBoundary
   }>(),
   {
     ariaLabel: undefined,
@@ -155,6 +158,7 @@ const props = withDefaults(
     variant: 'secondary',
     modelValue: false,
     strategy: 'absolute',
+    boundary: 'clippingAncestors',
   }
 )
 
@@ -208,6 +212,13 @@ const floating = ref<HTMLElement | null>(null)
 const button = ref<HTMLElement | null>(null)
 const splitButton = ref<HTMLElement | null>(null)
 
+const boundary = computed<Boundary | undefined>(() =>
+  props.boundary === 'document' || props.boundary === 'viewport' ? undefined : props.boundary
+)
+const rootBoundary = computed<RootBoundary | undefined>(() =>
+  props.boundary === 'document' || props.boundary === 'viewport' ? props.boundary : undefined
+)
+
 const referencePlacement = computed(() => (!splitBoolean.value ? splitButton.value : button.value))
 const floatingPlacement = computed(() =>
   resolveFloatingPlacement({
@@ -228,10 +239,20 @@ const floatingMiddleware = computed<Middleware[]>(() => {
       : props.offset
   const arr: Middleware[] = [floatingOffset(localOffset)]
   if (noFlipBoolean.value === false) {
-    arr.push(flip())
+    arr.push(
+      flip({
+        boundary: boundary.value,
+        rootBoundary: rootBoundary.value,
+      })
+    )
   }
   if (noShiftBoolean.value === false) {
-    arr.push(shift())
+    arr.push(
+      shift({
+        boundary: boundary.value,
+        rootBoundary: rootBoundary.value,
+      })
+    )
   }
   return arr
 })
@@ -248,6 +269,7 @@ const computedClasses = computed(() => ({
   'dropend': dropendBoolean.value,
   'dropstart': dropstartBoolean.value,
   'd-flex': blockBoolean.value && splitBoolean.value,
+  'position-static': props.boundary !== 'clippingAncestors' && !isNavBoolean.value,
 }))
 
 const buttonClasses = computed(() => [


### PR DESCRIPTION
# Describe the PR

Support boundary prop.

There's a small mismatch between BootstrapVue's, Bootstrap 5.3's and FloatingUI's default values for the boundary.

- BootstrapVue: 'scrollParent' (https://bootstrap-vue.org/docs/components/dropdown#comp-ref-b-dropdown-props)
- Bootstrap 5.3 / Popper v2: 'clippingParents' (https://getbootstrap.com/docs/5.3/components/dropdowns/#options)
- FloatingUI: 'clippingAncestors' (https://floating-ui.com/docs/detectoverflow#boundary)

I went with FloatingUI's; wdyt?

## Small replication


https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/31940190/7192b1a1-5cea-4ed3-92d2-e09593c73788



## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
