### PR TITLE
BTable thead-tr-class and tbody-tr-class

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -368,7 +368,8 @@ const getRowClasses = (item: TableItem | null, type: string): string | any[] | n
   ]
 
   if (props.tbodyTrClass) {
-    const extraClasses = props.tbodyTrClass(item, type)
+    const extraClasses =
+      typeof props.tbodyTrClass === 'string' ? props.tbodyTrClass : props.tbodyTrClass(item, type)
     if (extraClasses) {
       classesArray.push(...(typeof extraClasses === 'string' ? [extraClasses] : extraClasses))
     }
@@ -380,7 +381,8 @@ const getBusyRowClasses = () => {
   const classesArray = [{'b-table-static-busy': computedItems.value.length === 0}]
 
   if (props.tbodyTrClass) {
-    const extraClasses = props.tbodyTrClass(null, 'table-busy')
+    const extraClasses =
+      typeof props.tbodyTrClass === 'function' ? props.tbodyTrClass(null, 'table-busy') : ''
     if (extraClasses) {
       classesArray.push(...(typeof extraClasses === 'string' ? [extraClasses] : extraClasses))
     }

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -217,7 +217,7 @@ const props = withDefaults(
     tableClass: undefined,
     fieldColumnClass: undefined,
     tbodyTrClass: undefined,
-    theadTrClass: 'table-danger',
+    theadTrClass: undefined,
   }
 )
 

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -17,7 +17,7 @@
   >
     <thead>
       <slot v-if="$slots['thead-top']" name="thead-top" />
-      <tr>
+      <tr :class="theadTrClass">
         <slot name="thead-tr-prefix" />
         <th
           v-for="field in computedFields"
@@ -217,6 +217,7 @@ const props = withDefaults(
     tableClass: undefined,
     fieldColumnClass: undefined,
     tbodyTrClass: undefined,
+    theadTrClass: 'table-danger',
   }
 )
 
@@ -320,7 +321,7 @@ const getFieldColumnClasses = (field: TableFieldObject) => [
   field.class,
   field.thClass,
   {
-    [`table-${field.variant}`]: field.variant !== null,
+    [`table-${field.variant}`]: !!field.variant,
     'b-table-sticky-column': field.stickyColumn,
   },
   ...(props.fieldColumnClass ? props.fieldColumnClass(field) : []),
@@ -333,7 +334,7 @@ const getFieldRowClasses = (field: TableFieldObject, tr: TableItem) => [
     ? `table-${tr?._cellVariants[field.key]}`
     : undefined,
   {
-    [`table-${field.variant}`]: field.variant !== null,
+    [`table-${field.variant}`]: !!field.variant,
     'b-table-sticky-column': field.stickyColumn,
   },
 ]
@@ -345,7 +346,8 @@ const getRowClasses = (item: TableItem, type = 'row') => {
   ]
 
   if (props.tbodyTrClass) {
-    const extraClasses = props.tbodyTrClass(item, type)
+    const extraClasses =
+      typeof props.tbodyTrClass === 'string' ? props.tbodyTrClass : props.tbodyTrClass(item, type)
     if (extraClasses) {
       classesArray.push(...(typeof extraClasses === 'string' ? [extraClasses] : extraClasses))
     }

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -98,7 +98,10 @@ export interface BTableLiteProps {
   emptyText?: string
   emptyFilteredText?: string
   fieldColumnClass?: (field: TableFieldObject) => Record<string, any>[]
-  tbodyTrClass?: (item: TableItem | null, type: string) => string | Array<any> | null | undefined
+  tbodyTrClass?:
+    | string
+    | ((item: TableItem | null, type: string) => string | Array<any> | null | undefined)
+  theadTrClass?: ClassValue
   virtualFields?: number | string
 }
 


### PR DESCRIPTION
# Describe the PR
This PR adds ```thead-tr-class``` and allows ```tbody-tr-class``` to accept string and not only function
It also fixes the ```class="table-undefined"``` attribute on ```<td>```
