### PR TITLE
fix(BNavItem): don't stop click event for toggle directive.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
@@ -7,7 +7,7 @@
       :active-class="activeClass ?? 'active'"
       :tabindex="disabledBoolean ? -1 : undefined"
       :aria-disabled="disabledBoolean ? true : undefined"
-      @click.stop="emit('click', $event)"
+      @click="emit('click', $event)"
     >
       <slot />
     </BLink>


### PR DESCRIPTION
# Describe the PR

Fix `BNavItem` to get it back to work with `v-b-toggle` directive.

See [commit/8eb73718c91f1577b07e6bb7ee862e5f34b32a87](https://github.com/bootstrap-vue-next/bootstrap-vue-next/commit/8eb73718c91f1577b07e6bb7ee862e5f34b32a87) and #1332

## Small replication

```vue
<BNavItem v-b-toggle.main-offcanvas>Open Offcanvas</BNavItem>
<BOffcanvas  id="main-offcanvas">
  Hello Offcanvas!
</BOffcanvas>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
