### PR TITLE
BTable id attribute is not being transferred into the rendered DOM

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableSimple.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableSimple.vue
@@ -1,5 +1,5 @@
 <template>
-  <table v-if="!responsive" :class="computedClasses">
+  <table v-if="!responsive" :id="id" :class="computedClasses">
     <slot />
   </table>
   <div v-else :class="responsiveClasses">


### PR DESCRIPTION
fix(BTable): BTable id attribute is not being transferred into the rendered DOM

# Describe the PR

Add id attribute to BTableSimple component so it'll be transferred into the DOM

## Small replication

https://stackblitz.com/edit/github-yki5xm?file=src%2Fcomponents%2FComp.vue,src%2FApp.vue

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
