### PR TITLE
fix(BModal): Fix new modals stacking behind active modals

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -19,6 +19,7 @@
         :aria-describedby="`${computedId}-body`"
         tabindex="-1"
         v-bind="$attrs"
+        :style="computedZIndex"
       >
         <div class="modal-dialog" :class="modalDialogClasses">
           <div v-if="lazyShowing" class="modal-content" :class="contentClass">
@@ -100,7 +101,15 @@
 </template>
 
 <script setup lang="ts">
-import {computed, reactive, ref, type RendererElement, toRef, useSlots} from 'vue'
+import {
+  computed,
+  type CSSProperties,
+  reactive,
+  ref,
+  type RendererElement,
+  toRef,
+  useSlots,
+} from 'vue'
 import {
   useBackgroundVariant,
   useBooleanish,
@@ -506,7 +515,17 @@ const onAfterLeave = () => {
   if (lazyBoolean.value === true) lazyLoadCompleted.value = false
 }
 
-useModalManager(isActive)
+const {activePosition, activeModalCount} = useModalManager(isActive, computedId)
+const defaultModalDialogZIndex = 1056
+const computedZIndex = computed<CSSProperties>(() => ({
+  // Make sure that newly opened modals have a higher z-index than currently active ones.
+  // All active modals have a z-index of ('defaultZIndex' - 'stackSize' - 'positionInStack').
+  //
+  // This means inactive modals will already be higher than active ones when opened.
+  'z-index': isActive.value
+    ? defaultModalDialogZIndex - (activeModalCount.value - activePosition.value)
+    : defaultModalDialogZIndex,
+}))
 
 useEventListener(element, 'bv-toggle', () => {
   modelValueBoolean.value ? hide() : showFn()
@@ -531,6 +550,7 @@ defineExpose({
 .modal {
   display: block;
 }
+
 .modal-dialog {
   z-index: 1051;
 }

--- a/packages/bootstrap-vue-next/src/composables/useModalManager.ts
+++ b/packages/bootstrap-vue-next/src/composables/useModalManager.ts
@@ -75,6 +75,6 @@ export default (modalOpen: Ref<boolean>, id: MaybeRefOrGetter<string>) => {
 
   return {
     activePosition: computed(() => stack.value.findIndex((el) => el.exposed?.id === toValue(id))),
-    activeModalCount: computed(() => stack.value.length),
+    activeModalCount: toRef(() => stack.value.length),
   }
 }

--- a/packages/bootstrap-vue-next/src/composables/useModalManager.ts
+++ b/packages/bootstrap-vue-next/src/composables/useModalManager.ts
@@ -1,5 +1,15 @@
 import {createSharedComposable, getSSRHandler, tryOnScopeDispose, unrefElement} from '@vueuse/core'
-import {type ComponentInternalInstance, getCurrentInstance, type Ref, ref, toRef, watch} from 'vue'
+import {
+  type ComponentInternalInstance,
+  computed,
+  getCurrentInstance,
+  type MaybeRefOrGetter,
+  ref,
+  type Ref,
+  toRef,
+  toValue,
+  watch,
+} from 'vue'
 
 const MODAL_OPEN_CLASS_NAME = 'modal-open'
 
@@ -40,8 +50,8 @@ export const useSharedModalStack = createSharedComposable(() => {
   return {registry, stack, last, count, push, pop, remove, find}
 })
 
-export default (modalOpen: Ref<boolean>): void => {
-  const {registry, push, remove} = useSharedModalStack()
+export default (modalOpen: Ref<boolean>, id: MaybeRefOrGetter<string>) => {
+  const {registry, push, remove, stack} = useSharedModalStack()
 
   const currentModal = getCurrentInstance()
 
@@ -62,4 +72,9 @@ export default (modalOpen: Ref<boolean>): void => {
     },
     {immediate: true}
   )
+
+  return {
+    activePosition: computed(() => stack.value.findIndex((el) => el.exposed?.id === toValue(id))),
+    activeModalCount: computed(() => stack.value.length),
+  }
 }


### PR DESCRIPTION
# Describe the PR

This PR introduces a small change to how the z-indices of active modals are calculated.

Currently there are cases ([issue 1516](https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1516)) where a newly opened modal will open behind an active modal.

The change to behaviour here is to calculate the z-index of a modal based on it's position in the stack of active modals. All modals have a z-index lower than or equal to 1055. The newer (high up on the stack) the modal is the close to 1055. The latest having a z-index of 1055. Inactive modals have a z-index of 1055 by default, the highest value. Meaning when they open they are on top by default until the z-index is adjusted.

There is a slightly different approach I tried which was just to calculate the z-index as `1055 + indexInStack` however, this meant that for a small time window the new modal would be behind any active modal until the new z-index was calculated. This meant that the modal wouldn't fade in smoothly and instead would pop in quite abruptly. 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
