### PR TITLE
fix(BDropdown): set aria-disabled attr when disabled

### DIFF
--- a/apps/playground/src/components/Comps/TDropdown.vue
+++ b/apps/playground/src/components/Comps/TDropdown.vue
@@ -142,6 +142,15 @@
         <BDropdown text="Auto close outside" class="m-2" auto-close="outside">
           <BDropdownItem href="#">Action</BDropdownItem>
         </BDropdown>
+
+        <BDropdown text="Various Item Attributes" class="m-2" auto-close="outside">
+          <BDropdownItem href="#">First Action</BDropdownItem>
+          <BDropdownItem>Second Action</BDropdownItem>
+          <BDropdownItem>Third Action</BDropdownItem>
+          <BDropdownDivider />
+          <BDropdownItem href="#" active>Active action</BDropdownItem>
+          <BDropdownItem href="#" disabled>Disabled action</BDropdownItem>
+        </BDropdown>
       </BCol>
     </BRow>
     <BRow>

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
@@ -5,6 +5,7 @@
       class="dropdown-item"
       :class="computedClasses"
       :disabled="disabledBoolean"
+      :aria-disabled="disabledBoolean ? true : null"
       :aria-current="activeBoolean ? true : null"
       :href="tag === 'a' ? href : null"
       :rel="rel"

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown-item.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown-item.spec.ts
@@ -148,6 +148,16 @@ describe('dropdown-item', () => {
     expect($button.attributes('disabled')).toBeUndefined()
   })
 
+  it('button has aria-disabled attr when prop disabled', async () => {
+    const wrapper = mount(BDropdownItem, {
+      props: {disabled: true},
+    })
+    const $button = wrapper.get('button')
+    expect($button.attributes('aria-disabled')).toBe('true')
+    await wrapper.setProps({disabled: false})
+    expect($button.attributes('aria-disabled')).toBeUndefined()
+  })
+
   it('button has aria-current attr when prop active', async () => {
     const wrapper = mount(BDropdownItem, {
       props: {active: true},


### PR DESCRIPTION
# Describe the PR

Adds the aria-disabled attribute to b-drop-down-item to improve accessibility.

Also expands the playground page to include examples of b-drop-down-item with various different attributes.

## Small replication

Fixes #1350

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


