### PR TITLE
fix(BModal): Ensure modal-open class is always removed (#1545)

### DIFF
--- a/packages/bootstrap-vue-next/src/composables/useModalManager.ts
+++ b/packages/bootstrap-vue-next/src/composables/useModalManager.ts
@@ -61,6 +61,10 @@ export default (modalOpen: Ref<boolean>, id: MaybeRefOrGetter<string>) => {
 
   registry.value.push(currentModal)
 
+  tryOnScopeDispose(() => {
+    remove(currentModal)
+  })
+
   watch(
     modalOpen,
     (newValue, oldValue) => {


### PR DESCRIPTION
# Describe the PR

Fixes #1545 by ensuring the modal count is decremented in modalManager even when the transition doesn't have time to run (due to the element being removed immediately vs. hidden).

Sadly unable to write a unit test for this due to vitest not firing transition events.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
