### PR TITLE
fix: `input` reference of `<BFormInput>` is not exposed

### DIFF
--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -361,7 +361,7 @@ const autoDismissingAlertCountdown = ref(0);
 
 const secondAutoDismissingAlert = ref(10000);
 const secondAutoDismissingAlertCountdown = ref(0);
-const myAlert = ref<HTMLElment | null>(null)
+const myAlert = ref<HTMLElement | null>(null)
 
 const pause = () => myAlert.value?.pause()
 const resume = () => myAlert.value?.resume()

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -614,7 +614,7 @@ these methods and properties. Support will vary based on input type.
 // refs are unified in vue3. We need a ref variable with the same as used in the template.
 // The variable will be filled up during mount with the reference to custom component.
 // inputRef will become the reference to the b-form-input component.
-const inputRef = ref<HTMLElment | null>(null)
+const inputRef = ref<HTMLElement | null>(null)
 const sampleInputText = ref('sample text')
 
 // The inner native input is exposed as ref with name "input"
@@ -662,7 +662,7 @@ const formatInputText = ref('')
 const formatLazyInputText = ref('')
 const toLowerCaseFormatter = (value: string) => value.toLowerCase()
 
-const inputRef = ref<HTMLElment | null>(null)
+const inputRef = ref<HTMLElement | null>(null)
 const sampleInputText = ref('sample text')
 
 const selectAllText = () => inputRef.value.input.select()

--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -695,7 +695,7 @@ Easily create a loading button:
 let timeout = null
 
 const loadingBuzy = ref(false)
-const buzyButton = ref<HTMLElment | null>(null)
+const buzyButton = ref<HTMLElement | null>(null)
 
 const clearTimer = () => {
   if (timeout) {
@@ -836,7 +836,7 @@ This example also demonstrates additional accessibility markup.
 const formbusy = ref(false)
 const processing = ref(false)
 const processingcounter = ref(1)
-const formdialog = ref<HTMLElment | null>(null)
+const formdialog = ref<HTMLElement | null>(null)
 let processingInterval = null
 
 const clearProcessingInterval = () => {
@@ -943,7 +943,7 @@ const showNoWrapEx = ref(false)
 const showNoWrapEx2 = ref(false)
 
 const loadingBuzy = ref(false)
-const buzyButton = ref<HTMLElment | null>(null)
+const buzyButton = ref<HTMLElement | null>(null)
 let timeout = null;
 
 const clearTimer = () => {
@@ -975,7 +975,7 @@ const onFormOverlayShown = () => {
 const formbusy = ref(false)
 const processing = ref(false)
 const processingcounter = ref(1)
-const formdialog = ref<HTMLElment | null>(null)
+const formdialog = ref<HTMLElement | null>(null)
 let processingInterval = null;
 
 const clearProcessingInterval = () => {

--- a/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
@@ -111,6 +111,7 @@ const computedClasses = computed(() => {
 defineExpose({
   focus,
   blur,
+  input,
 })
 
 // const highlight = () => {


### PR DESCRIPTION
This PR fixes issue #1363 by exposing the `input` reference in `<BFormInput>`.

It will also fix some typos in the example code for using the `input` reference.

See #1363 and https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/form-input.html#input-methods for reproduction.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix #1363 `
- [ ] Feature
- [ ] ARIA accessibility
- [ ] Documentation update
- [ ] Other

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


BEGIN_COMMIT_OVERRIDE
fix(BFormInput): expose `input` ref from BFormInput
docs: correct spelling of `HTMLElement` in code examples
END_COMMIT_OVERRIDE
