### PR TITLE
fix: Invalid button code in dropdown component

### DIFF
--- a/apps/docs/src/data/components/button.data.ts
+++ b/apps/docs/src/data/components/button.data.ts
@@ -71,9 +71,10 @@ export default {
           type: 'Booleanish',
         },
         {
-          prop: 'loadingMode',
+          prop: 'loadingFill',
           description: '',
-          type: "'fill' | 'inline'",
+          type: 'Booleanish',
+          default: 'false',
         },
       ],
       emits: [

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -6,7 +6,9 @@
     v-bind="computedAttrs"
     @click="clicked"
   >
-    <BSpinner v-if="loadingBoolean" class="btn-spinner" :small="size !== 'lg'" />
+    <slot v-if="loadingBoolean" name="loading">
+      <BSpinner class="btn-spinner" :small="size !== 'lg'" />
+    </slot>
     <span v-if="(loadingBoolean && !fillBoolean) || !loadingBoolean" class="btn-content">
       <slot />
     </span>

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -7,11 +7,11 @@
     @click="clicked"
   >
     <slot v-if="loadingBoolean" name="loading">
-      <BSpinner class="btn-spinner" :small="size !== 'lg'" />
+      <BSpinner :small="size !== 'lg'" />
     </slot>
-    <span v-if="(loadingBoolean && !fillBoolean) || !loadingBoolean" class="btn-content">
+    <template v-if="(loadingBoolean && !fillBoolean) || !loadingBoolean">
       <slot />
-    </span>
+    </template>
   </component>
 </template>
 

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -6,19 +6,8 @@
     v-bind="computedAttrs"
     @click="clicked"
   >
-    <div
-      v-if="loadingBoolean"
-      class="btn-loading"
-      :class="{'mode-fill': loadingMode === 'fill', 'mode-inline': loadingMode === 'inline'}"
-    >
-      <slot name="loading">
-        <BSpinner class="btn-spinner" :small="size !== 'lg'" />
-      </slot>
-    </div>
-    <span
-      class="btn-content"
-      :class="{'btn-loading-fill': loadingBoolean && loadingMode === 'fill'}"
-    >
+    <BSpinner v-if="loadingBoolean" class="btn-spinner" :small="size !== 'lg'" />
+    <span v-if="(loadingBoolean && !fillBoolean) || !loadingBoolean" class="btn-content">
       <slot />
     </span>
   </component>
@@ -52,7 +41,7 @@ const props = withDefaults(
       type?: ButtonType
       variant?: ButtonVariant | null
       loading?: Booleanish
-      loadingMode?: 'fill' | 'inline'
+      loadingFill?: Booleanish
       block?: Booleanish
     } & Omit<BLinkProps, 'variant'>
   >(),
@@ -66,7 +55,7 @@ const props = withDefaults(
     type: 'button',
     variant: 'secondary',
     loading: false,
-    loadingMode: 'inline',
+    loadingFill: false,
     block: false,
     // Link props
     activeClass: 'router-link-active',
@@ -108,6 +97,7 @@ const pillBoolean = useBooleanish(() => props.pill)
 const pressedBoolean = useBooleanish(() => props.pressed)
 const squaredBoolean = useBooleanish(() => props.squared)
 const loadingBoolean = useBooleanish(() => props.loading)
+const fillBoolean = useBooleanish(() => props.loadingFill)
 
 const isToggle = computed<boolean>(() => typeof pressedBoolean.value === 'boolean')
 const isButton = computed<boolean>(

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -15,12 +15,12 @@
         <BSpinner class="btn-spinner" :small="size !== 'lg'" />
       </slot>
     </div>
-    <div
+    <span
       class="btn-content"
       :class="{'btn-loading-fill': loadingBoolean && loadingMode === 'fill'}"
     >
       <slot />
-    </div>
+    </span>
   </component>
 </template>
 

--- a/packages/bootstrap-vue-next/src/components/BButton/_button.scss
+++ b/packages/bootstrap-vue-next/src/components/BButton/_button.scss
@@ -1,30 +1,3 @@
 .btn {
   position: relative;
-
-  .btn-spinner {
-    margin-inline-end: 0.4rem;
-    --bs-spinner-width: 1.5rem;
-    --bs-spinner-height: 1.5rem;
-    --bs-spinner-border-width: 0.15em;
-
-    &.spinner-border-sm {
-      margin-inline-end: 0.25rem;
-      --bs-spinner-width: 1rem;
-      --bs-spinner-height: 1rem;
-    }
-  }
-
-  &.fw-bold {
-    .btn-spinner {
-      --bs-spinner-border-width: 0.2em;
-    }
-  }
-
-  .btn-content {
-    display: inline-block;
-
-    &.btn-loading-fill {
-      color: transparent;
-    }
-  }
 }

--- a/packages/bootstrap-vue-next/src/components/BButton/_button.scss
+++ b/packages/bootstrap-vue-next/src/components/BButton/_button.scss
@@ -1,39 +1,22 @@
 .btn {
   position: relative;
 
-  .btn-loading {
-    &.mode-inline {
-      display: inline-block;
-    }
+  .btn-spinner {
+    margin-inline-end: 0.4rem;
+    --bs-spinner-width: 1.5rem;
+    --bs-spinner-height: 1.5rem;
+    --bs-spinner-border-width: 0.15em;
 
-    &.mode-fill {
-      display: flex;
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      height: 100%;
-      justify-content: center;
-      align-items: center;
+    &.spinner-border-sm {
+      margin-inline-end: 0.25rem;
+      --bs-spinner-width: 1rem;
+      --bs-spinner-height: 1rem;
     }
+  }
 
+  &.fw-bold {
     .btn-spinner {
-      margin-inline-end: 0.4rem;
-      --bs-spinner-width: 1.5rem;
-      --bs-spinner-height: 1.5rem;
-      --bs-spinner-border-width: 0.15em;
-
-      &.spinner-border-sm {
-        margin-inline-end: 0.25rem;
-        --bs-spinner-width: 1rem;
-        --bs-spinner-height: 1rem;
-      }
-    }
-
-    &.fw-bold {
-      .btn-spinner {
-        --bs-spinner-border-width: 0.2em;
-      }
+      --bs-spinner-border-width: 0.2em;
     }
   }
 


### PR DESCRIPTION
resolves #1304

# Describe the PR

This PR fixes the Issue described in #1304 

This is my very first Pull request in OpenSource. Hope I did everything the way I should!

## Small replication

```
<template>
  <BDropdown v-model='show1' text='Button text via Prop' class='m-1'>
    <BDropdownItem href='#'>An item</BDropdownItem>
    <BDropdownItem href='#'>Another item</BDropdownItem>
  </BDropdown>
</template>

```
Now renders a valid button Code:
```
<button class="btn btn-md btn-secondary dropdown-toggle" type="button" id="__BVID__234593___BV_dropdown__" aria-expanded="false" aria-haspopup="menu">
    <!--v-if-->
    <span class="btn-content">Button text via Prop</span>
</button>
```
## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
