### PR TITLE
fix(BBadge): use text-bg-variant classes for setting badge background and foreground color

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BBadge/BBadge.vue
+++ b/packages/bootstrap-vue-next/src/components/BBadge/BBadge.vue
@@ -72,7 +72,6 @@ const {computedLink, computedLinkProps} = useBLinkHelper(props, [
   'routerComponentName',
   'target',
   'to',
-  'variant',
   'opacity',
   'opacityHover',
   'underlineVariant',
@@ -86,10 +85,9 @@ const {computedLink, computedLinkProps} = useBLinkHelper(props, [
 const computedTag = computed(() => (computedLink.value ? BLink : props.tag))
 
 const computedClasses = computed(() => ({
-  [`bg-${props.variant}`]: props.variant !== null,
+  [`text-bg-${props.variant}`]: props.variant !== null,
   'active': activeBoolean.value,
   'disabled': disabledBoolean.value,
-  'text-dark': props.variant !== null && ['warning', 'info', 'light'].includes(props.variant),
   'rounded-pill': pillBoolean.value,
   'position-absolute top-0 start-100 translate-middle':
     textIndicatorBoolean.value || dotIndicatorBoolean.value,

--- a/packages/bootstrap-vue-next/src/components/BBadge/badge.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BBadge/badge.spec.ts
@@ -54,14 +54,14 @@ describe('badge', () => {
     expect(wrapper.element.tagName).toBe('SPAN')
   })
 
-  it('contains class bg-{type} when prop varaint', async () => {
+  it('contains class text-bg-{type} when prop variant', async () => {
     const wrapper = mount(BBadge, {
       props: {variant: 'primary'},
     })
-    expect(wrapper.classes()).toContain('bg-primary')
+    expect(wrapper.classes()).toContain('text-bg-primary')
     await wrapper.setProps({variant: 'secondary'})
-    expect(wrapper.classes()).toContain('bg-secondary')
-    expect(wrapper.classes()).not.toContain('bg-primary')
+    expect(wrapper.classes()).toContain('text-bg-secondary')
+    expect(wrapper.classes()).not.toContain('text-bg-primary')
   })
 
   it('contains class active when prop active', async () => {
@@ -80,21 +80,6 @@ describe('badge', () => {
     expect(wrapper.classes()).toContain('disabled')
     await wrapper.setProps({disabled: false})
     expect(wrapper.classes()).not.toContain('disabled')
-  })
-
-  it('contains class text-dark when prop variant is warning|info|light', async () => {
-    const wrapper = mount(BBadge, {
-      props: {variant: 'primary'},
-    })
-    expect(wrapper.classes()).not.toContain('text-dark')
-    await wrapper.setProps({variant: 'warning'})
-    expect(wrapper.classes()).toContain('text-dark')
-    await wrapper.setProps({variant: 'info'})
-    expect(wrapper.classes()).toContain('text-dark')
-    await wrapper.setProps({variant: 'light'})
-    expect(wrapper.classes()).toContain('text-dark')
-    await wrapper.setProps({variant: 'primary'})
-    expect(wrapper.classes()).not.toContain('text-dark')
   })
 
   it('contains class rounded-pill when prop pill', async () => {


### PR DESCRIPTION
# Describe the PR

* As bootstrap 5.2+ supports text-bg-variant classes to set background colors and contrasting foreground colors automatically, use these to set the badge background and foreground color
* Remove functionality to manually set text-dark for contrasting foreground colors and remove relating test
* Remove setting link variant that conflicts with the new text-bg-variant class

## Small replication

n/a

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
