### PR TITLE
fix(BModal): Fix recent regression breaking body scroll locking

### DIFF
--- a/apps/docs/src/data/components/modal.data.ts
+++ b/apps/docs/src/data/components/modal.data.ts
@@ -206,11 +206,6 @@ export default {
           default: false,
         },
         {
-          prop: 'show',
-          type: 'Booleanish',
-          default: false,
-        },
-        {
           prop: 'size',
           type: "Size | 'xl'",
           default: 'md',

--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -75,6 +75,95 @@ const preventableModal = ref(false)
   </template>
 </HighlightCard>
 
+## Scrolling long content
+
+When modals become too long for the user's viewport or device, they scroll independent of the page
+itself. Try the demo below to see what we mean.
+
+<HighlightCard>
+  <BButton v-b-modal.modal-tall>Launch overflowing modal</BButton>
+
+  <BModal id="modal-tall" title="Overflowing Content">
+    <p class="my-4" v-for="i in 20" :key="i">
+      Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis
+      in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+    </p>
+  </BModal>
+  <template #html>
+
+```vue
+<template>
+  <BButton v-b-modal.modal-tall>Launch overflowing modal</BButton>
+
+  <BModal id="modal-tall" title="Overflowing Content">
+    <p class="my-4" v-for="i in 20" :key="i">
+      Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in,
+      egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+    </p>
+  </BModal>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+You can also create a scrollable modal that allows the scrolling of the modal body by setting the
+prop `scrollable` to `true`.
+
+<HighlightCard>
+  <BButton v-b-modal.modal-scrollable>Launch scrolling modal</BButton>
+
+  <BModal id="modal-scrollable" scrollable title="Scrollable Content">
+    <p class="my-4" v-for="i in 20" :key="i">
+      Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis
+      in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+    </p>
+  </BModal>
+  <template #html>
+
+```vue
+<template>
+  <BButton v-b-modal.modal-scrollable>Launch scrolling modal</BButton>
+
+  <BModal id="modal-scrollable" scrollable title="Scrollable Content">
+    <p class="my-4" v-for="i in 20" :key="i">
+      Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in,
+      egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+    </p>
+  </BModal>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+## Vertically centered modal
+
+Vertically center your modal in the viewport by setting the `centered` prop.
+
+<HighlightCard>
+  <BButton v-b-modal.modal-center>Launch centered modal</BButton>
+
+  <BModal id="modal-center" centered title="BootstrapVue">
+    <p class="my-4">Vertically centered modal!</p>
+  </BModal>
+  <template #html>
+
+```vue
+<template>
+  <BButton v-b-modal.modal-center>Launch centered modal</BButton>
+
+  <BModal id="modal-center" centered title="BootstrapVue">
+    <p class="my-4">Vertically centered modal!</p>
+  </BModal>
+</template>
+```
+
+  </template>
+</HighlightCard>
+
+Feel free to mix vertically `centered` with `scrollable`.
+
 ## Multiple Modal Support
 
 <HighlightCard>
@@ -131,7 +220,7 @@ To programmatically control your modals with global state, refer to our document
 import {data} from '../../data/components/modal.data'
 import ComponentReference from '../../components/ComponentReference.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
-import {BCard, BCardBody, BModal, BButton} from 'bootstrap-vue-next'
+import {BCard, BCardBody, BModal, BButton, vBModal} from 'bootstrap-vue-next'
 import {ref} from 'vue'
 
 const modal = ref(false)

--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -179,7 +179,6 @@ const props = withDefaults(
     okTitle?: string
     okVariant?: ButtonVariant | null
     scrollable?: Booleanish
-    show?: Booleanish
     size?: Size | 'xl'
     title?: string
     titleClass?: ClassValue
@@ -240,7 +239,6 @@ const props = withDefaults(
     okTitle: 'Ok',
     okVariant: 'primary',
     scrollable: false,
-    show: false,
     titleSrOnly: false,
     titleTag: 'h5',
     teleportDisabled: false,

--- a/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
+++ b/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
@@ -2,8 +2,8 @@ import {type MaybeRefOrGetter, onMounted, readonly, toRef, watch} from 'vue'
 import {useScrollLock} from '@vueuse/core'
 
 export default (isOpen: MaybeRefOrGetter<boolean>, bodyScroll: MaybeRefOrGetter<boolean>) => {
-  const resolvedIsOpen = readonly(toRef(() => isOpen))
-  const resolvedBodyScrolling = readonly(toRef(() => bodyScroll))
+  const resolvedIsOpen = readonly(toRef(isOpen))
+  const resolvedBodyScrolling = readonly(toRef(bodyScroll))
 
   /**
    * We use the inverse because bodyScrolling === true means we allow scrolling, while bodyScrolling === false means we disallow

--- a/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
+++ b/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
@@ -1,23 +1,18 @@
-import {type MaybeRefOrGetter, onMounted, toRef, watch} from 'vue'
+import {type MaybeRefOrGetter, onMounted, toValue, watch} from 'vue'
 import {useScrollLock} from '@vueuse/core'
 
-export default (isOpen: MaybeRefOrGetter<boolean>, bodyScroll: MaybeRefOrGetter<boolean>) => {
-  const resolvedIsOpen = toRef(() => isOpen)
-  const resolvedBodyScrolling = toRef(() => bodyScroll)
-
-  /**
-   * We use the inverse because bodyScrolling === true means we allow scrolling, while bodyScrolling === false means we disallow
-   */
-  const inverseBodyScrollingValue = toRef(() => !resolvedBodyScrolling.value)
-
+export default (
+  isOpen: MaybeRefOrGetter<boolean>,
+  bodyScrollLockingDisabled: MaybeRefOrGetter<boolean>
+) => {
   onMounted(() => {
     const isLocked = useScrollLock(
       document.body,
-      resolvedIsOpen.value && inverseBodyScrollingValue.value
+      toValue(isOpen) && !toValue(bodyScrollLockingDisabled)
     )
 
-    watch([resolvedIsOpen, inverseBodyScrollingValue], ([modelVal, bodyVal]) => {
-      isLocked.value = modelVal && bodyVal
+    watch([isOpen, bodyScrollLockingDisabled], ([modelVal, bodyVal]) => {
+      isLocked.value = toValue(modelVal) && !toValue(bodyVal)
     })
   })
 }

--- a/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
+++ b/packages/bootstrap-vue-next/src/composables/useSafeScrollLock.ts
@@ -1,18 +1,23 @@
-import {type MaybeRefOrGetter, onMounted, toValue, watch} from 'vue'
+import {type MaybeRefOrGetter, onMounted, readonly, toRef, watch} from 'vue'
 import {useScrollLock} from '@vueuse/core'
 
-export default (
-  isOpen: MaybeRefOrGetter<boolean>,
-  bodyScrollLockingDisabled: MaybeRefOrGetter<boolean>
-) => {
+export default (isOpen: MaybeRefOrGetter<boolean>, bodyScroll: MaybeRefOrGetter<boolean>) => {
+  const resolvedIsOpen = readonly(toRef(() => isOpen))
+  const resolvedBodyScrolling = readonly(toRef(() => bodyScroll))
+
+  /**
+   * We use the inverse because bodyScrolling === true means we allow scrolling, while bodyScrolling === false means we disallow
+   */
+  const inverseBodyScrollingValue = toRef(() => !resolvedBodyScrolling.value)
+
   onMounted(() => {
     const isLocked = useScrollLock(
       document.body,
-      toValue(isOpen) && !toValue(bodyScrollLockingDisabled)
+      resolvedIsOpen.value && inverseBodyScrollingValue.value
     )
 
-    watch([isOpen, bodyScrollLockingDisabled], ([modelVal, bodyVal]) => {
-      isLocked.value = toValue(modelVal) && !toValue(bodyVal)
+    watch([resolvedIsOpen, inverseBodyScrollingValue], ([modelVal, bodyVal]) => {
+      isLocked.value = modelVal && bodyVal
     })
   })
 }


### PR DESCRIPTION
# Describe the PR

Fix recent regression breaking body scroll locking when a modal is open and bodyScrolling isn't set to true.

Also removed unused 'show' prop, added some docs for scrollable and centered, and added some more unit tests. Docs and tests were mostly copied from bootstrap-vue.

## Small replication

Go to https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/modal.html, open a modal, and check the style attribute on document.body. Notice it doesn't exist, when it should be set to `overflow: hidden`

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
