### PR TITLE
BModal documentation for shown event has incorrect timing

### DIFF
--- a/apps/docs/src/data/components/modal.data.ts
+++ b/apps/docs/src/data/components/modal.data.ts
@@ -399,7 +399,7 @@ export default {
               type: 'BvTriggerableEvent',
             },
           ],
-          description: 'Always emits just after modal is shown. Cancelable',
+          description: 'Always emits just before modal is shown. Cancelable',
         },
         {
           event: 'hide',

--- a/apps/docs/src/data/components/modal.data.ts
+++ b/apps/docs/src/data/components/modal.data.ts
@@ -399,7 +399,7 @@ export default {
               type: 'BvTriggerableEvent',
             },
           ],
-          description: 'Always emits just before modal is shown. Cancelable',
+          description: 'Always emits just after modal is shown. Cancelable',
         },
         {
           event: 'hide',

--- a/packages/bootstrap-vue-next/src/components/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script setup lang="ts">
+import {onKeyStroke, useEventListener, useFocus, useVModel} from '@vueuse/core'
 import {computed, type CSSProperties, reactive, ref, type RendererElement, toRef, watch} from 'vue'
 import {
   useBooleanish,
@@ -109,7 +110,6 @@ import {
   useModalManager,
   useSafeScrollLock,
 } from '../composables'
-import {onKeyStroke, useEventListener, useFocus, useVModel} from '@vueuse/core'
 import type {
   Booleanish,
   Breakpoint,
@@ -122,8 +122,8 @@ import type {
 import {BvTriggerableEvent, isEmptySlot} from '../utils'
 import BButton from './BButton/BButton.vue'
 import BCloseButton from './BButton/BCloseButton.vue'
-import BTransition from './BTransition/BTransition.vue'
 import BOverlay from './BOverlay/BOverlay.vue'
+import BTransition from './BTransition/BTransition.vue'
 
 defineOptions({
   inheritAttrs: false,
@@ -484,14 +484,16 @@ const hide = (trigger = '') => {
 // TODO: If a show is prevented, it will briefly show the animation. This is a bug
 // I'm not sure how to wait for the event to be determined. Before showing
 const showFn = () => {
-  const event = buildTriggerableEvent('show', {cancelable: true})
-  emit('show', event)
-  if (event.defaultPrevented) {
-    if (modelValue.value) modelValue.value = false
-    emit('show-prevented')
-    return
+  if (!isActive.value) {
+    const event = buildTriggerableEvent('show', {cancelable: true})
+    emit('show', event)
+    if (event.defaultPrevented) {
+      if (modelValue.value) modelValue.value = false
+      emit('show-prevented')
+      return
+    }
+    if (!modelValue.value) modelValue.value = true
   }
-  if (!modelValue.value) modelValue.value = true
 }
 
 const pickFocusItem = () => {


### PR DESCRIPTION
# Describe the PR

Check if the modal is already open before to be shown

## Small replication

https://github.com/corymccarty/bootstrap-vue-next-modal-emits

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
