### PR TITLE
docs: improve component reference

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -44,7 +44,7 @@
                   <BCol>
                     <BTable
                       :items="component[sectionToComponentItem(section)]"
-                      :fields="component.fields?.[sectionToComponentItem(section)]"
+                      :fields="fields[sectionToComponentItem(section)]"
                       hover
                       small
                       responsive
@@ -94,7 +94,7 @@
 
 <script setup lang="ts">
 import {computed} from 'vue'
-import {BCol, BContainer, BLink, BRow, BTable} from 'bootstrap-vue-next'
+import {BCol, BContainer, BLink, BRow, BTable, type TableField} from 'bootstrap-vue-next'
 import type {
   ComponentItem,
   ComponentReference,
@@ -136,11 +136,6 @@ const sortData = computed(() =>
           scope: inner.scope,
         }))
         .sort((a, b) => a.name.localeCompare(b.name)),
-      fields: {
-        props: ['prop', 'type', 'default', 'description'],
-        emits: ['event', 'args', 'description'],
-        slots: ['name', 'scope', 'description'],
-      },
     }
 
     data.sections = (['Properties', 'Events', 'Slots'] as ComponentSection[]).filter(
@@ -155,6 +150,12 @@ const buildCompReferenceLink = (str: string): string => `#comp-reference-${str}`
 
 const sectionToComponentItem = (el: ComponentSection): ComponentItem =>
   el === 'Properties' ? 'props' : el === 'Events' ? 'emits' : 'slots'
+
+const fields: {[P in ComponentItem]: TableField[]} = {
+  props: ['prop', 'type', 'default', 'description'],
+  emits: ['event', 'args', 'description'],
+  slots: ['name', 'scope', 'description'],
+}
 
 const normalizeDefault = (val: unknown) =>
   val === undefined || val === null ? `${val}` : typeof val === 'string' ? `'${val}'` : val

--- a/apps/docs/src/data/components/ComponentReference.ts
+++ b/apps/docs/src/data/components/ComponentReference.ts
@@ -1,3 +1,6 @@
+export type EmitArgReference = {arg: string; type: string; description?: string}
+export type SlotScopeReference = {prop: string; type: string | string[]; description?: string}
+export type ComponentItem = 'props' | 'emits' | 'slots'
 export type ComponentSection = 'Properties' | 'Events' | 'Slots'
 
 export interface ComponentReference {
@@ -11,13 +14,16 @@ export interface ComponentReference {
   }[]
   emits: {
     event: string
-    args: {arg: string; type: string; description?: string}[]
+    args: EmitArgReference[]
     description?: string
   }[]
   slots: {
-    scope: {prop: string; type: string | string[]; description?: string}[]
+    scope: SlotScopeReference[]
     name: string
     description?: string
   }[]
   sections?: ComponentSection[]
+  fields?: {
+    [P in ComponentItem]: (keyof ComponentReference[P][number])[]
+  }
 }

--- a/apps/docs/src/data/components/ComponentReference.ts
+++ b/apps/docs/src/data/components/ComponentReference.ts
@@ -1,7 +1,7 @@
+export type ComponentItem = Exclude<keyof ComponentReference, 'component' | 'sections'>
+export type ComponentSection = 'Properties' | 'Events' | 'Slots'
 export type EmitArgReference = {arg: string; type: string; description?: string}
 export type SlotScopeReference = {prop: string; type: string | string[]; description?: string}
-export type ComponentItem = 'props' | 'emits' | 'slots'
-export type ComponentSection = 'Properties' | 'Events' | 'Slots'
 
 export interface ComponentReference {
   component: string
@@ -9,8 +9,7 @@ export interface ComponentReference {
     prop: string
     type: string
     description?: string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    default?: any
+    default?: unknown
   }[]
   emits: {
     event: string
@@ -23,7 +22,4 @@ export interface ComponentReference {
     description?: string
   }[]
   sections?: ComponentSection[]
-  fields?: {
-    [P in ComponentItem]: (keyof ComponentReference[P][number])[]
-  }
 }

--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -360,10 +360,6 @@ If you are using one of the preferred installation methods, JS will be tree-shak
 
 BootstrapVue is the parent project for which this is based on. We consider BootstrapVue as the best implementation of Bootstrap `v4`. We strive for a full compatibility list for BootstrapVue. However, due to the nature of the rewrite, some features may be missing or changed. If anyone has spotted a missing compatibility feature, we request that you submit a GitHub issue.
 
-<!-- To follow this, we'll implement a parity list where you can view the progress of covered components. This section is not ready yet. -->
-
-You can view the planned compatibility list in the following [section](./reference/parityList.md). It is _not_ a migration guide, which will be finalized upon v1.0.0.
-
 <script setup lang="ts">
 import {BCard, BCardBody, BAlert, BTab, BTabs} from 'bootstrap-vue-next'
 import {useLocalStorage} from '@vueuse/core'

--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -360,6 +360,10 @@ If you are using one of the preferred installation methods, JS will be tree-shak
 
 BootstrapVue is the parent project for which this is based on. We consider BootstrapVue as the best implementation of Bootstrap `v4`. We strive for a full compatibility list for BootstrapVue. However, due to the nature of the rewrite, some features may be missing or changed. If anyone has spotted a missing compatibility feature, we request that you submit a GitHub issue.
 
+<!-- To follow this, we'll implement a parity list where you can view the progress of covered components. This section is not ready yet. -->
+
+You can view the planned compatibility list in the following [section](./reference/parityList.md). It is _not_ a migration guide, which will be finalized upon v1.0.0.
+
 <script setup lang="ts">
 import {BCard, BCardBody, BAlert, BTab, BTabs} from 'bootstrap-vue-next'
 import {useLocalStorage} from '@vueuse/core'


### PR DESCRIPTION
# Describe the PR

- Update to accurately display the event and slot fields
- Support displaying multiple event args and slot scopes

## Small replication

![image](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/34233006/526b1167-829a-4ecc-baed-0f9f48191fbc)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
