### PR TITLE
Remove unused blur BOverlay (BModal)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -90,7 +90,6 @@
             no-spinner
             fixed
             no-wrap
-            blur="0px"
             @click="hide('backdrop')"
           />
         </slot>


### PR DESCRIPTION
Blur with 0px on latest version of Chrome 115.0.5790.171 with **CPU only** causes an FPS drop

# Describe the PR

Blur with 0 px on the latest Chrome (production version) causes an FPS drop. In performance, it's observable as "Paint". Blur with 0 px doesn't change visually much (some pixels has a slightly different color, but really - it's not visible), so IMHO it's simply unused. 
![image](https://github.com/adiantek/bootstrap-vue-next/assets/13407885/958d6a77-86fb-4b1a-a6ce-9b383c650145)

Maybe if you want to create in the future a property to set the blur, it should check if size > 0 (it looks cool except for performance if you use the software rendering).

## Small replication

Disable GPU rendering:
![image](https://github.com/adiantek/bootstrap-vue-next/assets/13407885/db82bbe1-0bf1-4e87-97c9-b87a622511a4)


Create any modal and test it:
![image](https://github.com/adiantek/bootstrap-vue-next/assets/13407885/e5a6df37-f62a-4c21-ac67-9325599ea3c4)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
