### PR TITLE
docs: Navbar doc fixes 

### DIFF
--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -15,7 +15,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 </div>
 
 <HighlightCard>
-  <BNavbar toggleable="lg" type="dark" variant="dark">
+  <BNavbar toggleable="lg" data-bs-theme="dark" variant="dark">
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-collapse" />
     <BCollapse id="nav-collapse" is-nav>
@@ -49,7 +49,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
   <template #html>
 
 ```vue-html
-<BNavbar toggleable="lg" type="dark" variant="dark">
+<BNavbar toggleable="lg" data-bs-theme="dark" variant="dark">
   <BNavbarBrand href="#">NavBar</BNavbarBrand>
   <BNavbarToggle target="nav-collapse" />
   <BCollapse id="nav-collapse" is-nav>
@@ -87,9 +87,9 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 
 ## Color schemes
 
-`BNavbar` supports the standard Bootstrap v4 available background color variants. Set the variant prop to one of the following values to change the background color: primary, success, info, warning, danger, dark, or light.
+`BNavbar` supports the standard Bootstrap v5 available background color variants. Set the variant prop to one of the following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
 
-Control the text color by setting `type` prop to `light` for use with light background color variants, or dark for dark background color variants.
+Control the text color by setting `data-bs-theme` prop to `dark` for use with dark background color variants, or `light` for light background color variants.
 
 ## Placement
 
@@ -118,14 +118,14 @@ Navbars come with built-in support for a handful of sub-components. Choose from 
 The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to is provided. If neither is given it renders as a `<div>` tag. You can override the tag type by setting the tag prop to the element you would like rendered:
 
 <HighlightCard>
-  <BNavbar variant="faded" type="light">
+  <BNavbar variant="faded" data-bs-theme="light">
     <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
   </BNavbar>
   <template #html>
 
 ```vue-html
 <!-- As a link -->
-<BNavbar variant="faded" type="light">
+<BNavbar variant="faded" data-bs-theme="light">
   <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
 </BNavbar>
 ```
@@ -134,14 +134,14 @@ The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to
 </HighlightCard>
 
 <HighlightCard>
-  <BNavbar variant="faded" type="light">
+  <BNavbar variant="faded" data-bs-theme="light">
     <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
   </BNavbar>
   <template #html>
 
 ```vue-html
 <!-- As a heading -->
-<BNavbar variant="faded" type="light">
+<BNavbar variant="faded" data-bs-theme="light">
   <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
 </BNavbar>
 ```
@@ -152,7 +152,7 @@ The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to
 Adding images to the `BNavbarBrand` will likely always require custom styles or utilities to properly size. Here are some examples to demonstrate:
 
 <HighlightCard>
-  <BNavbar variant="faded" type="light">
+  <BNavbar variant="faded" data-bs-theme="light">
     <BNavbarBrand href="#">
       <img src="https://placekitten.com/g/30/30" alt="Kitten">
     </BNavbarBrand>
@@ -161,7 +161,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 
 ```vue-html
 <!-- Just an image -->
-<BNavbar variant="faded" type="light">
+<BNavbar variant="faded" data-bs-theme="light">
   <BNavbarBrand href="#">
     <img src="https://placekitten.com/g/30/30" alt="Kitten">
   </BNavbarBrand>
@@ -172,7 +172,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 </HighlightCard>
 
 <HighlightCard>
-  <BNavbar variant="faded" type="light">
+  <BNavbar variant="faded" data-bs-theme="light">
     <BNavbarBrand href="#">
       <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
       BootstrapVue
@@ -182,7 +182,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 
 ```vue-html
 <!-- Image and text -->
-<BNavbar variant="faded" type="light">
+<BNavbar variant="faded" data-bs-theme="light">
   <BNavbarBrand href="#">
     <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
     BootstrapVue
@@ -217,7 +217,7 @@ Handle click events by specifying a handler for the @click event on `BNavItem`.
 Navbars may contain bits of text with the help of `BNavText`. This component adjusts vertical alignment and horizontal spacing for strings of text.
 
 <HighlightCard>
-  <BNavbar toggleable="sm" type="light" variant="light">
+  <BNavbar toggleable="sm" data-bs-theme="light" variant="light">
     <BNavbarToggle target="nav-text-collapse" />
     <BNavbarBrand>BootstrapVue</BNavbarBrand>
     <BCollapse id="nav-text-collapse" is-nav>
@@ -229,7 +229,7 @@ Navbars may contain bits of text with the help of `BNavText`. This component adj
   <template #html>
 
 ```vue-html
-<BNavbar toggleable="sm" type="light" variant="light">
+<BNavbar toggleable="sm" data-bs-theme="light" variant="light">
   <BNavbarToggle target="nav-text-collapse" />
 
   <BNavbarBrand>BootstrapVue</BNavbarBrand>
@@ -250,7 +250,7 @@ Navbars may contain bits of text with the help of `BNavText`. This component adj
 For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are not supported in `BNavbar` and `BNavbarNav`.
 
 <HighlightCard>
-  <BNavbar type="dark" variant="dark">
+  <BNavbar data-bs-theme="dark" variant="dark">
     <BNavbarNav>
       <BNavItem href="#">Home</BNavItem>
       <BNavItemDropdown text="Lang" right>
@@ -268,7 +268,7 @@ For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are
   <template #html>
 
 ```vue-html
-<BNavbar type="dark" variant="dark">
+<BNavbar data-bs-theme="dark" variant="dark">
   <BNavbarNav>
     <BNavItem href="#">Home</BNavItem>
 
@@ -296,7 +296,7 @@ For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are
 Use `BNavForm` to place inline form controls into your navbar
 
 <HighlightCard>
-  <BNavbar type="light" variant="light">
+  <BNavbar data-bs-theme="light" variant="light">
     <BNavForm>
       <BFormInput class="me-sm-2" placeholder="Search" />
       <BButton variant="outline-success" class="my-2 my-sm-0" type="submit">Search</BButton>
@@ -305,7 +305,7 @@ Use `BNavForm` to place inline form controls into your navbar
   <template #html>
 
 ```vue-html
-<BNavbar type="light" variant="light">
+<BNavbar data-bs-theme="light" variant="light">
   <BNavForm>
     <BFormInput class="me-sm-2" placeholder="Search" />
     <BButton variant="outline-success" class="my-2 my-sm-0" type="submit">Search</BButton>
@@ -319,7 +319,7 @@ Use `BNavForm` to place inline form controls into your navbar
 Input Groups work as well:
 
 <HighlightCard>
-  <BNavbar type="light" variant="light">
+  <BNavbar data-bs-theme="light" variant="light">
     <BNavForm>
       <BInputGroup prepend="@">
         <BFormInput placeholder="Username" />
@@ -329,7 +329,7 @@ Input Groups work as well:
   <template #html>
 
 ```vue-html
-<BNavbar type="light" variant="light">
+<BNavbar data-bs-theme="light" variant="light">
   <BNavForm>
     <BInputGroup prepend="@">
       <BFormInput placeholder="Username" />
@@ -361,12 +361,12 @@ Internally, `BNavbarToggle` uses the v-b-toggle directive.
 
 ### Custom navbar toggle
 
-`BNavbarToggle` renders the default Bootstrap v4 hamburger (which is a background SVG image). You can supply your own content (such as an icon) via the optionally scoped default slot. The default slot scope contains the property expanded, which will be true when the collapse is expanded, or false when the collapse is collapsed.
+`BNavbarToggle` renders the default Bootstrap v5 hamburger (which is a background SVG image). You can supply your own content (such as an icon) via the optionally scoped default slot. The default slot scope contains the property expanded, which will be true when the collapse is expanded, or false when the collapse is collapsed.
 
 Note that the expanded scope property only works when supplying the target prop as a string, and not an array.
 
 <HighlightCard>
-  <BNavbar toggleable type="dark" variant="dark">
+  <BNavbar toggleable data-bs-theme="dark" variant="dark">
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="navbar-toggle-collapse">
       <template #default="{ expanded }">
@@ -385,7 +385,7 @@ Note that the expanded scope property only works when supplying the target prop 
   <template #html>
 
 ```vue-html
-<BNavbar toggleable type="dark" variant="dark">
+<BNavbar toggleable data-bs-theme="dark" variant="dark">
   <BNavbarBrand href="#">NavBar</BNavbarBrand>
 
   <BNavbarToggle target="navbar-toggle-collapse">

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -93,7 +93,7 @@ following values to change the background color: primary, secondary, success, in
 If the `variant` prop is set, it may be necessary to control the text color so that it contrasts with the variant
 irrespective of the theme. This can be done by use the `v-b-color-mode` directive or `useColorMode` composable
 
-An example using `v-b-colorMode`. Form more information see the [BColorMode directive](/docs/directives/BColorMode).
+An example using `v-b-colorMode`. For more information see the [BColorMode directive](/docs/directives/BColorMode).
 
 <HighlightCard>
   <BNavbar variant="primary" v-b-color-mode="'dark'">

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -117,7 +117,7 @@ irrespective of the theme. This can be done by use the `v-b-color-mode` directiv
 
 ```vue-html
 <!-- Using the data-bs-theme attribute -->
-<BNavbar data-bs-theme="dark">
+<BNavbar variant="primary" data-bs-theme="dark">
   <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
 </BNavbar>
 ```

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -110,6 +110,7 @@ An example using `v-b-colorMode`. For more information see the [BColorMode direc
 
   </template>
 </HighlightCard>
+
 `BNavbar` will conform to the current color theme if the `variant` prop is not set.
 
 ## Placement

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -15,7 +15,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 </div>
 
 <HighlightCard>
-  <BNavbar toggleable="lg" data-bs-theme="dark" variant="primary">
+  <BNavbar toggleable="lg" variant="primary" v-b-color-mode="'dark'">
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-collapse" />
     <BCollapse id="nav-collapse" is-nav>
@@ -49,7 +49,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
   <template #html>
 
 ```vue-html
-<BNavbar toggleable="lg" data-bs-theme="dark" variant="primary">
+<BNavbar toggleable="lg" variant="primary" v-b-color-mode="'dark'">
   <BNavbarBrand href="#">NavBar</BNavbarBrand>
   <BNavbarToggle target="nav-collapse" />
   <BCollapse id="nav-collapse" is-nav>
@@ -90,8 +90,20 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 `BNavbar` supports the standard Bootstrap v5 available background color variants. Set the `variant` prop to one of the
 following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
 
-If the `variant` property is set, control the text color by setting `data-bs-theme` prop to `dark` for use with dark
-background color variants, or `light` for light background color variants.
+If the `variant` property is set, it may be necessary to control the text color so that it contrasts with the variant
+irrespective of the theme. This can be done in one of two ways.
+
+Use the `v-b-color-mode` directive:
+
+```vue-html
+<BNavbar toggleable="lg" variant="primary" v-b-color-mode="'dark'">
+```
+
+Or use the raw `data-bs-theme` attribute:
+
+```vue-html
+<BNavbar toggleable="lg" variant="primary" data-bs-theme="dark">
+```
 
 `BNavbar` will conform to the current color theme if the `variant` prop is not set.
 
@@ -221,7 +233,7 @@ Handle click events by specifying a handler for the @click event on `BNavItem`.
 Navbars may contain bits of text with the help of `BNavText`. This component adjusts vertical alignment and horizontal spacing for strings of text.
 
 <HighlightCard>
-  <BNavbar toggleable="sm" data-bs-theme="light" variant="light">
+  <BNavbar toggleable="sm" variant="primary" v-b-color-mode="'dark'">
     <BNavbarToggle target="nav-text-collapse" />
     <BNavbarBrand>BootstrapVue</BNavbarBrand>
     <BCollapse id="nav-text-collapse" is-nav>
@@ -233,7 +245,7 @@ Navbars may contain bits of text with the help of `BNavText`. This component adj
   <template #html>
 
 ```vue-html
-<BNavbar toggleable="sm" data-bs-theme="light" variant="light">
+<BNavbar toggleable="sm" variant="primary" v-b-color-mode="'dark'">
   <BNavbarToggle target="nav-text-collapse" />
 
   <BNavbarBrand>BootstrapVue</BNavbarBrand>
@@ -254,7 +266,7 @@ Navbars may contain bits of text with the help of `BNavText`. This component adj
 For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are not supported in `BNavbar` and `BNavbarNav`.
 
 <HighlightCard>
-  <BNavbar data-bs-theme="dark" variant="dark">
+  <BNavbar variant="dark" v-b-color-mode="'dark'">
     <BNavbarNav>
       <BNavItem href="#">Home</BNavItem>
       <BNavItemDropdown text="Lang" right>
@@ -272,7 +284,7 @@ For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are
   <template #html>
 
 ```vue-html
-<BNavbar data-bs-theme="dark" variant="dark">
+<BNavbar variant="dark" v-b-color-mode="'dark'">
   <BNavbarNav>
     <BNavItem href="#">Home</BNavItem>
 
@@ -300,7 +312,7 @@ For `BNavItemDropdown` usage, see the `BDropdown` docs. Note split dropdowns are
 Use `BNavForm` to place inline form controls into your navbar
 
 <HighlightCard>
-  <BNavbar data-bs-theme="light" variant="light">
+  <BNavbar variant="primary" v-b-color-mode="'dark'">
     <BNavForm>
       <BFormInput class="me-sm-2" placeholder="Search" />
       <BButton variant="outline-success" class="my-2 my-sm-0" type="submit">Search</BButton>
@@ -309,7 +321,7 @@ Use `BNavForm` to place inline form controls into your navbar
   <template #html>
 
 ```vue-html
-<BNavbar data-bs-theme="light" variant="light">
+<BNavbar variant="primary" v-b-color-mode="'dark'">
   <BNavForm>
     <BFormInput class="me-sm-2" placeholder="Search" />
     <BButton variant="outline-success" class="my-2 my-sm-0" type="submit">Search</BButton>
@@ -323,7 +335,7 @@ Use `BNavForm` to place inline form controls into your navbar
 Input Groups work as well:
 
 <HighlightCard>
-  <BNavbar data-bs-theme="light" variant="light">
+  <BNavbar variant="primary" v-b-color-mode="'dark'">
     <BNavForm>
       <BInputGroup prepend="@">
         <BFormInput placeholder="Username" />
@@ -333,7 +345,7 @@ Input Groups work as well:
   <template #html>
 
 ```vue-html
-<BNavbar data-bs-theme="light" variant="light">
+<BNavbar variant="primary" v-b-color-mode="'dark'">
   <BNavForm>
     <BInputGroup prepend="@">
       <BFormInput placeholder="Username" />
@@ -370,7 +382,7 @@ Internally, `BNavbarToggle` uses the v-b-toggle directive.
 Note that the expanded scope property only works when supplying the target prop as a string, and not an array.
 
 <HighlightCard>
-  <BNavbar toggleable data-bs-theme="dark" variant="dark">
+  <BNavbar toggleable variant="dark" v-b-color-mode="'dark'">
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="navbar-toggle-collapse">
       <template #default="{ expanded }">
@@ -389,7 +401,7 @@ Note that the expanded scope property only works when supplying the target prop 
   <template #html>
 
 ```vue-html
-<BNavbar toggleable data-bs-theme="dark" variant="dark">
+<BNavbar toggleable variant="dark" v-b-color-mode="'dark'">
   <BNavbarBrand href="#">NavBar</BNavbarBrand>
 
   <BNavbarToggle target="navbar-toggle-collapse">
@@ -430,7 +442,7 @@ Navbars are hidden by default when printing. Force them to be printed by setting
 import {data} from '../../data/components/navbar.data'
 import ComponentReference from '../../components/ComponentReference.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
-import {BNavText, BInputGroup, BNavbar, BNavbarBrand, BNavbarToggle, BCollapse, BNavbarNav, BNavForm, BNavItem, BFormInput, BNavbarItem, BNavItemDropdown, BDropdownItem, BButton} from 'bootstrap-vue-next'
+import {BNavText, BInputGroup, BNavbar, BNavbarBrand, BNavbarToggle, BCollapse, BNavbarNav, BNavForm, BNavItem, BFormInput, BNavbarItem, BNavItemDropdown, BDropdownItem, BButton, vBColorMode} from 'bootstrap-vue-next'
 import ChevronBarUpIcon from '~icons/bi/chevron-bar-up'
 import ChevronBarDownIcon from '~icons/bi/chevron-bar-down'
 </script>

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -110,25 +110,6 @@ An example using `v-b-colorMode`. Form more information see the [BColorMode dire
 
   </template>
 </HighlightCard>
-
-An example using `data-bs-theme`. For more information see the
-[bootstrap documentation](https://getbootstrap.com/docs/5.3/components/navbar/#color-schemes).
-
-<HighlightCard>
-  <BNavbar variant="primary" data-bs-theme="dark">
-    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
-  </BNavbar>
-  <template #html>
-
-```vue-html
-<BNavbar variant="primary" data-bs-theme="dark">
-  <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
-</BNavbar>
-```
-
-  </template>
-</HighlightCard>
-
 `BNavbar` will conform to the current color theme if the `variant` prop is not set.
 
 ## Placement

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -93,21 +93,25 @@ following values to change the background color: primary, secondary, success, in
 If the `variant` property is set, it may be necessary to control the text color so that it contrasts with the variant
 irrespective of the theme. This can be done by use the `v-b-color-mode` directive or the `data-bs-theme` attribute.
 
+An example using `v-b-colorMode`. Form more information see the [BColorMode directive](/docs/directives/BColorMode).
+
 <HighlightCard>
-  <BNavbar variant="primary" v-b-color-mode="'dark'">
-    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
-  </BNavbar>
+<BNavbar variant="primary" v-b-color-mode="'dark'">
+  <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+</BNavbar>
   <template #html>
 
 ```vue-html
-<!-- Using the v-b-color-mode directive -->
-<BNavbar variant="faded">
+<BNavbar variant="primary" v-b-color-mode="'dark'">
   <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
 </BNavbar>
 ```
 
-</template>
+  </template>
 </HighlightCard>
+
+An example using `data-bs-theme`. For more information see the
+[bootstrap documentation](https://getbootstrap.com/docs/5.3/components/navbar/#color-schemes).
 
 <HighlightCard>
   <BNavbar variant="primary" data-bs-theme="dark">
@@ -116,7 +120,6 @@ irrespective of the theme. This can be done by use the `v-b-color-mode` directiv
   <template #html>
 
 ```vue-html
-<!-- Using the data-bs-theme attribute -->
 <BNavbar variant="primary" data-bs-theme="dark">
   <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
 </BNavbar>

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -15,7 +15,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 </div>
 
 <HighlightCard>
-  <BNavbar toggleable="lg" data-bs-theme="dark" variant="dark">
+  <BNavbar toggleable="lg" data-bs-theme="dark" variant="primary">
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-collapse" />
     <BCollapse id="nav-collapse" is-nav>
@@ -49,7 +49,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
   <template #html>
 
 ```vue-html
-<BNavbar toggleable="lg" data-bs-theme="dark" variant="dark">
+<BNavbar toggleable="lg" data-bs-theme="dark" variant="primary">
   <BNavbarBrand href="#">NavBar</BNavbarBrand>
   <BNavbarToggle target="nav-collapse" />
   <BCollapse id="nav-collapse" is-nav>
@@ -87,9 +87,13 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 
 ## Color schemes
 
-`BNavbar` supports the standard Bootstrap v5 available background color variants. Set the variant prop to one of the following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
+`BNavbar` supports the standard Bootstrap v5 available background color variants. Set the `variant` prop to one of the
+following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
 
-Control the text color by setting `data-bs-theme` prop to `dark` for use with dark background color variants, or `light` for light background color variants.
+If the `variant` property is set, control the text color by setting `data-bs-theme` prop to `dark` for use with dark
+background color variants, or `light` for light background color variants.
+
+`BNavbar` will conform to the current color theme if the `variant` prop is not set.
 
 ## Placement
 
@@ -118,14 +122,14 @@ Navbars come with built-in support for a handful of sub-components. Choose from 
 The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to is provided. If neither is given it renders as a `<div>` tag. You can override the tag type by setting the tag prop to the element you would like rendered:
 
 <HighlightCard>
-  <BNavbar variant="faded" data-bs-theme="light">
+  <BNavbar variant="faded">
     <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
   </BNavbar>
   <template #html>
 
 ```vue-html
 <!-- As a link -->
-<BNavbar variant="faded" data-bs-theme="light">
+<BNavbar variant="faded">
   <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
 </BNavbar>
 ```
@@ -134,14 +138,14 @@ The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to
 </HighlightCard>
 
 <HighlightCard>
-  <BNavbar variant="faded" data-bs-theme="light">
+  <BNavbar variant="faded">
     <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
   </BNavbar>
   <template #html>
 
 ```vue-html
 <!-- As a heading -->
-<BNavbar variant="faded" data-bs-theme="light">
+<BNavbar variant="faded">
   <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
 </BNavbar>
 ```
@@ -152,7 +156,7 @@ The `BNavbarBrand` generates a link if href is provided, or a `RouterLink` if to
 Adding images to the `BNavbarBrand` will likely always require custom styles or utilities to properly size. Here are some examples to demonstrate:
 
 <HighlightCard>
-  <BNavbar variant="faded" data-bs-theme="light">
+  <BNavbar variant="faded">
     <BNavbarBrand href="#">
       <img src="https://placekitten.com/g/30/30" alt="Kitten">
     </BNavbarBrand>
@@ -161,7 +165,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 
 ```vue-html
 <!-- Just an image -->
-<BNavbar variant="faded" data-bs-theme="light">
+<BNavbar variant="faded">
   <BNavbarBrand href="#">
     <img src="https://placekitten.com/g/30/30" alt="Kitten">
   </BNavbarBrand>
@@ -172,7 +176,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 </HighlightCard>
 
 <HighlightCard>
-  <BNavbar variant="faded" data-bs-theme="light">
+  <BNavbar variant="faded">
     <BNavbarBrand href="#">
       <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
       BootstrapVue
@@ -182,7 +186,7 @@ Adding images to the `BNavbarBrand` will likely always require custom styles or 
 
 ```vue-html
 <!-- Image and text -->
-<BNavbar variant="faded" data-bs-theme="light">
+<BNavbar variant="faded">
   <BNavbarBrand href="#">
     <img src="https://placekitten.com/g/30/30" class="d-inline-block align-top" alt="Kitten">
     BootstrapVue

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -24,7 +24,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
         <BNavItem href="#" disabled>Disabled</BNavItem>
       </BNavbarNav>
       <!-- Right aligned nav items -->
-      <BNavbarNav class="me-auto mb-2 mb-lg-0">
+      <BNavbarNav class="ms-auto mb-2 mb-lg-0">
         <BNavItemDropdown text="Lang" right>
           <BDropdownItem href="#">EN</BDropdownItem>
           <BDropdownItem href="#">ES</BDropdownItem>
@@ -58,7 +58,7 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
       <BNavItem href="#" disabled>Disabled</BNavItem>
     </BNavbarNav>
     <!-- Right aligned nav items -->
-    <BNavbarNav class="me-auto mb-2 mb-lg-0">
+    <BNavbarNav class="ms-auto mb-2 mb-lg-0">
       <BNavItemDropdown text="Lang" right>
         <BDropdownItem href="#">EN</BDropdownItem>
         <BDropdownItem href="#">ES</BDropdownItem>

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -90,8 +90,8 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 `BNavbar` supports the standard Bootstrap v5 available background color variants. Set the `variant` prop to one of the
 following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
 
-If the `variant` property is set, it may be necessary to control the text color so that it contrasts with the variant
-irrespective of the theme. This can be done by use the `v-b-color-mode` directive or the `data-bs-theme` attribute.
+If the `variant` prop is set, it may be necessary to control the text color so that it contrasts with the variant
+irrespective of the theme. This can be done by use the `v-b-color-mode` directive or `useColorMode` composable
 
 An example using `v-b-colorMode`. Form more information see the [BColorMode directive](/docs/directives/BColorMode).
 

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -96,10 +96,11 @@ irrespective of the theme. This can be done by use the `v-b-color-mode` directiv
 An example using `v-b-colorMode`. Form more information see the [BColorMode directive](/docs/directives/BColorMode).
 
 <HighlightCard>
-<BNavbar variant="primary" v-b-color-mode="'dark'">
-  <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
-</BNavbar>
-  <template #html>
+  <BNavbar variant="primary" v-b-color-mode="'dark'">
+    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+  </BNavbar>
+
+<template #html>
 
 ```vue-html
 <BNavbar variant="primary" v-b-color-mode="'dark'">

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -91,19 +91,39 @@ The component `BNavbar` is a wrapper that positions branding, navigation, and ot
 following values to change the background color: primary, secondary, success, info, warning, danger, dark, light, or any of the \*-subtle variants.
 
 If the `variant` property is set, it may be necessary to control the text color so that it contrasts with the variant
-irrespective of the theme. This can be done in one of two ways.
+irrespective of the theme. This can be done by use the `v-b-color-mode` directive or the `data-bs-theme` attribute.
 
-Use the `v-b-color-mode` directive:
-
-```vue-html
-<BNavbar toggleable="lg" variant="primary" v-b-color-mode="'dark'">
-```
-
-Or use the raw `data-bs-theme` attribute:
+<HighlightCard>
+  <BNavbar variant="primary" v-b-color-mode="'dark'">
+    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+  </BNavbar>
+  <template #html>
 
 ```vue-html
-<BNavbar toggleable="lg" variant="primary" data-bs-theme="dark">
+<!-- Using the v-b-color-mode directive -->
+<BNavbar variant="faded">
+  <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+</BNavbar>
 ```
+
+</template>
+</HighlightCard>
+
+<HighlightCard>
+  <BNavbar variant="primary" data-bs-theme="dark">
+    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+  </BNavbar>
+  <template #html>
+
+```vue-html
+<!-- Using the data-bs-theme attribute -->
+<BNavbar data-bs-theme="dark">
+  <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+</BNavbar>
+```
+
+  </template>
+</HighlightCard>
 
 `BNavbar` will conform to the current color theme if the `variant` prop is not set.
 


### PR DESCRIPTION
# Fixes two issues with the NavBar docs

1. The use of type="light|dark" has been replaced with data-bs-theme="light|dark" in order to modify the text color of the NavBar.  I've replaced all cases in the samples and updated the description.  This addresses #1507 and makes the samples readable again.
2. Changed the classes in the initial sample to make the comment stating that a portion of the navbar would be right aligned accurate.  This was a matter of changing me-auto to ms-auto to conform with bootstrap 5's utility classes.  This addresses #1510 

## Small replication

Fixes #1507 and #1510

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
