### PR TITLE
fix(): Remove @input in favor of @update:modelValue

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -18,8 +18,6 @@
       :true-value="value"
       :false-value="uncheckedValue"
       :indeterminate="indeterminateBoolean"
-      @change="modelValue !== undefined && emit('change', modelValue)"
-      @input="modelValue !== undefined && emit('input', modelValue)"
     />
     <label v-if="hasDefaultSlot || plainBoolean === false" :for="computedId" :class="labelClasses">
       <slot />
@@ -87,8 +85,6 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: CheckboxValue | CheckboxValue[]]
-  'input': [value: CheckboxValue | CheckboxValue[]]
   'update:modelValue': [value: CheckboxValue | CheckboxValue[]]
   'update:indeterminate': [value: boolean]
 }>()

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -97,7 +97,7 @@ defineSlots<{
   first?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'checkbox')
 const computedName = useId(() => props.name, 'checkbox')

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -570,24 +570,24 @@ describe('form-checkbox', () => {
   })
 
   describe('model behavior', () => {
-    it('default unchecked checkbox emits input===false event when clicked', async () => {
+    it('default unchecked checkbox emits input event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
 
       await wrapper.find('input').trigger('click')
 
       expect(wrapper.emitted('input')).toBeDefined()
       expect(wrapper.emitted('input')?.length).toBe(1)
-      expect(wrapper.emitted('input')?.[0][0]).toBe(false)
+      expect(wrapper.emitted('input')?.[0][0]).toBeInstanceOf(Event)
     })
 
-    it('default unchecked checkbox emits change===true event when clicked', async () => {
+    it('default unchecked checkbox emits change event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
 
       await wrapper.find('input').trigger('click')
 
       expect(wrapper.emitted('change')).toBeDefined()
       expect(wrapper.emitted('change')?.length).toBe(1)
-      expect(wrapper.emitted('change')?.[0][0]).toBe(true)
+      expect(wrapper.emitted('change')?.[0][0]).toBeInstanceOf(Event)
     })
 
     it('default unchecked checkbox emits update:modelValue===true event when clicked', async () => {
@@ -600,24 +600,24 @@ describe('form-checkbox', () => {
       expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(true)
     })
 
-    it('default checked checkbox emits input===true event when clicked', async () => {
+    it('default checked checkbox emits input event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
 
       await wrapper.find('input').trigger('click')
 
       expect(wrapper.emitted('input')).toBeDefined()
       expect(wrapper.emitted('input')?.length).toBe(1)
-      expect(wrapper.emitted('input')?.[0][0]).toBe(true)
+      expect(wrapper.emitted('input')?.[0][0]).toBeInstanceOf(Event)
     })
 
-    it('default checked checkbox emits change===false event when clicked', async () => {
+    it('default checked checkbox emits change event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
 
       await wrapper.find('input').trigger('click')
 
       expect(wrapper.emitted('change')).toBeDefined()
       expect(wrapper.emitted('change')?.length).toBe(1)
-      expect(wrapper.emitted('change')?.[0][0]).toBe(false)
+      expect(wrapper.emitted('change')?.[0][0]).toBeInstanceOf(Event)
     })
 
     it('default checked checkbox emits update:modelValue===false event when clicked', async () => {
@@ -630,7 +630,7 @@ describe('form-checkbox', () => {
       expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(false)
     })
 
-    it('custom value unchecked checkbox emits input==="unchecked=value" event when clicked', async () => {
+    it('custom value unchecked checkbox emits input event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {
         props: {
           modelValue: 'unchecked',
@@ -644,10 +644,10 @@ describe('form-checkbox', () => {
 
       expect(wrapper.emitted('input')).toBeDefined()
       expect(wrapper.emitted('input')?.length).toBe(1)
-      expect(wrapper.emitted('input')?.[0][0]).toBe('unchecked')
+      expect(wrapper.emitted('input')?.[0][0]).toBeInstanceOf(Event)
     })
 
-    it('custom value unchecked checkbox emits change==="checked" event when clicked', async () => {
+    it('custom value unchecked checkbox emits change event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {
         props: {value: 'checked', uncheckedValue: 'unchecked'},
         attachTo: document.body,
@@ -657,7 +657,7 @@ describe('form-checkbox', () => {
 
       expect(wrapper.emitted('change')).toBeDefined()
       expect(wrapper.emitted('change')?.length).toBe(1)
-      expect(wrapper.emitted('change')?.[0][0]).toBe('checked')
+      expect(wrapper.emitted('change')?.[0][0]).toBeInstanceOf(Event)
     })
 
     it('custom value unchecked checkbox emits update:modelValue==="checked" event when clicked', async () => {
@@ -673,7 +673,7 @@ describe('form-checkbox', () => {
       expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('checked')
     })
 
-    it('custom value checked checkbox emits input==="checked" event when clicked', async () => {
+    it('custom value checked checkbox emits input event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {
         props: {
           modelValue: 'checked',
@@ -687,10 +687,10 @@ describe('form-checkbox', () => {
 
       expect(wrapper.emitted('input')).toBeDefined()
       expect(wrapper.emitted('input')?.length).toBe(1)
-      expect(wrapper.emitted('input')?.[0][0]).toBe('checked')
+      expect(wrapper.emitted('input')?.[0][0]).toBeInstanceOf(Event)
     })
 
-    it('custom value checked checkbox emits change=="unchecked" event when clicked', async () => {
+    it('custom value checked checkbox emits change event when clicked', async () => {
       const props = {
         modelValue: 'checked',
         value: 'checked',
@@ -705,7 +705,7 @@ describe('form-checkbox', () => {
 
       expect(wrapper.emitted('change')).toBeDefined()
       expect(wrapper.emitted('change')?.length).toBe(1)
-      expect(wrapper.emitted('change')?.[0][0]).toBe('unchecked')
+      expect(wrapper.emitted('change')?.[0][0]).toBeInstanceOf(Event)
     })
 
     it('custom value checked checkbox emits update:modelValue==="unhecked-value" event when clicked', async () => {

--- a/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
@@ -85,11 +85,10 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: Event]
   'update:modelValue': [value: File | File[] | null]
 }>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 const computedId = useId(() => props.id)
 
 const autofocusBoolean = useBooleanish(() => props.autofocus)
@@ -122,11 +121,10 @@ const computedClasses = computed(() => [
   },
 ])
 
-const onChange = (e: Readonly<Event>) => {
+const onChange = () => {
   const value =
     input.value?.files === null || input.value?.files === undefined ? null : [...input.value.files]
   modelValue.value = value === null ? null : multipleBoolean.value === true ? value : value[0]
-  emit('change', e)
 }
 
 const onDrop = (e: Readonly<Event>) => {

--- a/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
@@ -72,13 +72,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'blur': [val: FocusEvent]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'change': [val: any]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'input': [val: any]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'update:modelValue': [val: any]
+  'update:modelValue': [val: Numberish | null]
 }>()
 
 const {input, computedId, computedAriaInvalid, onInput, onChange, onBlur, focus, blur} =

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -15,8 +15,6 @@
       :aria-labelledby="ariaLabelledby"
       :value="value"
       :aria-required="computedRequired || undefined"
-      @change="modelValue !== undefined && emit('change', modelValue)"
-      @input="modelValue !== undefined && emit('input', modelValue)"
     />
     <label v-if="hasDefaultSlot || plainBoolean === false" :for="computedId" :class="labelClasses">
       <slot />
@@ -78,8 +76,6 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: RadioValue]
-  'input': [value: RadioValue]
   'update:modelValue': [value: RadioValue]
 }>()
 

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
@@ -100,7 +100,7 @@ defineSlots<{
   first?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'radio')
 const computedName = useId(() => props.name, 'checkbox')

--- a/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelect.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormSelect/BFormSelect.vue
@@ -42,7 +42,7 @@ import type {
   SelectOptionRaw,
   Size,
 } from '../../types'
-import {computed, nextTick, ref, toRef} from 'vue'
+import {computed, ref, toRef} from 'vue'
 import BFormSelectOption from './BFormSelectOption.vue'
 import BFormSelectOptionGroup from './BFormSelectOptionGroup.vue'
 import {useAriaInvalid, useBooleanish, useFormSelect, useId, useStateClass} from '../../composables'
@@ -91,8 +91,6 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: unknown]
-  'input': [value: unknown]
   'update:modelValue': [value: unknown]
 }>()
 
@@ -103,7 +101,7 @@ defineSlots<{
   first?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = useVModel(props, 'modelValue', emit)
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'input')
 
@@ -148,11 +146,7 @@ const normalizedOptsWrapper = computed(
 const localValue = computed({
   get: () => modelValue.value,
   set: (newValue) => {
-    emit('input', newValue)
     modelValue.value = newValue
-    nextTick(() => {
-      emit('change', newValue)
-    })
   },
 })
 

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
@@ -67,13 +67,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'blur': [val: FocusEvent]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'change': [val: any]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'input': [val: any]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  'update:modelValue': [val: any]
+  'update:modelValue': [val: Numberish | null]
 }>()
 
 const {input, computedId, computedAriaInvalid, onInput, onChange, onBlur, focus, blur} =

--- a/packages/bootstrap-vue-next/src/composables/useFormInput.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormInput.ts
@@ -9,17 +9,11 @@ import type {CommonInputProps} from '../types/FormCommonInputProps'
 export default (
   props: Readonly<CommonInputProps>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  emit: ((evt: 'update:modelValue', val: any) => void) &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ((evt: 'change', val: any) => void) &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ((evt: 'blur', val: any) => void) &
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ((evt: 'input', val: any) => void)
+  emit: (evt: 'update:modelValue', val: any) => void
 ) => {
   const input = ref<HTMLInputElement | null>(null)
 
-  const modelValue = useVModel(props, 'modelValue', emit)
+  const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
   const computedId = useId(() => props.id, 'input')
   const autofocusBoolean = useBooleanish(() => props.autofocus)
@@ -90,8 +84,6 @@ export default (
     const nextModel = _getModelValue(formattedValue)
 
     updateModelValue(nextModel)
-
-    emit('input', formattedValue)
   }
 
   const onChange = (evt: Readonly<Event>) => {
@@ -106,12 +98,9 @@ export default (
     if (modelValue.value !== nextModel) {
       updateModelValue(formattedValue, true)
     }
-
-    emit('change', formattedValue)
   }
 
   const onBlur = (evt: Readonly<FocusEvent>) => {
-    emit('blur', evt)
     if (!lazyBoolean.value && !lazyFormatterBoolean.value) return
 
     const {value} = evt.target as HTMLInputElement


### PR DESCRIPTION
# Describe the PR

Change @input for @update:modelValue event in BFormCheckbox, BFormCheckboxGroup, BFormRadio, BFormRadioGroup, BFormSelect, BFormTags and useFormInput

fix #1657

## Small replication

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
