### PR TITLE
fix(BFormTags): dark mode compatibility

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormTags/_form-tags.scss
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/_form-tags.scss
@@ -1,13 +1,13 @@
 .b-form-tags.focus {
   color: #212529;
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   border-color: #86b7fe;
   outline: 0;
   box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
 .b-form-tags.disabled {
-  background-color: #e9ecef;
+  background-color: var(--bs-secondary-bg);
 }
 
 .b-form-tag.disabled {


### PR DESCRIPTION
Relates to https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1668

I looked into what the textarea uses, and using the variable instead of the hard-coded value fixes it for the b-form-tags.