### PR TITLE
Fix types: select, checkbox should accept readonly array for options

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -52,7 +52,7 @@ const props = withDefaults(
     id?: string
     indeterminate?: Booleanish
     inline?: Booleanish
-    modelValue?: CheckboxValue | CheckboxValue[]
+    modelValue?: CheckboxValue | ReadonlyArray<CheckboxValue>
     name?: string
     plain?: Booleanish
     required?: Booleanish
@@ -87,9 +87,9 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: CheckboxValue | CheckboxValue[]]
-  'input': [value: CheckboxValue | CheckboxValue[]]
-  'update:modelValue': [value: CheckboxValue | CheckboxValue[]]
+  'change': [value: CheckboxValue | ReadonlyArray<CheckboxValue>]
+  'input': [value: CheckboxValue | ReadonlyArray<CheckboxValue>]
+  'update:modelValue': [value: CheckboxValue | ReadonlyArray<CheckboxValue>]
 }>()
 
 const slots = defineSlots<{
@@ -124,13 +124,13 @@ const hasDefaultSlot = toRef(() => !isEmptySlot(slots.default))
 
 const localValue = computed({
   get: () => parentData?.modelValue.value ?? modelValue.value,
-  set: (val: CheckboxValue[] | CheckboxValue | undefined) => {
+  set: (val: ReadonlyArray<CheckboxValue> | CheckboxValue | undefined) => {
     if (val === undefined) return
     if (parentData !== null && Array.isArray(val)) {
       // The type cast isn't perfect. Array.isArray detects CheckboxValue.unknown[],
       // but since it's parentData, it should always be CheckboxValue[]
       // It doesn't quite work when props.value is an [], but this is more of a Vue issue
-      parentData.modelValue.value = val as CheckboxValue[]
+      parentData.modelValue.value = val as ReadonlyArray<CheckboxValue>
       return
     }
     modelValue.value = val

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -37,9 +37,9 @@ const props = withDefaults(
     form?: string
     htmlField?: string
     id?: string
-    modelValue?: CheckboxValue[]
+    modelValue?: ReadonlyArray<CheckboxValue>
     name?: string
-    options?: (string | number | Record<string, unknown>)[]
+    options?: ReadonlyArray<string | number | Record<string, unknown>>
     plain?: Booleanish
     required?: Booleanish
     size?: Size
@@ -76,9 +76,9 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: CheckboxValue[]]
-  'input': [value: CheckboxValue[]]
-  'update:modelValue': [value: CheckboxValue[]]
+  'change': [value: ReadonlyArray<CheckboxValue>]
+  'input': [value: ReadonlyArray<CheckboxValue>]
+  'update:modelValue': [value: ReadonlyArray<CheckboxValue>]
 }>()
 
 defineSlots<{

--- a/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelect.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelect.vue
@@ -58,10 +58,10 @@ const props = withDefaults(
     htmlField?: string
     id?: string
     labelField?: string
-    modelValue?: string | unknown[] | Record<string, unknown> | number | null
+    modelValue?: string | ReadonlyArray<unknown> | Record<string, unknown> | number | null
     multiple?: Booleanish
     name?: string
-    options?: unknown[] | Record<string, unknown> // TODO It was declared deprecated in useFormSelect to use a Record. https://bootstrap-vue.org/docs/components/form-select#options-as-an-object
+    options?: ReadonlyArray<unknown> | Record<string, unknown> // TODO It was declared deprecated in useFormSelect to use a Record. https://bootstrap-vue.org/docs/components/form-select#options-as-an-object
     optionsField?: string
     plain?: Booleanish
     required?: Booleanish

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -67,7 +67,7 @@ export const accordionInjectionKey: InjectionKey<{
 
 // BFormCheckboxGroup
 export const checkboxGroupKey: InjectionKey<{
-  modelValue: Ref<CheckboxValue[]>
+  modelValue: Ref<ReadonlyArray<CheckboxValue>>
   switch: Readonly<Ref<boolean>>
   buttonVariant: Readonly<Ref<ButtonVariant | null>>
   form: Readonly<Ref<string | undefined>>


### PR DESCRIPTION
# Describe the PR

We have a lot of `const options = [...] as const` in our codebase and tsc complains that b-form-select wants mutable array while we have read only array.
It probably make sense to make all array props readonly throughout all codebase.


## Small replication

```
          <b-form-select
            :options="[{ value: '', text: '' }] as const"
          />
```

Results in `Type 'readonly [{ readonly value: ""; readonly text: ""; }]' is not assignable to type 'unknown[] | Record<string, unknown> | undefined'.`

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
