### PR TITLE
fix(BToggle): Passing ID as arg or href broken in v0.15

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BToggle.ts
+++ b/packages/bootstrap-vue-next/src/directives/BToggle.ts
@@ -2,7 +2,7 @@ import {RX_HASH, RX_HASH_ID, RX_SPACE_SPLIT} from '../constants/regex'
 import {getAttr, isTag} from '../utils'
 import type {Directive, DirectiveBinding} from 'vue'
 
-const getTargets = (binding: DirectiveBinding<string | string[]>, el: HTMLElement) => {
+const getTargets = (binding: DirectiveBinding<string | string[] | undefined>, el: HTMLElement) => {
   const {modifiers, arg, value} = binding
   // Any modifiers are considered target Ids
   const targets = Object.keys(modifiers || {})
@@ -59,8 +59,8 @@ const checkVisibility = (targetIds: string[], el: HTMLElement) => {
 
 const handleUpdate = (el: WithToggle, binding: DirectiveBinding<string | string[] | undefined>) => {
   // Determine targets
-  if (binding.value === undefined && Object.keys(binding.modifiers || {}).length === 0) return
-  const targets = getTargets(binding as DirectiveBinding<string | string[]>, el)
+  const targets = getTargets(binding, el)
+  if (targets.length === 0) return
 
   // Set up click handler
   if (el.__toggle) {

--- a/packages/bootstrap-vue-next/src/directives/toggle.spec.ts
+++ b/packages/bootstrap-vue-next/src/directives/toggle.spec.ts
@@ -1,0 +1,330 @@
+import {enableAutoUnmount, flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {nextTick} from 'vue'
+import VBToggle from './BToggle'
+import {asyncTimeout} from '../../tests/utils'
+
+// Emitted control event for collapse (emitted to collapse)
+const EVENT_TOGGLE = 'bv-toggle'
+
+describe('toggle directive', () => {
+  enableAutoUnmount(afterEach)
+
+  it('works on buttons', async () => {
+    const spy = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      mounted() {
+        document.getElementById('test')?.addEventListener(EVENT_TOGGLE, spy)
+      },
+      destroy() {
+        document.getElementById('test')?.removeEventListener(EVENT_TOGGLE, spy)
+      },
+      template: '<button v-b-toggle.test>button</button><div id="test"></div>',
+    }
+
+    const wrapper = mount(App, {attachTo: document.body})
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy).not.toHaveBeenCalled()
+
+    const $button = wrapper.find('button')
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.attributes('tabindex')).toBeUndefined()
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+
+    await $button.trigger('click')
+    await asyncTimeout(50)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.attributes('tabindex')).toBeUndefined()
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+  })
+
+  it('works on passing ID as directive value', async () => {
+    const spy = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      mounted() {
+        document.getElementById('test')?.addEventListener(EVENT_TOGGLE, spy)
+      },
+      destroy() {
+        document.getElementById('test')?.removeEventListener(EVENT_TOGGLE, spy)
+      },
+      template: `<button v-b-toggle="'test'">button</button><div id="test"></div>`,
+    }
+
+    const wrapper = mount(App, {attachTo: document.body})
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy).not.toHaveBeenCalled()
+
+    const $button = wrapper.find('button')
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+
+    await $button.trigger('click')
+    await asyncTimeout(50)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+  })
+
+  it('works on passing ID as directive argument', async () => {
+    const spy = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      mounted() {
+        document.getElementById('test')?.addEventListener(EVENT_TOGGLE, spy)
+      },
+      destroy() {
+        document.getElementById('test')?.removeEventListener(EVENT_TOGGLE, spy)
+      },
+      template: `<button v-b-toggle:test>button</button><div id="test"></div>`,
+    }
+
+    const wrapper = mount(App, {attachTo: document.body})
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy).not.toHaveBeenCalled()
+
+    const $button = wrapper.find('button')
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+
+    await $button.trigger('click')
+    await asyncTimeout(50)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($button.attributes('aria-controls')).toBe('test')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+  })
+
+  it('works on passing ID as href value on links', async () => {
+    const spy = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      mounted() {
+        document.getElementById('test')?.addEventListener(EVENT_TOGGLE, spy)
+      },
+      destroy() {
+        document.getElementById('test')?.removeEventListener(EVENT_TOGGLE, spy)
+      },
+      template: '<a href="#test" v-b-toggle>link</a><div id="test"></div>',
+    }
+
+    const wrapper = mount(App, {attachTo: document.body})
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy).not.toHaveBeenCalled()
+
+    const $link = wrapper.find('a')
+    expect($link.attributes('aria-controls')).toBe('test')
+    expect($link.attributes('aria-expanded')).toBe('false')
+    expect($link.attributes('tabindex')).toBeUndefined()
+    expect($link.classes()).toContain('collapsed')
+    expect($link.classes()).not.toContain('not-collapsed')
+
+    await $link.trigger('click')
+    await asyncTimeout(50)
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($link.attributes('aria-controls')).toBe('test')
+    expect($link.attributes('aria-expanded')).toBe('false')
+    expect($link.attributes('tabindex')).toBeUndefined()
+    expect($link.classes()).toContain('collapsed')
+    expect($link.classes()).not.toContain('not-collapsed')
+  })
+
+  it('works with multiple targets, and updates when targets change', async () => {
+    const spy1 = vi.fn()
+    const spy2 = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      props: {
+        target: {
+          type: [String, Array],
+          default: null,
+        },
+      },
+      mounted() {
+        document.getElementById('test1')?.addEventListener(EVENT_TOGGLE, spy1)
+        document.getElementById('test2')?.addEventListener(EVENT_TOGGLE, spy2)
+      },
+      destroy() {
+        document.getElementById('test1')?.removeEventListener(EVENT_TOGGLE, spy1)
+        document.getElementById('test2')?.removeEventListener(EVENT_TOGGLE, spy2)
+      },
+      template: `<button v-b-toggle="target">button</button><div id="test1"></div><div id="test2"></div>`,
+    }
+
+    const wrapper = mount(App, {
+      attachTo: document.body,
+      props: {
+        target: 'test1',
+      },
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy1).not.toHaveBeenCalled()
+    expect(spy2).not.toHaveBeenCalled()
+
+    const $button = wrapper.find('button')
+    expect($button.attributes('aria-controls')).toBe('test1')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+
+    await wrapper.setProps({target: ['test1', 'test2']})
+    expect($button.attributes('aria-controls')).toBe('test1 test2')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+    expect(spy1).not.toHaveBeenCalled()
+    expect(spy2).not.toHaveBeenCalled()
+
+    await $button.trigger('click')
+    await asyncTimeout(50)
+    expect(spy1).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledTimes(1)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($button.attributes('aria-controls')).toBe('test1 test2')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+
+    await wrapper.setProps({target: ['test2']})
+    expect($button.attributes('aria-controls')).toBe('test2')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+    expect(spy1).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledTimes(1)
+
+    await $button.trigger('click')
+    await asyncTimeout(50)
+    expect(spy1).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledTimes(2)
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($button.attributes('aria-controls')).toBe('test2')
+    expect($button.attributes('aria-expanded')).toBe('false')
+    expect($button.classes()).toContain('collapsed')
+    expect($button.classes()).not.toContain('not-collapsed')
+  })
+
+  it('works on non-buttons', async () => {
+    const spy = vi.fn()
+    const App = {
+      directives: {
+        bToggle: VBToggle,
+      },
+      data() {
+        return {
+          text: 'span',
+        }
+      },
+      mounted() {
+        document.getElementById('test')?.addEventListener(EVENT_TOGGLE, spy)
+      },
+      destroy() {
+        document.getElementById('test')?.removeEventListener(EVENT_TOGGLE, spy)
+      },
+      template:
+        '<span v-b-toggle.test role="button" tabindex="0">{{ text }}</span><div id="test"></div>',
+    }
+
+    const wrapper = mount(App, {attachTo: document.body})
+
+    await flushPromises()
+    await nextTick()
+
+    expect(wrapper.vm).toBeDefined()
+    expect(spy).not.toHaveBeenCalled()
+
+    const $span = wrapper.find('span')
+    expect($span.attributes('role')).toBe('button')
+    expect($span.attributes('tabindex')).toBe('0')
+    expect($span.attributes('aria-controls')).toBe('test')
+    expect($span.attributes('aria-expanded')).toBe('false')
+    expect($span.classes()).toContain('collapsed')
+    expect($span.classes()).not.toContain('not-collapsed')
+    expect($span.text()).toBe('span')
+
+    await $span.trigger('click')
+    await asyncTimeout(50)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect($span.attributes('role')).toBe('button')
+    expect($span.attributes('tabindex')).toBe('0')
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($span.attributes('aria-controls')).toBe('test')
+    expect($span.attributes('aria-expanded')).toBe('false')
+    expect($span.classes()).toContain('collapsed')
+    expect($span.classes()).not.toContain('not-collapsed')
+
+    // Test updating component, should maintain role attribute
+    await wrapper.setData({text: 'foobar'})
+    expect($span.text()).toBe('foobar')
+    expect($span.attributes('role')).toBe('button')
+    expect($span.attributes('tabindex')).toBe('0')
+
+    // Since there is no target collapse to respond with the
+    // current state, the classes and attrs remain the same
+    expect($span.attributes('aria-controls')).toBe('test')
+    expect($span.attributes('aria-expanded')).toBe('false')
+    expect($span.classes()).toContain('collapsed')
+    expect($span.classes()).not.toContain('not-collapsed')
+  })
+})


### PR DESCRIPTION
# Describe the PR

Hello! v0.15, specifically #1532, introduced a regression in the BToggle directive that caused specifying ID as arg or href to be broken. This PR fixes that regression.

Also re-added toggle.spec.ts, copied as-is from v0.14.10. Those tests caught this regression and can prevent it from happening again.

## Small replication

The following were broken:
```html
<button v-b-toggle:test1>button</button><div id="test1"></div>
<a href="#test2" v-b-toggle>link</a><div id="test2"></div>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
