### PR TITLE
clear up Popover target & reference props

### DIFF
--- a/apps/playground/src/components/Comps/TPopover.vue
+++ b/apps/playground/src/components/Comps/TPopover.vue
@@ -100,11 +100,7 @@
       </BCol>
       <BCol>
         <BButton ref="popoverRef">Hover popover by ref with ref target</BButton>
-        <BPopover
-          :target="() => popoverRef"
-          :reference="() => popoverContainerRef"
-          placement="right"
-        >
+        <BPopover :target="popoverRef" :reference="popoverContainerRef" placement="right">
           <template #title>
             Popover
             <em>Title</em>
@@ -125,7 +121,7 @@
           >Manual popover showing</BButton
         >
         <BPopover
-          :target="() => popoverManualButtonRef"
+          :target="popoverManualButtonRef"
           manual
           :model-value="manualClickPopoverExample"
           placement="right"

--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -80,7 +80,7 @@ export const resolveContent = (
 }
 
 export const resolveDirectiveProps = (binding: DirectiveBinding, el: HTMLElement) => ({
-  target: () => el,
+  target: el,
   modelValue: binding.modifiers.show,
   inline: binding.modifiers.inline,
   click: binding.modifiers.click,


### PR DESCRIPTION
closes #1455 

fix(BPopover): remove function from BPopover target and Reference props and add MaybeRef to it.

I couldn't think why I added function there, and only one using it was the directives (which don't need to use it)