### PR TITLE
fix(utils): make useId SSR friendly

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import {inject, onMounted, useAttrs, watch} from 'vue'
+import {inject, nextTick, onMounted, useAttrs, watch} from 'vue'
 import {useVModel} from '@vueuse/core'
 import BCollapse from '../BCollapse.vue'
 import {accordionInjectionKey, BvTriggerableEvent} from '../../utils'
@@ -124,12 +124,13 @@ const parentData = inject(accordionInjectionKey, null)
 
 const computedId = useId(() => props.id, 'accordion_item')
 
-onMounted(() => {
-  if (modelValue.value && !parentData?.free.value) {
-    parentData?.setOpenItem(computedId.value)
-  }
+onMounted(async () => {
   if (!modelValue.value && parentData?.openItem.value === computedId.value) {
     modelValue.value = true
+  }
+  await nextTick()
+  if (modelValue.value && !parentData?.free.value && computedId.value) {
+    parentData?.setOpenItem(computedId.value)
   }
 })
 
@@ -139,6 +140,7 @@ watch(
     (modelValue.value = parentData?.openItem.value === computedId.value && !parentData?.free.value)
 )
 watch(modelValue, () => {
-  if (modelValue.value && !parentData?.free.value) parentData?.setOpenItem(computedId.value)
+  if (modelValue.value && !parentData?.free.value && computedId.value)
+    parentData?.setOpenItem(computedId.value)
 })
 </script>

--- a/packages/bootstrap-vue-next/src/components/BAccordion/accordion.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/accordion.spec.ts
@@ -13,7 +13,7 @@ describe('accordion', () => {
 
   it('has computed id by default', async () => {
     const wrapper = mount(BAccordion)
-    expect(wrapper.attributes('id')).not.toBeDefined()
+    expect(wrapper.attributes('id')).toBeUndefined()
     await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BAccordion/accordion.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/accordion.spec.ts
@@ -1,5 +1,6 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
+import {nextTick} from 'vue'
 import BAccordion from './BAccordion.vue'
 
 describe('accordion', () => {
@@ -10,8 +11,10 @@ describe('accordion', () => {
     expect(wrapper.classes()).toContain('accordion')
   })
 
-  it('has computed id by default', () => {
+  it('has computed id by default', async () => {
     const wrapper = mount(BAccordion)
+    expect(wrapper.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BCarousel/carousel.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BCarousel/carousel.spec.ts
@@ -23,7 +23,7 @@ describe('carousel', () => {
 
   it('has attr id', async () => {
     const wrapper = mount(BCarousel)
-    expect(wrapper.attributes('id')).not.toBeDefined()
+    expect(wrapper.attributes('id')).toBeUndefined()
     await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BCarousel/carousel.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BCarousel/carousel.spec.ts
@@ -1,5 +1,6 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
+import {nextTick} from 'vue'
 import BCarousel from './BCarousel.vue'
 // TODO test for newest changes
 describe('carousel', () => {
@@ -20,13 +21,16 @@ describe('carousel', () => {
     expect(wrapper.element.tagName).toBe('DIV')
   })
 
-  it('has attr id', () => {
+  it('has attr id', async () => {
     const wrapper = mount(BCarousel)
+    expect(wrapper.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })
 
-  it('has attr id when prop id', () => {
+  it('has attr id when prop id', async () => {
     const wrapper = mount(BCarousel)
+    await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
     expect(wrapper.attributes('id')).toContain('carousel')
   })

--- a/packages/bootstrap-vue-next/src/components/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse.vue
@@ -61,7 +61,7 @@ const emit = defineEmits<{
 
 type SharedSlotsData = {
   close: () => void
-  id: string
+  id: string | undefined
   open: () => void
   toggle: () => void
   visible: boolean

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
@@ -46,7 +46,7 @@ describe('dropdown', () => {
   it('child ul has attr aria-labelledby to be defined by default', async () => {
     const wrapper = mount(BDropdown)
     const $ul = wrapper.get('ul')
-    expect($ul.attributes('aria-labelledby')).not.toBeDefined()
+    expect($ul.attributes('aria-labelledby')).toBeUndefined()
     await nextTick()
     expect($ul.attributes('aria-labelledby')).toBeDefined()
   })
@@ -95,7 +95,7 @@ describe('dropdown', () => {
   it('first child BButton has prop id', async () => {
     const wrapper = mount(BDropdown)
     const $bbutton = wrapper.getComponent(BButton)
-    expect($bbutton.attributes('id')).not.toBeDefined()
+    expect($bbutton.attributes('id')).toBeUndefined()
     await nextTick()
     expect($bbutton.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
@@ -1,5 +1,6 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
+import {nextTick} from 'vue'
 import BDropdown from './BDropdown.vue'
 import BButton from '../BButton/BButton.vue'
 
@@ -42,9 +43,11 @@ describe('dropdown', () => {
     expect($ul.attributes('role')).toBe('menu')
   })
 
-  it('child ul has attr aria-labelledby to be defined by default', () => {
+  it('child ul has attr aria-labelledby to be defined by default', async () => {
     const wrapper = mount(BDropdown)
     const $ul = wrapper.get('ul')
+    expect($ul.attributes('aria-labelledby')).not.toBeDefined()
+    await nextTick()
     expect($ul.attributes('aria-labelledby')).toBeDefined()
   })
 
@@ -89,9 +92,11 @@ describe('dropdown', () => {
     expect($bbutton.exists()).toBe(true)
   })
 
-  it('first child BButton has prop id', () => {
+  it('first child BButton has prop id', async () => {
     const wrapper = mount(BDropdown)
     const $bbutton = wrapper.getComponent(BButton)
+    expect($bbutton.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect($bbutton.attributes('id')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -93,7 +93,7 @@ describe('form-checkbox', () => {
     it('input element has attr id', async () => {
       const wrapper = mount(BFormCheckbox)
       const $input = wrapper.get('input')
-      expect($input.attributes('id')).not.toBeDefined()
+      expect($input.attributes('id')).toBeUndefined()
       await nextTick()
       expect($input.attributes('id')).toBeDefined()
     })
@@ -399,7 +399,7 @@ describe('form-checkbox', () => {
         props: {plain: false},
       })
       const $label = wrapper.get('label')
-      expect($label.attributes('for')).not.toBeDefined()
+      expect($label.attributes('for')).toBeUndefined()
       await nextTick()
       expect($label.attributes('for')).toBeDefined()
     })

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {nextTick} from 'vue'
 import BFormCheckbox from './BFormCheckbox.vue'
 
 describe('form-checkbox', () => {
@@ -89,9 +90,11 @@ describe('form-checkbox', () => {
       expect($input.exists()).toBe(true)
     })
 
-    it('input element has attr id', () => {
+    it('input element has attr id', async () => {
       const wrapper = mount(BFormCheckbox)
       const $input = wrapper.get('input')
+      expect($input.attributes('id')).not.toBeDefined()
+      await nextTick()
       expect($input.attributes('id')).toBeDefined()
     })
 
@@ -391,11 +394,13 @@ describe('form-checkbox', () => {
       expect($label.exists()).toBe(true)
     })
 
-    it('child label has attr for to be defined by default', () => {
+    it('child label has attr for to be defined by default', async () => {
       const wrapper = mount(BFormCheckbox, {
         props: {plain: false},
       })
       const $label = wrapper.get('label')
+      expect($label.attributes('for')).not.toBeDefined()
+      await nextTick()
       expect($label.attributes('for')).toBeDefined()
     })
 

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -76,6 +76,8 @@ export default defineComponent({
     const ariaDescribedby: string | null = null as string | null
     const breakPoints = ['xs', 'sm', 'md', 'lg', 'xl']
 
+    const computedId = useId(() => props.id, 'form-group')
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const getAlignClasses = (props: any, prefix: string) =>
       breakPoints.reduce((result: string[], breakpoint) => {
@@ -222,6 +224,7 @@ export default defineComponent({
       labelColProps,
       onLegendClick,
       stateClass,
+      computedId,
     }
   },
   render() {
@@ -382,7 +385,7 @@ export default defineComponent({
           'was-validated': this.validatedBoolean,
         },
       ],
-      'id': useId(() => props.id).value,
+      'id': this.computedId,
       'disabled': isFieldset ? this.disabledBoolean : null,
       'role': isFieldset ? null : 'group',
       'aria-invalid': this.computedAriaInvalid,

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -64,7 +64,7 @@ describe('form-group', () => {
 
   it('attr id is defined by default', async () => {
     const wrapper = mount(BFormGroup)
-    expect(wrapper.attributes('id')).not.toBeDefined()
+    expect(wrapper.attributes('id')).toBeUndefined()
     await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {nextTick} from 'vue'
 import BFormGroup from './BFormGroup.vue'
 
 describe('form-group', () => {
@@ -61,8 +62,10 @@ describe('form-group', () => {
     expect(wrapper.classes()).not.toContain('was-validated')
   })
 
-  it('attr id is defined by default', () => {
+  it('attr id is defined by default', async () => {
     const wrapper = mount(BFormGroup)
+    expect(wrapper.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
@@ -29,7 +29,7 @@ describe('form-radio-group', () => {
 
   it('has attr id to be defined', async () => {
     const wrapper = mount(BFormRadioGroup)
-    expect(wrapper.attributes('id')).not.toBeDefined()
+    expect(wrapper.attributes('id')).toBeUndefined()
     await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio-group.spec.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {nextTick} from 'vue'
 import BFormRadioGroup from './BFormRadioGroup.vue'
 import BFormRadio from './BFormRadio.vue'
 
@@ -26,8 +27,10 @@ describe('form-radio-group', () => {
     expect(wrapper.attributes('tabindex')).toBe('-1')
   })
 
-  it('has attr id to be defined', () => {
+  it('has attr id to be defined', async () => {
     const wrapper = mount(BFormRadioGroup)
+    expect(wrapper.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect(wrapper.attributes('id')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
@@ -90,7 +90,7 @@ describe('form-radio', () => {
   it('input element has attr id', async () => {
     const wrapper = mount(BFormRadio)
     const $input = wrapper.get('input')
-    expect($input.attributes('id')).not.toBeDefined()
+    expect($input.attributes('id')).toBeUndefined()
     await nextTick()
     expect($input.attributes('id')).toBeDefined()
   })
@@ -394,7 +394,7 @@ describe('form-radio', () => {
       props: {plain: false},
     })
     const $label = wrapper.get('label')
-    expect($label.attributes('for')).not.toBeDefined()
+    expect($label.attributes('for')).toBeUndefined()
     await nextTick()
     expect($label.attributes('for')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
@@ -1,5 +1,6 @@
 import {afterEach, describe, expect, it} from 'vitest'
 import {enableAutoUnmount, mount} from '@vue/test-utils'
+import {nextTick} from 'vue'
 import BFormRadio from './BFormRadio.vue'
 
 describe('form-radio', () => {
@@ -86,9 +87,11 @@ describe('form-radio', () => {
     expect($input.exists()).toBe(true)
   })
 
-  it('input element has attr id', () => {
+  it('input element has attr id', async () => {
     const wrapper = mount(BFormRadio)
     const $input = wrapper.get('input')
+    expect($input.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect($input.attributes('id')).toBeDefined()
   })
 
@@ -386,11 +389,13 @@ describe('form-radio', () => {
     expect($label.exists()).toBe(true)
   })
 
-  it('child label has attr for to be defined by default', () => {
+  it('child label has attr for to be defined by default', async () => {
     const wrapper = mount(BFormRadio, {
       props: {plain: false},
     })
     const $label = wrapper.get('label')
+    expect($label.attributes('for')).not.toBeDefined()
+    await nextTick()
     expect($label.attributes('for')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
@@ -62,7 +62,7 @@ describe('modal', () => {
       global: {stubs: {teleport: true}},
     })
     const $div = wrapper.get('div')
-    expect($div.attributes('id')).not.toBeDefined()
+    expect($div.attributes('id')).toBeUndefined()
     await nextTick()
     expect($div.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
@@ -1,10 +1,10 @@
 import {DOMWrapper, enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
+import {nextTick} from 'vue'
 import BModal from './BModal.vue'
 import BCloseButton from '../BButton/BCloseButton.vue'
 import BButton from '../BButton/BButton.vue'
 import {BvTriggerableEvent} from '../../utils'
-import {nextTick} from 'vue'
 
 describe('modal', () => {
   enableAutoUnmount(afterEach)
@@ -57,11 +57,13 @@ describe('modal', () => {
     expect($div.attributes('id')).toBe('foo')
   })
 
-  it('div has attr id is defined by default', () => {
+  it('div has attr id is defined by default', async () => {
     const wrapper = mount(BModal, {
       global: {stubs: {teleport: true}},
     })
     const $div = wrapper.get('div')
+    expect($div.attributes('id')).not.toBeDefined()
+    await nextTick()
     expect($div.attributes('id')).toBeDefined()
   })
 

--- a/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
@@ -104,7 +104,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  if (!parentData) return
+  if (!parentData || !computedId.value) return
   parentData.unregisterTab(computedId.value)
 })
 

--- a/packages/bootstrap-vue-next/src/components/collapse.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/collapse.spec.ts
@@ -1,5 +1,6 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
+import {nextTick} from 'vue'
 import BCollapse from './BCollapse.vue'
 
 describe('collapse', () => {
@@ -23,9 +24,12 @@ describe('collapse', () => {
     expect(wrapper.findAll('*')[0].element.tagName).toBe('SPAN')
   })
 
-  it('has default id', () => {
+  it('has default id', async () => {
     const wrapper = mount(BCollapse)
-    expect(wrapper.findAll('*')[0].attributes('id')).toBeDefined()
+    const [el] = wrapper.findAll('*')
+    expect(el.attributes('id')).not.toBeDefined()
+    await nextTick()
+    expect(el.attributes('id')).toBeDefined()
   })
 
   it('has id as prop id', () => {

--- a/packages/bootstrap-vue-next/src/components/collapse.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/collapse.spec.ts
@@ -27,7 +27,7 @@ describe('collapse', () => {
   it('has default id', async () => {
     const wrapper = mount(BCollapse)
     const [el] = wrapper.findAll('*')
-    expect(el.attributes('id')).not.toBeDefined()
+    expect(el.attributes('id')).toBeUndefined()
     await nextTick()
     expect(el.attributes('id')).toBeDefined()
   })

--- a/packages/bootstrap-vue-next/src/composables/useId.ts
+++ b/packages/bootstrap-vue-next/src/composables/useId.ts
@@ -17,7 +17,6 @@ export default (
 
   onMounted(() =>
     nextTick(() => {
-      debugger
       if (!localId.value) {
         localId.value = getId(suffix)
       }

--- a/packages/bootstrap-vue-next/src/composables/useId.ts
+++ b/packages/bootstrap-vue-next/src/composables/useId.ts
@@ -1,5 +1,28 @@
 import {getId} from '../utils'
-import {computed, type ComputedRef, type MaybeRefOrGetter, toValue} from 'vue'
+import {
+  computed,
+  type ComputedRef,
+  type MaybeRefOrGetter,
+  nextTick,
+  onMounted,
+  ref,
+  toValue,
+} from 'vue'
 
-export default (id?: MaybeRefOrGetter<string | undefined>, suffix?: string): ComputedRef<string> =>
-  computed(() => toValue(id) || getId(suffix))
+export default (
+  id?: MaybeRefOrGetter<string | undefined>,
+  suffix?: string
+): ComputedRef<string | null> => {
+  const localId = ref(toValue(id) || null)
+
+  onMounted(() =>
+    nextTick(() => {
+      debugger
+      if (!localId.value) {
+        localId.value = getId(suffix)
+      }
+    })
+  )
+
+  return computed(() => toValue(id) || localId.value)
+}

--- a/packages/bootstrap-vue-next/src/composables/useId.ts
+++ b/packages/bootstrap-vue-next/src/composables/useId.ts
@@ -1,13 +1,5 @@
 import {getId} from '../utils'
-import {
-  computed,
-  type ComputedRef,
-  type MaybeRefOrGetter,
-  nextTick,
-  onMounted,
-  ref,
-  toValue,
-} from 'vue'
+import {computed, type ComputedRef, type MaybeRefOrGetter, onMounted, ref, toValue} from 'vue'
 
 export default (
   id?: MaybeRefOrGetter<string | undefined>,
@@ -15,13 +7,11 @@ export default (
 ): ComputedRef<string | null> => {
   const localId = ref(toValue(id) || null)
 
-  onMounted(() =>
-    nextTick(() => {
-      if (!localId.value) {
-        localId.value = getId(suffix)
-      }
-    })
-  )
+  onMounted(() => {
+    if (!localId.value) {
+      localId.value = getId(suffix)
+    }
+  })
 
   return computed(() => toValue(id) || localId.value)
 }

--- a/packages/bootstrap-vue-next/src/composables/useId.ts
+++ b/packages/bootstrap-vue-next/src/composables/useId.ts
@@ -4,8 +4,8 @@ import {computed, type ComputedRef, type MaybeRefOrGetter, onMounted, ref, toVal
 export default (
   id?: MaybeRefOrGetter<string | undefined>,
   suffix?: string
-): ComputedRef<string | null> => {
-  const localId = ref(toValue(id) || null)
+): ComputedRef<string> => {
+  const localId = ref(toValue(id) || '')
 
   onMounted(() => {
     if (!localId.value) {

--- a/packages/bootstrap-vue-next/src/composables/useId.ts
+++ b/packages/bootstrap-vue-next/src/composables/useId.ts
@@ -4,8 +4,8 @@ import {computed, type ComputedRef, type MaybeRefOrGetter, onMounted, ref, toVal
 export default (
   id?: MaybeRefOrGetter<string | undefined>,
   suffix?: string
-): ComputedRef<string> => {
-  const localId = ref(toValue(id) || '')
+): ComputedRef<string | undefined> => {
+  const localId = ref(toValue(id) || undefined)
 
   onMounted(() => {
     if (!localId.value) {

--- a/packages/bootstrap-vue-next/src/utils/getId.ts
+++ b/packages/bootstrap-vue-next/src/utils/getId.ts
@@ -1,2 +1,6 @@
-export default (suffix = ''): string =>
-  `__BVID__${Math.random().toString().slice(2, 8)}___BV_${suffix}__`
+let uniqueId = 0
+
+export default (suffix = ''): string => {
+  uniqueId++
+  return `__BVID__${uniqueId}___BV_${suffix}__`
+}

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -88,7 +88,7 @@ export const checkboxGroupKey: InjectionKey<{
   switch: Readonly<Ref<boolean>>
   buttonVariant: Readonly<Ref<ButtonVariant | null>>
   form: Readonly<Ref<string | undefined>>
-  name: Readonly<Ref<string>>
+  name: Readonly<Ref<string | undefined>>
   state: Readonly<Ref<boolean | undefined | null>>
   plain: Readonly<Ref<boolean>>
   size: Readonly<Ref<Size>>
@@ -102,7 +102,7 @@ export const radioGroupKey: InjectionKey<{
   modelValue: Ref<RadioValue>
   buttonVariant: Readonly<Ref<ButtonVariant | null>>
   form: Readonly<Ref<string | undefined>>
-  name: Readonly<Ref<string>>
+  name: Readonly<Ref<string | undefined>>
   buttons: Readonly<Ref<boolean>>
   state: Readonly<Ref<boolean | undefined | null>>
   plain: Readonly<Ref<boolean>>
@@ -114,7 +114,7 @@ export const radioGroupKey: InjectionKey<{
 
 // Collapse
 export const collapseInjectionKey: InjectionKey<{
-  id?: Readonly<Ref<string>>
+  id?: Readonly<Ref<string | undefined>>
   readonly close?: () => void
   readonly open?: () => void
   readonly toggle?: () => void
@@ -123,7 +123,7 @@ export const collapseInjectionKey: InjectionKey<{
 }> = Symbol('collapse')
 
 export const dropdownInjectionKey: InjectionKey<{
-  id?: Readonly<Ref<string>>
+  id?: Readonly<Ref<string | undefined>>
   readonly close?: () => void
   readonly open?: () => void
   readonly toggle?: () => void

--- a/packages/bootstrap-vue-next/tests/composables/useId.spec.ts
+++ b/packages/bootstrap-vue-next/tests/composables/useId.spec.ts
@@ -11,11 +11,11 @@ describe('useId blackbox test', () => {
 
   it('returns null when id is undefined', () => {
     const value = useId()
-    expect(value.value).toBeNull()
+    expect(value.value).toBeUndefined()
   })
 
   it('something returned when undefined contains suffix when suffix', () => {
     const value = useId(undefined, 'foobar')
-    expect(value.value).toBeNull()
+    expect(value.value).toBeUndefined()
   })
 })

--- a/packages/bootstrap-vue-next/tests/composables/useId.spec.ts
+++ b/packages/bootstrap-vue-next/tests/composables/useId.spec.ts
@@ -9,13 +9,13 @@ describe('useId blackbox test', () => {
     expect(value.value).toBe('foo')
   })
 
-  it('returns something when id is undefined', () => {
+  it('returns null when id is undefined', () => {
     const value = useId()
-    expect(value.value).toBeDefined()
+    expect(value.value).toBeNull()
   })
 
   it('something returned when undefined contains suffix when suffix', () => {
     const value = useId(undefined, 'foobar')
-    expect(value.value).toContain('foobar')
+    expect(value.value).toBeNull()
   })
 })


### PR DESCRIPTION
# Describe the PR

If component id is not explicitly specified, it is generated using Math.random(), which leads to hydration errors:

```
Hydration attribute mismatch on <input id=​"__BVID__921175___BV_form-check__" class=​"form-check-input" type=​"checkbox">​ 
  - rendered on server: id="__BVID__921175___BV_form-check__"
  - expected on client: id="__BVID__935395___BV_form-check__"
```

Solution: use the bootstrap-vue strategy. If the component id is not specified, leave it empty during SSR and generate it `onMounted`.

Fixes: https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1730

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
