### PR TITLE
BTable items nested object

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -382,7 +382,7 @@ const getRowClasses = (item: TableItem | null, type: string): string | any[] | n
 }
 
 const getBusyRowClasses = () => {
-  const classesArray = [{'b-table-static-busy': props.items.length === 0}]
+  const classesArray = [{'b-table-static-busy': computedItems.value.length === 0}]
 
   if (props.tbodyTrClass) {
     const extraClasses = props.tbodyTrClass(null, 'table-busy')

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -70,7 +70,7 @@
           <slot name="table-busy">
             <div class="d-flex align-items-center justify-content-center gap-2">
               <BSpinner class="align-middle" />
-              <strong>Loading...</strong>
+              <strong>{{ busyLoadingText }}</strong>
             </div>
           </slot>
         </td>
@@ -135,6 +135,7 @@ const props = withDefaults(
     selectionVariant?: ColorVariant | null
     stickyHeader?: Booleanish
     busy?: Booleanish
+    busyLoadingText?: string
     showEmpty?: Booleanish
     perPage?: number
     currentPage?: number
@@ -182,6 +183,7 @@ const props = withDefaults(
     selectionVariant: 'primary',
     stickyHeader: false,
     busy: false,
+    busyLoadingText: 'Loading...',
     showEmpty: false,
     currentPage: 1,
     emptyText: 'There are no records to show',

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -70,7 +70,7 @@
             <slot
               v-if="$slots['cell(' + field.key + ')'] || $slots['cell()']"
               :name="$slots['cell(' + field.key + ')'] ? 'cell(' + field.key + ')' : 'cell()'"
-              :value="item[field.key]"
+              :value="get(item, field.key)"
               :index="itemIndex"
               :item="item"
               :field="field"
@@ -152,6 +152,7 @@ import type {
 import BTableSimple from './BTableSimple.vue'
 import {filterEvent} from './helpers/filter-event'
 import type {TableFieldObjectFormatter} from '../../types/TableFieldObject'
+import {get} from '../../utils/object'
 
 const props = withDefaults(
   defineProps<{
@@ -285,7 +286,7 @@ const formatItem = (
   fieldKey: string,
   formatter?: TableFieldObjectFormatter<typeof item>
 ) => {
-  const val = item[fieldKey]
+  const val = get(item, fieldKey)
   if (formatter && typeof formatter === 'function') {
     return formatter(val, fieldKey, item)
   }

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -139,7 +139,7 @@
 <script setup lang="ts">
 import {computed} from 'vue'
 import {useBooleanish} from '../../composables'
-import {isObject, startCase, titleCase} from '../../utils'
+import {get, isObject, startCase, titleCase} from '../../utils'
 import type {
   Booleanish,
   Breakpoint,
@@ -152,7 +152,6 @@ import type {
 import BTableSimple from './BTableSimple.vue'
 import {filterEvent} from './helpers/filter-event'
 import type {TableFieldObjectFormatter} from '../../types/TableFieldObject'
-import {get} from '../../utils/object'
 
 const props = withDefaults(
   defineProps<{
@@ -357,4 +356,3 @@ const getRowClasses = (item: TableItem, type = 'row') => {
   return classesArray
 }
 </script>
-../../composables/tableItems

--- a/packages/bootstrap-vue-next/src/utils/object.ts
+++ b/packages/bootstrap-vue-next/src/utils/object.ts
@@ -28,3 +28,26 @@ export const pick = <
     memo[prop] = objToPluck[prop]
     return memo
   }, {} as Record<PropertyKey, unknown>) as Pick<A, B[number]>
+
+/**
+ * Dynamically get a nested value from an array or
+ * object with a string.
+ *
+ * @example get(person, 'friends[0].name')
+ */
+export const get = <TDefault = unknown>(
+  value: any,
+  path: string,
+  defaultValue?: TDefault
+): TDefault => {
+  const segments = path.split(/[.[\]]/g)
+  let current: any = value
+  for (const key of segments) {
+    if (current === null) return defaultValue as TDefault
+    if (current === undefined) return defaultValue as TDefault
+    if (key.trim() === '') continue
+    current = current[key]
+  }
+  if (current === undefined) return defaultValue as TDefault
+  return current
+}

--- a/packages/bootstrap-vue-next/src/utils/object.ts
+++ b/packages/bootstrap-vue-next/src/utils/object.ts
@@ -34,13 +34,16 @@ export const pick = <
  * object with a string.
  *
  * @example get(person, 'friends[0].name')
+ * @link https://github.com/rayepps/radash/blob/master/src/object.ts#L214
  */
 export const get = <TDefault = unknown>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any,
   path: string,
   defaultValue?: TDefault
 ): TDefault => {
   const segments = path.split(/[.[\]]/g)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let current: any = value
   for (const key of segments) {
     if (current === null) return defaultValue as TDefault


### PR DESCRIPTION
# This PR solves #957 

Show nested objects table rows also using a dot key. Look at issue #957 

Fixed #1307

Added ```busyLoadingText``` prop
