### PR TITLE
docs(BContainer): update props

### DIFF
--- a/apps/docs/src/data/components/gridSystem.data.ts
+++ b/apps/docs/src/data/components/gridSystem.data.ts
@@ -8,26 +8,25 @@ export default {
         {
           prop: 'gutterX',
           type: 'string',
+          description: 'Horizontal gutter',
         },
         {
           prop: 'gutterY',
           type: 'string',
+          description: 'Vertical gutter',
         },
         {
           prop: 'fluid',
-          type: 'boolean | Breakpoint',
-        },
-        {
-          prop: 'toast',
-          type: 'Record<string, unknown>',
-        },
-        {
-          prop: 'position',
-          type: 'Position',
+          type: 'Booleanish | Breakpoint',
+          default: false,
+          description:
+            'When set to true, makes the row 100% wide all the time, or set to one of the Bootstrap breakpoint names for 100% width up to the breakpoint',
         },
         {
           prop: 'tag',
           type: 'string',
+          default: 'div',
+          description: 'Specify the HTML tag to render instead of the default tag',
         },
       ],
       emits: [],


### PR DESCRIPTION
# Describe the PR

Update doc of BContainer component (https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1538):
- Remove `position` & `toast` props
- Update default values & add descriptions

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
