### PR TITLE
fix(BTable): resolve selectAllRows no longer working with provider

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -443,7 +443,7 @@ const handleRowSelection = (
 const selectAllRows = () => {
   if (!selectableBoolean.value) return
   const unselectableItems = selectedItems.value.size > 0 ? Array.from(selectedItems.value) : []
-  selectedItems.value = new Set([...props.items])
+  selectedItems.value = new Set([...computedItems.value])
   selectedItems.value.forEach((item) => {
     if (unselectableItems.includes(item)) return
     emit('row-selected', item)


### PR DESCRIPTION
# Describe the PR

After upgrading to the latest version (0.14.8), we found that the `selectAllRows` function for BTable no longer works if the table uses a `provider` function rather than the static `items` prop. It did work previously (we were a ways behind before upgrading, around version 0.9.23). The PR switches back to using `computedItems.value` instead of `props.items` for the value assigned to `selectedItems.value` returning to how it was in earlier versions.

## Small replication

I reproduced the issue in a simple demo in `App.vue` in my `bootstrap-vue-next` fork. Applying the fix in this PR causes the selectAllRows function work work again.

```
<template>
  <BContainer>
    <BRow>
      <BCol>
        <h4 class="my-3">Table (Async Provider)</h4>
        <BButton @click="testTable?.refresh()" class="me-2">Refresh</BButton>
        <BButton @click="testTable?.selectAllRows()" class="me-2">Select All</BButton>
        <BButton @click="testTable?.clearSelected()" class="me-2">Clear Selected</BButton>
      </BCol>
    </BRow>

    <BRow>
      <BCol>
        <BTable
          ref="testTable"
          selectable
          select-mode="multi"
          :select-head="false"
          :fields="tableDefinitions"
          :provider="asyncProvider"
        />
      </BCol>
    </BRow>
  </BContainer>
</template>

<script setup lang="ts">
import {ref} from 'vue'
import type {TableField, TableItem, BTable} from 'bootstrap-vue-next'

const testTable = ref<typeof BTable | null>(null)

const tableDefinitions: TableField[] = [
  {key: 'userId', label: 'User ID'},
  {key: 'id', label: 'ID'},
  {key: 'title', label: 'Title'},
  {key: 'completed', label: 'Completed'},
]

const asyncProvider = async (): Promise<TableItem[]> => {
  const response = await fetch('https://jsonplaceholder.typicode.com/todos')
  return await response.json()
}
</script>
```

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
