### PR TITLE
fix: Pass through table header/footer variant & classes

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -19,9 +19,9 @@
     :variant="variant"
     :striped-columns="stripedColumns"
   >
-    <BThead>
+    <BThead :variant="headVariant" :class="theadClass">
       <slot v-if="$slots['thead-top']" name="thead-top" />
-      <BTr>
+      <BTr :variant="headRowVariant" :class="theadTrClass">
         <BTh
           v-for="field in computedFields"
           :key="field.key"
@@ -63,7 +63,7 @@
         </BTd>
       </BTr>
     </BThead>
-    <BTbody>
+    <BTbody :class="tbodyClass">
       <slot
         name="custom-body"
         :fields="computedFields"
@@ -142,8 +142,8 @@
         </BTr>
       </slot>
     </BTbody>
-    <BTfoot v-if="footCloneBoolean">
-      <BTr>
+    <BTfoot v-if="footCloneBoolean" :variant="footVariant" :class="tfootClass">
+      <BTr :variant="footRowVariant" :class="tfootTrClass">
         <BTh
           v-for="field in computedFields"
           :key="field.key"


### PR DESCRIPTION
# Describe the PR

Currently it is not possible to pass variant or classes down to thead so the table's header just blends in with the rest of the table, this change simply passes the values of the existing properties to the place where they can take effect.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
