### PR TITLE
fix(BTooltip): close when opening dropdown, and other changes

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="computedClasses" class="btn-group">
+  <div ref="wrapper" :class="computedClasses" class="btn-group">
     <BButton
       :id="computedId"
       ref="splitButton"
@@ -163,6 +163,7 @@ const offsetToNumber = useToNumber(computedOffset)
 const floating = ref<HTMLElement | null>(null)
 const button = ref<HTMLElement | null>(null)
 const splitButton = ref<HTMLElement | null>(null)
+const wrapper = ref<HTMLElement | null>(null)
 
 const boundary = computed<Boundary | undefined>(() =>
   props.boundary === 'document' || props.boundary === 'viewport' ? undefined : props.boundary
@@ -314,6 +315,7 @@ const toggle = () => {
   }
   modelValue.value = !currentModelValue
   currentModelValue ? emit('hidden') : emit('shown')
+  wrapper.value?.dispatchEvent(new Event('forceHide'))
 }
 
 watch(modelValueBoolean, update)

--- a/packages/bootstrap-vue-next/src/components/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover.vue
@@ -1,6 +1,6 @@
 <template>
   <span ref="placeholder" />
-  <slot name="target" :show="show" :hide="hideFn" :toggle="toggle" :show-state="showState" />
+  <slot name="target" :show="show" :hide="hide" :toggle="toggle" :show-state="showState" />
   <!-- TODO: fix this clunky solution when https://github.com/vuejs/core/issues/6152 is fixed -->
   <RenderComponentOrSkip :tag="'Teleport'" :to="container" :skip="!container">
     <div
@@ -115,7 +115,7 @@ const props = withDefaults(defineProps<BPopoverProps>(), {
   noShift: false,
   noFade: false,
   noAutoClose: false,
-  hide: true,
+  noHide: false,
   realtime: false,
   inline: false,
   tooltip: false,
@@ -158,7 +158,7 @@ watchEffect(() => {
 
 watch(modelValueBoolean, () => {
   if (modelValueBoolean.value === showState.value) return
-  modelValueBoolean.value ? show() : hideFn(new Event('update:modelValue'))
+  modelValueBoolean.value ? show() : hide(new Event('update:modelValue'))
 })
 
 const computedId = useId(() => props.id, 'popover')
@@ -169,7 +169,7 @@ const noShiftBoolean = useBooleanish(() => props.noShift)
 const noFlipBoolean = useBooleanish(() => props.noFlip)
 const noFadeBoolean = useBooleanish(() => props.noFade)
 const noAutoCloseBoolean = useBooleanish(() => props.noAutoClose)
-const hideBoolean = useBooleanish(() => props.hide)
+const noHideBoolean = useBooleanish(() => props.noHide)
 const realtimeBoolean = useBooleanish(() => props.realtime)
 const inlineBoolean = useBooleanish(() => props.inline)
 const tooltipBoolean = useBooleanish(() => props.tooltip)
@@ -212,7 +212,7 @@ const floatingMiddleware = computed<Middleware[]>(() => {
   if (noShiftBoolean.value === false) {
     arr.push(shift())
   }
-  if (hideBoolean.value === true) {
+  if (noHideBoolean.value === false) {
     arr.push(hideMiddleware({padding: 10}))
   }
   if (inlineBoolean.value === true) {
@@ -240,7 +240,7 @@ const {floatingStyles, middlewareData, placement, update} = useFloating(targetTr
 const arrowStyle = ref<CSSProperties>({position: 'absolute'})
 
 watch(middlewareData, () => {
-  if (hideBoolean.value === true) {
+  if (noHideBoolean.value === false) {
     if (middlewareData.value.hide?.referenceHidden) {
       hidden.value = true
     } else {
@@ -279,7 +279,7 @@ const {isOutside: triggerIsOutside} = useMouseInElement(trigger)
 
 const toggle = (e: Event) => {
   const event = e ?? new Event('click')
-  showState.value ? hideFn(event) : show()
+  showState.value ? hide(event) : show()
 }
 
 const buildTriggerableEvent = (
@@ -319,7 +319,7 @@ const show = () => {
   })
 }
 
-const hideFn = (e: Event) => {
+const hide = (e: Event) => {
   const event = buildTriggerableEvent('hide', {cancelable: true})
   emit('hide', event)
   if (event.defaultPrevented) {
@@ -334,6 +334,7 @@ const hideFn = (e: Event) => {
   setTimeout(() => {
     if (
       e?.type === 'click' ||
+      e?.type === 'forceHide' ||
       (e?.type === 'update:modelValue' && manualBoolean.value) ||
       (!noninteractiveBoolean.value &&
         isOutside.value &&
@@ -355,7 +356,7 @@ const hideFn = (e: Event) => {
     } else {
       setTimeout(
         () => {
-          hideFn(e)
+          hide(e)
         },
         delay < 50 ? 50 : delay
       )
@@ -364,7 +365,7 @@ const hideFn = (e: Event) => {
 }
 
 defineExpose({
-  hideFn,
+  hide,
   show,
   toggle,
 })
@@ -415,20 +416,22 @@ const bind = () => {
     return
   }
   if (!IS_BROWSER) return
+  trigger.value.addEventListener('forceHide', hide)
   clickBoolean.value && trigger.value.addEventListener('click', toggle)
   !clickBoolean.value && trigger.value.addEventListener('pointerenter', show)
-  !clickBoolean.value && trigger.value.addEventListener('pointerleave', hideFn)
+  !clickBoolean.value && trigger.value.addEventListener('pointerleave', hide)
   !clickBoolean.value && trigger.value.addEventListener('focus', show)
-  !clickBoolean.value && trigger.value.addEventListener('blur', hideFn)
+  !clickBoolean.value && trigger.value.addEventListener('blur', hide)
 }
 
 const unbind = () => {
   if (trigger.value) {
+    trigger.value.removeEventListener('forceHide', hide)
     trigger.value.removeEventListener('click', toggle)
     trigger.value.removeEventListener('pointerenter', show)
-    trigger.value.removeEventListener('pointerleave', hideFn)
+    trigger.value.removeEventListener('pointerleave', hide)
     trigger.value.removeEventListener('focus', show)
-    trigger.value.removeEventListener('blur', hideFn)
+    trigger.value.removeEventListener('blur', hide)
   }
 }
 
@@ -436,7 +439,7 @@ onClickOutside(
   element,
   () => {
     if (showState.value && clickBoolean.value && !noAutoCloseBoolean.value && !manualBoolean.value)
-      hideFn(new Event('clickOutside'))
+      hide(new Event('clickOutside'))
   },
   {ignore: [trigger]}
 )

--- a/packages/bootstrap-vue-next/src/components/BTooltip.vue
+++ b/packages/bootstrap-vue-next/src/components/BTooltip.vue
@@ -30,19 +30,19 @@ withDefaults(defineProps<Omit<BPopoverProps, 'tooltip'>>(), {
   noShift: undefined,
   noFade: undefined,
   noAutoClose: undefined,
-  hide: undefined,
+  noHide: undefined,
   realtime: undefined,
   inline: undefined,
   html: undefined,
   reference: undefined,
   target: undefined,
-  noninteractive: undefined,
+  noninteractive: true,
 })
 
 const popover = ref<null | InstanceType<typeof BPopover>>(null)
 
 defineExpose({
-  hide: popover.value?.hideFn,
+  hide: popover.value?.hide,
   show: popover.value?.show,
   toggle: popover.value?.toggle,
 })

--- a/packages/bootstrap-vue-next/src/directives/BTooltip.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip.ts
@@ -18,6 +18,7 @@ export default {
     if (!text.content && !text.title) return
 
     el.$__state = ref({
+      noninteractive: true,
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.content ?? '',
       tooltip: isActive,
@@ -37,6 +38,7 @@ export default {
       // This happens when mounting occurs, but binding does not happen ie (if (!text.content && !text.title) return)
       // So mounting occurs without a title or content set
       el.$__state = ref({
+        noninteractive: true,
         ...resolveDirectiveProps(binding, el),
         title: text.title ?? text.content ?? '',
         tooltip: isActive,
@@ -45,6 +47,7 @@ export default {
       return
     }
     el.$__state.value = {
+      noninteractive: true,
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.content ?? '',
       tooltip: isActive,


### PR DESCRIPTION
# Describe the PR
closes #1503 
fix(BTooltip): close popover when opening dropdown
fix(BPopover): prop hide renamed to noHide, to be inline with other props.
fix(BPopover): expose hideFn renamed to hide

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
