### PR TITLE
fix(docs): Fix code block duplicate.

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -690,4 +690,16 @@ watch(
     }
   }
 }
+
+// Code Block
+[data-bs-theme='dark'] {
+  .vp-code-light {
+    display: none;
+  }
+}
+[data-bs-theme='light'] {
+  .vp-code-dark {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
# Describe the PR

Currently docs code block has duplicated. The code block for light and dark mode mixed. This PR try to fix this.

BEFORE

![p-001-2023-09-12-00-22-34](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/1639206/165b5662-f744-4a47-b814-941d655ed6e7)

AFTER

![p-001-2023-09-12-00-22-42](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/1639206/37486b6f-0154-4574-8470-abc30d127a1c)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
