### PR TITLE
fix(BCarousel): carousel-item class disappears after transition

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BCarousel/BCarousel.vue
+++ b/packages/bootstrap-vue-next/src/components/BCarousel/BCarousel.vue
@@ -32,6 +32,7 @@
         :leave-to-class="leaveClasses"
         @before-leave="onBeforeLeave"
         @after-leave="onAfterLeave"
+        @after-enter="onAfterEnter"
       >
         <component
           :is="slide"
@@ -280,6 +281,14 @@ const onBeforeLeave = () => {
 const onAfterLeave = () => {
   emit('slid', buildBvCarouselEvent('slid'))
   isTransitioning.value = false
+}
+// carousel-item class is removed from the slide during the transition,
+// as is included within enter classes.
+// The first slide recovers carousel-item class,
+const onAfterEnter = (el: Element) => {
+  if (modelValue.value !== 0) {
+    el.classList.add('carousel-item')
+  }
 }
 
 watch(


### PR DESCRIPTION
# Describe the PR
fixes #1303.

It adds `carousel-item` class to the slide component using the `afterEnter` event. Therefore, the component recovers the class removed by the transition.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
