### PR TITLE
fix(BTable): emitting and listening to hover events

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -9,8 +9,8 @@
     :field-column-class="getFieldColumnClasses"
     @head-clicked="onFieldHeadClick"
     @row-clicked="onRowClick"
-    @row-hovered="(row, index, e) => emit('row-hovered', row, index, e)"
-    @row-unhovered="(row, index, e) => emit('row-unhovered', row, index, e)"
+    @row-hovered="(row, index, e) => { emit('row-hovered', row, index, e) }"
+    @row-unhovered="(row, index, e) => { emit('row-unhovered', row, index, e) }"
   >
     <template v-for="(_, name) in $slots" #[name]="slotData">
       <slot :name="name" v-bind="slotData" />

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -9,6 +9,8 @@
     :field-column-class="getFieldColumnClasses"
     @head-clicked="onFieldHeadClick"
     @row-clicked="onRowClick"
+    @row-hovered="(row, index, e) => emit('row-hovered', row, index, e)"
+    @row-unhovered="(row, index, e) => emit('row-unhovered', row, index, e)"
   >
     <template v-for="(_, name) in $slots" #[name]="slotData">
       <slot :name="name" v-bind="slotData" />
@@ -321,10 +323,10 @@ const computedFields = computed<TableField[]>(() =>
               isSortable.value === false
                 ? undefined
                 : sortByModel.value !== el.key
-                ? 'none'
-                : sortDescBoolean.value === true
-                ? 'descending'
-                : 'ascending',
+                  ? 'none'
+                  : sortDescBoolean.value === true
+                    ? 'descending'
+                    : 'ascending',
             ...el.thAttr,
           },
         }


### PR DESCRIPTION
# Describe the PR
fix #1687 
emitting and listening to hover events on BTable

## Small replication

https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/53003820/d6631fb2-0724-4239-b073-9866e51cfc2e


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
