### PR TITLE
feat(BFormCheckBox): Implements tri-state checkbox

### DIFF
--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -24,6 +24,7 @@ export default {
           prop: 'indeterminate',
           type: 'Booleanish',
           default: undefined,
+          description: 'Set or clear the indeterminate state of the checkbox.',
         },
         {
           prop: 'name',
@@ -108,35 +109,38 @@ export default {
       ],
       emits: [
         {
+          event: 'update:modelValue',
+          description: 'Emitted when the checked value is changed',
           args: [
             {
-              arg: 'update:modelValue',
-              description: '',
-              type: 'unknown',
+              arg: 'checked',
+              description:
+                'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
+              type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
-          description: '',
-          event: 'update:modelValue',
         },
         {
           event: 'input',
-          description: '',
+          description: 'Emitted before the checked value is changed',
           args: [
             {
-              arg: 'input',
-              description: '',
-              type: 'unknown',
+              arg: 'checked',
+              description:
+                'Value of the checkbox before the event. Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
+              type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
         },
         {
           event: 'change',
-          description: '',
+          description: 'Emitted when the checked value is changed',
           args: [
             {
-              arg: 'change',
-              description: '',
-              type: 'unknown',
+              arg: 'checked',
+              description:
+                'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
+              type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
         },

--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -23,8 +23,9 @@ export default {
         {
           prop: 'indeterminate',
           type: 'Booleanish',
-          default: undefined,
-          description: 'Set or clear the indeterminate state of the checkbox.',
+          default: false,
+          description:
+            'Set to true to show the checkbox as indeterminate, false to show its normal checked/unchecked.',
         },
         {
           prop: 'name',

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -719,22 +719,35 @@ Visually, there are actually three states a checkbox can be in: checked, uncheck
 
 The indeterminate state is **visual only**. The checkbox is still either checked or unchecked as a value. That means the visual indeterminate state masks the real value of the checkbox, so that better make sense in your UI!.
 
-`BFormCheckbox` supports setting this visual indeterminate state via the indeterminate prop (defaults to false). Clicking the checkbox will clear its indeterminate state.
+`BFormCheckbox` supports setting this visual indeterminate state via a secondary named model called indeterminate (defaults to undefined). Clicking the checkbox will clear the indeterminate state and emit an `update:indeterminate=false` event. To reset the state set the indeterminate model value to true.
 
 <HighlightCard>
-  <BFormCheckbox v-model="intermChecked" :indeterminate="true">Click me to see what happens</BFormCheckbox>
+  <BFormCheckbox v-model="intermChecked" v-model:indeterminate="indeterminate">Click me to see what happens</BFormCheckbox>
+  <BButton class="mt-2" :disabled="indeterminate" @click="indeterminate = true">Reset Indeterminate</BButton>
   <div class="mt-2">
-    Checked: <strong>{{ intermChecked }}</strong>
+    Checked: <strong>{{ intermChecked }}</strong><br>
+    Indeterminate: <strong>{{ indeterminate }}</strong>
   </div>
   <template #html>
 
 ```vue
 <template>
-  <BFormCheckbox :indeterminate="true">Click me to see what happens</BFormCheckbox>
+  <BFormCheckbox v-model="intermChecked" v-model:indeterminate="indeterminate"
+    >Click me to see what happens</BFormCheckbox
+  >
+  <BButton class="mt-2" :disabled="indeterminate" @click="indeterminate = true"
+    >Reset Indeterminate</BButton
+  >
+  <div class="mt-2">
+    Checked: <strong>{{ intermChecked }}</strong
+    ><br />
+    Indeterminate: <strong>{{ indeterminate }}</strong>
+  </div>
 </template>
 
 <script setup lang="ts">
 const intermChecked = ref(true)
+const indeterminate = ref(true)
 </script>
 ```
 
@@ -749,12 +762,13 @@ import {ref, computed} from 'vue'
 import ComponentReference from '../../components/ComponentReference.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarning.vue'
-import {BFormCheckboxGroup, BFormCheckbox, BCard, BCardBody, BAlert} from 'bootstrap-vue-next'
+import {BButton, BFormCheckboxGroup, BFormCheckbox, BCard, BCardBody, BAlert} from 'bootstrap-vue-next'
 
 const button1Checked = ref(false);
 const button2Checked = ref(false);
 const switchChecked = ref(false);
 const intermChecked = ref(true);
+const indeterminate = ref(true);
 
 const availableCars = ['BMW', 'Mercedes', 'Toyota'];
 const selectedCars = ref([]);

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -17,7 +17,7 @@
       :value="value"
       :true-value="value"
       :false-value="uncheckedValue"
-      :indeterminate="indeterminate"
+      :indeterminate="indeterminateBoolean"
       @change="modelValue !== undefined && emit('change', modelValue)"
       @input="modelValue !== undefined && emit('input', modelValue)"
     />
@@ -50,6 +50,7 @@ const props = withDefaults(
     disabled?: Booleanish
     form?: string
     id?: string
+    indeterminate?: Booleanish
     inline?: Booleanish
     modelValue?: CheckboxValue | readonly CheckboxValue[]
     name?: string
@@ -71,6 +72,7 @@ const props = withDefaults(
     disabled: false,
     form: undefined,
     id: undefined,
+    indeterminate: undefined,
     inline: false,
     modelValue: undefined,
     name: undefined,
@@ -88,6 +90,7 @@ const emit = defineEmits<{
   'change': [value: CheckboxValue | CheckboxValue[]]
   'input': [value: CheckboxValue | CheckboxValue[]]
   'update:modelValue': [value: CheckboxValue | CheckboxValue[]]
+  'update:indeterminate': [value: boolean]
 }>()
 
 const slots = defineSlots<{
@@ -96,10 +99,11 @@ const slots = defineSlots<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
-const indeterminate = defineModel('indeterminate', {default: false})
+const indeterminate = useVModel(props, 'indeterminate', emit, {passive: false})
 
 const computedId = useId(() => props.id, 'form-check')
 
+const indeterminateBoolean = useBooleanish(() => props.indeterminate)
 const autofocusBoolean = useBooleanish(() => props.autofocus)
 const plainBoolean = useBooleanish(() => props.plain)
 const buttonBoolean = useBooleanish(() => props.button)

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -72,7 +72,7 @@ const props = withDefaults(
     disabled: false,
     form: undefined,
     id: undefined,
-    indeterminate: undefined,
+    indeterminate: false,
     inline: false,
     modelValue: undefined,
     name: undefined,
@@ -99,7 +99,7 @@ const slots = defineSlots<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
-const indeterminate = useVModel(props, 'indeterminate', emit, {passive: false})
+const indeterminate = useVModel(props, 'indeterminate', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'form-check')
 

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -12,7 +12,7 @@
       :name="name || parentData?.name.value"
       :form="form || parentData?.form.value"
       :aria-label="ariaLabel"
-      :aria-labelledby="ariaLabelledBy"
+      :aria-labelledby="ariaLabelledby"
       :aria-required="computedRequired || undefined"
       :value="value"
       :true-value="value"
@@ -42,7 +42,7 @@ defineOptions({
 const props = withDefaults(
   defineProps<{
     ariaLabel?: string
-    ariaLabelledBy?: string
+    ariaLabelledby?: string
     autofocus?: Booleanish
     button?: Booleanish
     buttonGroup?: Booleanish
@@ -64,7 +64,7 @@ const props = withDefaults(
   }>(),
   {
     ariaLabel: undefined,
-    ariaLabelledBy: undefined,
+    ariaLabelledby: undefined,
     autofocus: false,
     button: false,
     buttonGroup: false,

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -17,7 +17,7 @@
       :value="value"
       :true-value="value"
       :false-value="uncheckedValue"
-      :indeterminate="indeterminateBoolean"
+      :indeterminate="indeterminate"
       @change="modelValue !== undefined && emit('change', modelValue)"
       @input="modelValue !== undefined && emit('input', modelValue)"
     />
@@ -50,7 +50,6 @@ const props = withDefaults(
     disabled?: Booleanish
     form?: string
     id?: string
-    indeterminate?: Booleanish
     inline?: Booleanish
     modelValue?: CheckboxValue | readonly CheckboxValue[]
     name?: string
@@ -72,7 +71,6 @@ const props = withDefaults(
     disabled: false,
     form: undefined,
     id: undefined,
-    indeterminate: undefined,
     inline: false,
     modelValue: undefined,
     name: undefined,
@@ -98,10 +96,10 @@ const slots = defineSlots<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
+const indeterminate = defineModel('indeterminate', {default: false})
 
 const computedId = useId(() => props.id, 'form-check')
 
-const indeterminateBoolean = useBooleanish(() => props.indeterminate)
 const autofocusBoolean = useBooleanish(() => props.autofocus)
 const plainBoolean = useBooleanish(() => props.plain)
 const buttonBoolean = useBooleanish(() => props.button)
@@ -126,6 +124,10 @@ const localValue = computed({
   get: () => parentData?.modelValue.value ?? modelValue.value,
   set: (newVal) => {
     if (newVal === undefined) return
+    // Indeterminate is implicitly cleared when the checked state is changed to any value
+    //  by the user.  We reflect that here by setting our indetermiate model to false
+    //  which will emit the indeterminate event to the parent
+    indeterminate.value = false
     if (parentData !== null && Array.isArray(newVal)) {
       // The type cast isn't perfect. Array.isArray detects CheckboxValue.unknown[],
       // but since it's parentData, it should always be CheckboxValue[]

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -99,7 +99,7 @@ const slots = defineSlots<{
 }>()
 
 const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
-const indeterminate = useVModel(props, 'indeterminate', emit, {passive: true})
+const indeterminate = useVModel(props, 'indeterminate', emit)
 
 const computedId = useId(() => props.id, 'form-check')
 

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -647,7 +647,7 @@ describe('form-checkbox', () => {
       expect(wrapper.emitted('input')?.[0][0]).toBe('unchecked')
     })
 
-    it('custom value unchecked checkbox emits change==-"checked" event when clicked', async () => {
+    it('custom value unchecked checkbox emits change==="checked" event when clicked', async () => {
       const wrapper = mount(BFormCheckbox, {
         props: {value: 'checked', uncheckedValue: 'unchecked'},
         attachTo: document.body,

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -1,0 +1,728 @@
+import {afterEach, describe, expect, it} from 'vitest'
+import {enableAutoUnmount, mount} from '@vue/test-utils'
+import BFormCheckbox from './BFormCheckbox.vue'
+
+describe('form-checkbox', () => {
+  enableAutoUnmount(afterEach)
+
+  describe('useFormCHeck attributes', () => {
+    // TODO: This set of tests could better be implemented
+    //  on the composable? (useFormcheck)
+    it('tag is div', () => {
+      const wrapper = mount(BFormCheckbox)
+      expect(wrapper.element.tagName).toBe('DIV')
+    })
+
+    it('has class form-check if prop plain and prop button are false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: false},
+      })
+      expect(wrapper.classes()).toContain('form-check')
+    })
+
+    it('has class form-check if prop plain and prop button are true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: true},
+      })
+      expect(wrapper.classes()).not.toContain('form-check')
+    })
+
+    it('does not have class form-check if prop plain false and prop button true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: true},
+      })
+      expect(wrapper.classes()).not.toContain('form-check')
+    })
+
+    it('does not have class form-check if prop plain true and prop button false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: false},
+      })
+      expect(wrapper.classes()).not.toContain('form-check')
+    })
+
+    it('has class form-check-inline when prop inline', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {inline: true},
+      })
+      expect(wrapper.classes()).toContain('form-check-inline')
+    })
+
+    it('has class form-check-inline when prop inline', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {inline: false},
+      })
+      expect(wrapper.classes()).not.toContain('form-check-inline')
+    })
+
+    it('does not have class form-switch when prop switch is false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {switch: false},
+      })
+      expect(wrapper.classes()).not.toContain('form-switch')
+    })
+
+    it('has class form-control-{type} when prop size', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {size: 'lg'},
+      })
+      expect(wrapper.classes()).toContain('form-control-lg')
+    })
+
+    it('does not have class form-control-{type} when prop size undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {size: undefined},
+      })
+      expect(wrapper.classes()).not.toContain('form-control-lg')
+    })
+
+    it('has class form-control-{type} when prop size is md', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {size: 'md'},
+      })
+      expect(wrapper.classes()).not.toContain('form-control-md')
+    })
+  })
+
+  describe('input attributes', () => {
+    it('has input element', () => {
+      const wrapper = mount(BFormCheckbox)
+      const $input = wrapper.find('input')
+      expect($input.exists()).toBe(true)
+    })
+
+    it('input element has attr id', () => {
+      const wrapper = mount(BFormCheckbox)
+      const $input = wrapper.get('input')
+      expect($input.attributes('id')).toBeDefined()
+    })
+
+    it('input element attr id contains content from prop id', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {id: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('id')).toBe('foobar')
+    })
+
+    it('input element has attr type to be checkbox', () => {
+      const wrapper = mount(BFormCheckbox)
+      const $input = wrapper.get('input')
+      expect($input.attributes('type')).toBe('checkbox')
+    })
+
+    it('input element has class form-check-input when prop plain and prop button are false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: false},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).toContain('form-check-input')
+    })
+
+    it('input element does not have class form-check-input when prop plain and prop button false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: false},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).not.toContain('form-check-input')
+    })
+
+    it('input element does not have class form-check-input when prop plain false and prop button true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).not.toContain('form-check-input')
+    })
+
+    it('input element does not have class form-check-input when prop plain and prop button are true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).not.toContain('form-check-input')
+    })
+
+    it('input element has class form-check-input when prop plain and prop button are undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: undefined, button: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).toContain('form-check-input')
+    })
+
+    it('input element has class btn-check when prop button is true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).toContain('btn-check')
+    })
+
+    it('input element does not have class btn-check when prop button is false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: false},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).not.toContain('btn-check')
+    })
+
+    it('input element does not have class btn-check when prop button is undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.classes()).not.toContain('btn-check')
+    })
+
+    it('input element has attr disabled when prop disabled', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {disabled: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('disabled')).toBe('')
+    })
+
+    it('input element does not have attr disabled when prop disabled is false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {disabled: false},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('disabled')).toBeUndefined()
+    })
+
+    it('input element does not have attr disabled when prop disabled is undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {disabled: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('disabled')).toBeUndefined()
+    })
+
+    it('input element has attr required when prop name and prop required', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {required: true, name: 'foo'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('required')).toBe('')
+    })
+
+    it('input element does not have attr required when prop name is empty string and prop required', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {required: true, name: ''},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('required')).toBeUndefined()
+    })
+
+    it('input element does not have attr required when prop name is undefined and prop required', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {required: true, name: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('required')).toBeUndefined()
+    })
+
+    it('input element does not have attr required when prop name and prop required false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {required: false, name: 'foo'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('required')).toBeUndefined()
+    })
+
+    it('input element does not have attr required when prop name and prop required undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {required: undefined, name: 'foo'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('required')).toBeUndefined()
+    })
+
+    it('input element has attr name to be prop name', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {name: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('name')).toBe('foobar')
+    })
+
+    it('input element has attr name is undefined when prop name undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {name: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('name')).toBeUndefined()
+    })
+
+    it('input element has attr form to be prop form', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {form: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('form')).toBe('foobar')
+    })
+
+    it('input element has attr form is undefined when prop form undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {form: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('form')).toBeUndefined()
+    })
+
+    it('input element has attr aria-label to be prop ariaLabel', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {ariaLabel: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-label')).toBe('foobar')
+    })
+
+    it('input element has attr aria-label is undefined when prop ariaLabel undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {ariaLabel: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-label')).toBeUndefined()
+    })
+
+    it('input element has attr aria-labelledby to be prop ariaLabelledby', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {ariaLabelledby: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-labelledby')).toBe('foobar')
+    })
+
+    it('input element has attr aria-labelledby is undefined when prop ariaLabelledby undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {ariaLabelledby: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-labelledby')).toBeUndefined()
+    })
+
+    it('input element has attr aria-labelledby is undefined when prop ariaLabelledby undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {ariaLabelledby: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-labelledby')).toBeUndefined()
+    })
+
+    it('input element has attr value to be prop value', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {value: 'foobar'},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('value')).toBe('foobar')
+    })
+
+    it('input element has attr value to be true when value is undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {value: undefined},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('value')).toBe('true')
+    })
+
+    it('input element aria-required when prop name and prop required true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {name: 'foo', required: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-required')).toBe('true')
+    })
+
+    it('input element does not have aria-required when prop name is empty string and prop required true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {name: '', required: true},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-required')).toBeUndefined()
+    })
+
+    it('input element does not have aria-required when prop name and prop required false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {name: 'foo', required: false},
+      })
+      const $input = wrapper.get('input')
+      expect($input.attributes('aria-required')).toBeUndefined()
+    })
+  })
+
+  describe('label attributes', () => {
+    it('has child label by default', () => {
+      const wrapper = mount(BFormCheckbox)
+      const $label = wrapper.find('label')
+      expect($label.exists()).toBe(true)
+    })
+
+    it('does not have child label when prop plain is true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true},
+      })
+      const $label = wrapper.find('label')
+      expect($label.exists()).toBe(false)
+    })
+
+    it('has child label when prop plain is false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+      })
+      const $label = wrapper.find('label')
+      expect($label.exists()).toBe(true)
+    })
+
+    it('has child label when prop plain is false but has default slot', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+        slots: {default: 'foobar'},
+      })
+      const $label = wrapper.find('label')
+      expect($label.exists()).toBe(true)
+    })
+
+    it('has child label when prop plain is true but has default slot', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true},
+        slots: {default: 'foobar'},
+      })
+      const $label = wrapper.find('label')
+      expect($label.exists()).toBe(true)
+    })
+
+    it('child label has attr for to be defined by default', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.attributes('for')).toBeDefined()
+    })
+
+    it('child label has attr for is prop id', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, id: 'foobar'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.attributes('for')).toBe('foobar')
+    })
+
+    it('child label attr for is same as input id', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+      })
+      const $label = wrapper.get('label')
+      const $input = wrapper.get('input')
+      const $labelFor = $label.attributes('for')
+      const $inputId = $input.attributes('id')
+      expect($labelFor).toBe($inputId)
+    })
+
+    it('child label does not have class focus by default', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('focus')
+    })
+
+    it('child label removes class focus when input is blurred after focus', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false},
+      })
+      const $label = wrapper.get('label')
+      const $input = wrapper.get('input')
+      await $input.trigger('focus')
+      await $input.trigger('blur')
+      expect($label.classes()).not.toContain('focus')
+    })
+
+    it('child label has class form-check-label when prop plain and prop button are false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).toContain('form-check-label')
+    })
+
+    it('child label has class form-check-label when prop plain and prop button are false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).toContain('form-check-label')
+    })
+
+    it('child label does not have class form-check-label when prop plain true and prop button false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: false},
+        slots: {default: 'foo'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('form-check-label')
+    })
+
+    it('child label does not have class form-check-label when prop plain false and prop button true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, button: true},
+        slots: {default: 'foo'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('form-check-label')
+    })
+
+    it('child label does not have class form-check-label when prop plain and prop button are true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: true, button: true},
+        slots: {default: 'foo'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('form-check-label')
+    })
+
+    it('child label has class btn when prop button', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).toContain('btn')
+    })
+
+    it('child label does not have class btn when prop button false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: false, plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn')
+    })
+
+    it('child label has class btn-{type} when prop button and prop buttonVariant', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, buttonVariant: 'danger', plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).toContain('btn-danger')
+    })
+
+    it('child label does not have class btn-{type} when prop button false and prop buttonVariant', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: false, buttonVariant: 'danger', plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn-danger')
+    })
+
+    it('child label does not have class btn-{type} when prop button true and prop buttonVariant undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, buttonVariant: undefined, plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn-undefined')
+    })
+
+    it('child label has class btn-{type} when prop button and prop size', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, size: 'lg', plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).toContain('btn-lg')
+    })
+
+    it('child label does not have class btn-{type} when prop button false and prop size', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: false, size: 'lg', plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn-lg')
+    })
+
+    it('child label does not have class btn-{type} when prop button true and prop size undefined', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, size: undefined, plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn-undefined')
+    })
+
+    it('child label does not have class btn-md when prop button true and prop size md', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {button: true, size: 'md', plain: false},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('btn-md')
+    })
+
+    it('child label has class active when value and modelValue are not the same', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {plain: false, value: 'foo1', modelValue: 'foo'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.classes()).not.toContain('active')
+    })
+
+    it('child label renders default slot', () => {
+      const wrapper = mount(BFormCheckbox, {
+        slots: {default: 'foobar'},
+      })
+      const $label = wrapper.get('label')
+      expect($label.text()).toBe('foobar')
+    })
+  })
+
+  it('default unchecked checkbox emits input===false event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input')?.length).toBe(1)
+    expect(wrapper.emitted('input')?.[0][0]).toBe(false)
+  })
+
+  it('default unchecked checkbox emits change===true event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change')?.length).toBe(1)
+    expect(wrapper.emitted('change')?.[0][0]).toBe(true)
+  })
+
+  it('default unchecked checkbox emits update:modelValue===true event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeDefined()
+    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(true)
+  })
+
+  it('default checked checkbox emits input===true event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input')?.length).toBe(1)
+    expect(wrapper.emitted('input')?.[0][0]).toBe(true)
+  })
+
+  it('default checked checkbox emits change===false event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change')?.length).toBe(1)
+    expect(wrapper.emitted('change')?.[0][0]).toBe(false)
+  })
+
+  it('default checked checkbox emits update:modelValue===false event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeDefined()
+    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(false)
+  })
+
+  it('custom value unchecked checkbox emits input==="unchecked=value" event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      props: {
+        modelValue: 'unchecked',
+        value: 'checked',
+        uncheckedValue: 'unchecked',
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input')?.length).toBe(1)
+    expect(wrapper.emitted('input')?.[0][0]).toBe('unchecked')
+  })
+
+  it('custom value unchecked checkbox emits change==-"checked" event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      props: {value: 'checked', uncheckedValue: 'unchecked'},
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change')?.length).toBe(1)
+    expect(wrapper.emitted('change')?.[0][0]).toBe('checked')
+  })
+
+  it('custom value unchecked checkbox emits update:modelValue==="checked" event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      props: {value: 'checked', uncheckedValue: 'unchecked'},
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeDefined()
+    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('checked')
+  })
+
+  it('custom value checked checkbox emits input==="checked" event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      props: {
+        modelValue: 'checked',
+        value: 'checked',
+        uncheckedValue: 'unchecked',
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('input')).toBeDefined()
+    expect(wrapper.emitted('input')?.length).toBe(1)
+    expect(wrapper.emitted('input')?.[0][0]).toBe('checked')
+  })
+
+  it('custom value checked checkbox emits change=="unchecked" event when clicked', async () => {
+    const props = {
+      modelValue: 'checked',
+      value: 'checked',
+      uncheckedValue: 'unchecked',
+    }
+    const wrapper = mount(BFormCheckbox, {
+      props,
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('change')).toBeDefined()
+    expect(wrapper.emitted('change')?.length).toBe(1)
+    expect(wrapper.emitted('change')?.[0][0]).toBe('unchecked')
+  })
+
+  it('custom value checked checkbox emits update:modelValue==="unhecked-value" event when clicked', async () => {
+    const wrapper = mount(BFormCheckbox, {
+      props: {
+        modelValue: 'checked',
+        value: 'checked',
+        uncheckedValue: 'unchecked',
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('input').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeDefined()
+    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('unchecked')
+  })
+})

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -6,8 +6,6 @@ describe('form-checkbox', () => {
   enableAutoUnmount(afterEach)
 
   describe('useFormCHeck attributes', () => {
-    // TODO: This set of tests could better be implemented
-    //  on the composable? (useFormcheck)
     it('tag is div', () => {
       const wrapper = mount(BFormCheckbox)
       expect(wrapper.element.tagName).toBe('DIV')
@@ -571,158 +569,200 @@ describe('form-checkbox', () => {
     })
   })
 
-  it('default unchecked checkbox emits input===false event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
+  describe('model behavior', () => {
+    it('default unchecked checkbox emits input===false event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
 
-    await wrapper.find('input').trigger('click')
+      await wrapper.find('input').trigger('click')
 
-    expect(wrapper.emitted('input')).toBeDefined()
-    expect(wrapper.emitted('input')?.length).toBe(1)
-    expect(wrapper.emitted('input')?.[0][0]).toBe(false)
-  })
-
-  it('default unchecked checkbox emits change===true event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
-
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('change')).toBeDefined()
-    expect(wrapper.emitted('change')?.length).toBe(1)
-    expect(wrapper.emitted('change')?.[0][0]).toBe(true)
-  })
-
-  it('default unchecked checkbox emits update:modelValue===true event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
-
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('update:modelValue')).toBeDefined()
-    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
-    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(true)
-  })
-
-  it('default checked checkbox emits input===true event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
-
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('input')).toBeDefined()
-    expect(wrapper.emitted('input')?.length).toBe(1)
-    expect(wrapper.emitted('input')?.[0][0]).toBe(true)
-  })
-
-  it('default checked checkbox emits change===false event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
-
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('change')).toBeDefined()
-    expect(wrapper.emitted('change')?.length).toBe(1)
-    expect(wrapper.emitted('change')?.[0][0]).toBe(false)
-  })
-
-  it('default checked checkbox emits update:modelValue===false event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
-
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('update:modelValue')).toBeDefined()
-    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
-    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(false)
-  })
-
-  it('custom value unchecked checkbox emits input==="unchecked=value" event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {
-        modelValue: 'unchecked',
-        value: 'checked',
-        uncheckedValue: 'unchecked',
-      },
-      attachTo: document.body,
+      expect(wrapper.emitted('input')).toBeDefined()
+      expect(wrapper.emitted('input')?.length).toBe(1)
+      expect(wrapper.emitted('input')?.[0][0]).toBe(false)
     })
 
-    await wrapper.find('input').trigger('click')
+    it('default unchecked checkbox emits change===true event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
 
-    expect(wrapper.emitted('input')).toBeDefined()
-    expect(wrapper.emitted('input')?.length).toBe(1)
-    expect(wrapper.emitted('input')?.[0][0]).toBe('unchecked')
-  })
+      await wrapper.find('input').trigger('click')
 
-  it('custom value unchecked checkbox emits change==-"checked" event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {value: 'checked', uncheckedValue: 'unchecked'},
-      attachTo: document.body,
+      expect(wrapper.emitted('change')).toBeDefined()
+      expect(wrapper.emitted('change')?.length).toBe(1)
+      expect(wrapper.emitted('change')?.[0][0]).toBe(true)
     })
 
-    await wrapper.find('input').trigger('click')
+    it('default unchecked checkbox emits update:modelValue===true event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: false}, attachTo: document.body})
 
-    expect(wrapper.emitted('change')).toBeDefined()
-    expect(wrapper.emitted('change')?.length).toBe(1)
-    expect(wrapper.emitted('change')?.[0][0]).toBe('checked')
-  })
+      await wrapper.find('input').trigger('click')
 
-  it('custom value unchecked checkbox emits update:modelValue==="checked" event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {value: 'checked', uncheckedValue: 'unchecked'},
-      attachTo: document.body,
+      expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+      expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(true)
     })
 
-    await wrapper.find('input').trigger('click')
+    it('default checked checkbox emits input===true event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
 
-    expect(wrapper.emitted('update:modelValue')).toBeDefined()
-    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
-    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('checked')
-  })
+      await wrapper.find('input').trigger('click')
 
-  it('custom value checked checkbox emits input==="checked" event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {
+      expect(wrapper.emitted('input')).toBeDefined()
+      expect(wrapper.emitted('input')?.length).toBe(1)
+      expect(wrapper.emitted('input')?.[0][0]).toBe(true)
+    })
+
+    it('default checked checkbox emits change===false event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('change')).toBeDefined()
+      expect(wrapper.emitted('change')?.length).toBe(1)
+      expect(wrapper.emitted('change')?.[0][0]).toBe(false)
+    })
+
+    it('default checked checkbox emits update:modelValue===false event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {props: {modelValue: true}, attachTo: document.body})
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+      expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe(false)
+    })
+
+    it('custom value unchecked checkbox emits input==="unchecked=value" event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {
+          modelValue: 'unchecked',
+          value: 'checked',
+          uncheckedValue: 'unchecked',
+        },
+        attachTo: document.body,
+      })
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('input')).toBeDefined()
+      expect(wrapper.emitted('input')?.length).toBe(1)
+      expect(wrapper.emitted('input')?.[0][0]).toBe('unchecked')
+    })
+
+    it('custom value unchecked checkbox emits change==-"checked" event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {value: 'checked', uncheckedValue: 'unchecked'},
+        attachTo: document.body,
+      })
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('change')).toBeDefined()
+      expect(wrapper.emitted('change')?.length).toBe(1)
+      expect(wrapper.emitted('change')?.[0][0]).toBe('checked')
+    })
+
+    it('custom value unchecked checkbox emits update:modelValue==="checked" event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {value: 'checked', uncheckedValue: 'unchecked'},
+        attachTo: document.body,
+      })
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+      expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('checked')
+    })
+
+    it('custom value checked checkbox emits input==="checked" event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {
+          modelValue: 'checked',
+          value: 'checked',
+          uncheckedValue: 'unchecked',
+        },
+        attachTo: document.body,
+      })
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('input')).toBeDefined()
+      expect(wrapper.emitted('input')?.length).toBe(1)
+      expect(wrapper.emitted('input')?.[0][0]).toBe('checked')
+    })
+
+    it('custom value checked checkbox emits change=="unchecked" event when clicked', async () => {
+      const props = {
         modelValue: 'checked',
         value: 'checked',
         uncheckedValue: 'unchecked',
-      },
-      attachTo: document.body,
+      }
+      const wrapper = mount(BFormCheckbox, {
+        props,
+        attachTo: document.body,
+      })
+
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('change')).toBeDefined()
+      expect(wrapper.emitted('change')?.length).toBe(1)
+      expect(wrapper.emitted('change')?.[0][0]).toBe('unchecked')
     })
 
-    await wrapper.find('input').trigger('click')
+    it('custom value checked checkbox emits update:modelValue==="unhecked-value" event when clicked', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {
+          modelValue: 'checked',
+          value: 'checked',
+          uncheckedValue: 'unchecked',
+        },
+        attachTo: document.body,
+      })
 
-    expect(wrapper.emitted('input')).toBeDefined()
-    expect(wrapper.emitted('input')?.length).toBe(1)
-    expect(wrapper.emitted('input')?.[0][0]).toBe('checked')
+      await wrapper.find('input').trigger('click')
+
+      expect(wrapper.emitted('update:modelValue')).toBeDefined()
+      expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
+      expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('unchecked')
+    })
   })
 
-  it('custom value checked checkbox emits change=="unchecked" event when clicked', async () => {
-    const props = {
-      modelValue: 'checked',
-      value: 'checked',
-      uncheckedValue: 'unchecked',
-    }
-    const wrapper = mount(BFormCheckbox, {
-      props,
-      attachTo: document.body,
+  describe('indeterminate model behavior', () => {
+    it('has attribute "indeterminate" when indeterminate prop is true', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {indeterminate: true},
+      })
+      const $input = wrapper.find('input')
+      expect($input.attributes('indeterminate')).toBeDefined()
     })
 
-    await wrapper.find('input').trigger('click')
-
-    expect(wrapper.emitted('change')).toBeDefined()
-    expect(wrapper.emitted('change')?.length).toBe(1)
-    expect(wrapper.emitted('change')?.[0][0]).toBe('unchecked')
-  })
-
-  it('custom value checked checkbox emits update:modelValue==="unhecked-value" event when clicked', async () => {
-    const wrapper = mount(BFormCheckbox, {
-      props: {
-        modelValue: 'checked',
-        value: 'checked',
-        uncheckedValue: 'unchecked',
-      },
-      attachTo: document.body,
+    it('does not have attribute "indeterminate" when indeterminate prop is false', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {indeterminate: false},
+      })
+      const $input = wrapper.find('input')
+      expect($input.attributes('indeterminate')).toBeUndefined()
     })
 
-    await wrapper.find('input').trigger('click')
+    it('does not have attribute "indeterminate" when indeterminate prop is undefined', () => {
+      const wrapper = mount(BFormCheckbox)
+      const $input = wrapper.find('input')
+      expect($input.attributes('indeterminate')).toBeUndefined()
+    })
 
-    expect(wrapper.emitted('update:modelValue')).toBeDefined()
-    expect(wrapper.emitted('update:modelValue')?.length).toBe(1)
-    expect(wrapper.emitted('update:modelValue')?.[0][0]).toBe('unchecked')
+    it('emits "update:indeterminate=false" when checkbox is changed', async () => {
+      const wrapper = mount(BFormCheckbox)
+      const $input = wrapper.find('input')
+      await $input.trigger('change')
+      expect($input.attributes('indeterminate')).toBeUndefined()
+    })
+
+    it('has attribute "indeterminate" when indeterminate prop is set to true', async () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {indeterminate: false},
+      })
+      await wrapper.setProps({indeterminate: true})
+      const $input = wrapper.find('input')
+      expect($input.attributes('indeterminate')).toBeDefined()
+    })
   })
 })

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
@@ -73,7 +73,7 @@ describe('form-radio', () => {
     expect(wrapper.classes()).not.toContain('form-control-lg')
   })
 
-  it('has does not have class form-control-{type} when prop size is md', () => {
+  it('has class form-control-{type} when prop size is md', () => {
     const wrapper = mount(BFormRadio, {
       props: {size: 'md'},
     })
@@ -296,14 +296,6 @@ describe('form-radio', () => {
     })
     const $input = wrapper.get('input')
     expect($input.attributes('aria-labelledby')).toBeUndefined()
-  })
-
-  it('input element has attr aria-labelledby to be prop ariaLabelledby', () => {
-    const wrapper = mount(BFormRadio, {
-      props: {ariaLabelledby: 'foobar'},
-    })
-    const $input = wrapper.get('input')
-    expect($input.attributes('aria-labelledby')).toBe('foobar')
   })
 
   it('input element has attr aria-labelledby is undefined when prop ariaLabelledby undefined', () => {


### PR DESCRIPTION
# Describe the PR

This PR implements tri-state checkboxes by creating an indeterminate named model that tracks the indeterminate attribute on the control.  This addresses #1611.

I also implemented unit tests for BFormCheckbox that roughly map to the tests for BFormRadiobutton.  I, of course, added some testing around the indeterminate model, and while I was at it some tests around the primary model.

While writing the tests, I found and fixed a typo in ariaLabelledby (the 'b' in by was upper case).

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x ] Bugfix :bug: - `fix(...)`
- [ x ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ x ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
