### PR TITLE
Top and bottom row slot support in BTable

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -62,7 +62,12 @@
         </td>
       </tr>
     </thead>
+
     <tbody>
+      <tr v-if="$slots['top-row']">
+        <slot name="top-row" />
+      </tr>
+
       <template v-for="(item, itemIndex) in items" :key="itemIndex">
         <tr
           :class="getRowClasses(item, 'row')"
@@ -112,6 +117,9 @@
             {{ emptyText }}
           </slot>
         </td>
+      </tr>
+      <tr v-if="$slots['bottom-row']">
+        <slot name="bottom-row" />
       </tr>
     </tbody>
     <tfoot v-if="footCloneBoolean">

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -62,7 +62,6 @@
         </td>
       </tr>
     </thead>
-
     <tbody>
       <tr v-if="!stacked && $slots['top-row']">
         <slot name="top-row" />

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -64,7 +64,7 @@
     </thead>
 
     <tbody>
-      <tr v-if="$slots['top-row']">
+      <tr v-if="!stacked && $slots['top-row']">
         <slot name="top-row" />
       </tr>
 
@@ -118,7 +118,7 @@
           </slot>
         </td>
       </tr>
-      <tr v-if="$slots['bottom-row']">
+      <tr v-if="!stacked && $slots['bottom-row']">
         <slot name="bottom-row" />
       </tr>
     </tbody>


### PR DESCRIPTION
feat: Added missing support for top-row and bottom-row slots in BTableLite (and consequently BTable)

Enhancement for #1276 