### PR TITLE
docs(BFormCheckbox): Fill out docs and Component Reference

### DIFF
--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -9,16 +9,60 @@ export default {
           prop: 'ariaLabel',
           type: 'string',
           default: undefined,
+          description: 'Sets the value of `aria-label` attribute on the rendered element',
         },
         {
           prop: 'ariaLabelledBy',
           type: 'string',
           default: undefined,
+          description:
+            'The ID of the element that provides a label for this component. Used as the value for the `aria-labelledby` attribute',
+        },
+        {
+          prop: 'autofocus',
+          type: 'Booleanish',
+          default: false,
+          description:
+            'When set to `true`, attempts to auto-focus the control when it is mounted, or re-activated when in a keep-alive. Does not set the `autofocus` attribute on the control',
+        },
+        {
+          prop: 'button',
+          type: 'Booleanish',
+          default: false,
+          description: 'When set, renders the checkbox with the appearance of a button',
+        },
+        {
+          prop: 'buttonGroup',
+          type: 'Booleanish',
+          default: false,
+          description: '',
+        },
+        {
+          prop: 'buttonVariant',
+          type: 'ButtonVariant | null',
+          default: null,
+          description: "Applies one of Bootstrap's theme colors when in `button` mode",
+        },
+        {
+          prop: 'disabled',
+          type: 'Booleanish',
+          default: false,
+          description:
+            "When set to `true`, disables the component's functionality and places it in a disabled state",
         },
         {
           prop: 'form',
           type: 'string',
           default: undefined,
+          description:
+            'ID of the form that the form control belongs to. Sets the `form` attribute on the control',
+        },
+        {
+          prop: 'id',
+          type: 'string',
+          default: undefined,
+          description:
+            'Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed',
         },
         {
           prop: 'indeterminate',
@@ -28,84 +72,68 @@ export default {
             'Set to true to show the checkbox as indeterminate, false to show its normal checked/unchecked.',
         },
         {
+          prop: 'inline',
+          type: 'Booleanish',
+          default: false,
+          description:
+            'When set, renders the checkbox as an inline element rather than as a 100% width block',
+        },
+        {
+          prop: 'modelValue',
+          type: 'CheckboxValue | readonly CheckboxValue[]',
+          default: undefined,
+          description:
+            'The current value of the checkbox(es). Must be an array when there are multiple checkboxes bound to the same v-model',
+        },
+        {
           prop: 'name',
           type: 'string',
           default: undefined,
-        },
-        {
-          prop: 'id',
-          type: 'string',
-          default: undefined,
-        },
-        {
-          prop: 'autofocus',
-          type: 'Booleanish',
-          default: false,
+          description: 'Sets the value of the `name` attribute on the form control',
         },
         {
           prop: 'plain',
           type: 'Booleanish',
           default: false,
-        },
-        {
-          prop: 'button',
-          type: 'Booleanish',
-          default: false,
-        },
-        {
-          prop: 'buttonGroup',
-          type: 'Booleanish',
-          default: false,
-        },
-        {
-          prop: 'switch',
-          type: 'Booleanish',
-          default: false,
-        },
-        {
-          prop: 'disabled',
-          type: 'Booleanish',
-          default: false,
-        },
-        {
-          prop: 'buttonVariant',
-          type: 'ButtonVariant | null',
-          default: undefined,
-        },
-        {
-          prop: 'inline',
-          type: 'Booleanish',
-          default: false,
+          description: 'Render the form control in plain mode, rather than custom styled mode',
         },
         {
           prop: 'required',
           type: 'Booleanish',
           default: undefined,
+          description: 'Adds the `required` attribute to the form control',
         },
         {
           prop: 'size',
           type: 'Size',
           default: undefined,
+          description: "Set the size of the component's appearance. 'sm', 'md' (default), or 'lg'",
         },
         {
           prop: 'state',
           type: 'Booleanish | null',
           default: undefined,
+          description:
+            'Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state',
+        },
+        {
+          prop: 'switch',
+          type: 'Booleanish',
+          default: false,
+          description: 'When set, renders the checkbox with the appearance of a switch',
         },
         {
           prop: 'uncheckedValue',
-          type: 'unknown[] | Set<unknown> | boolean | string | Record<string, unknown> | number | null',
+          type: 'CheckboxValue',
           default: false,
+          description:
+            'Value returned when this checkbox is unchecked. Note not applicable when multiple checkboxes bound to the same v-model array',
         },
         {
           prop: 'value',
-          type: 'unknown[] | Set<unknown> | boolean | string | Record<string, unknown> | number | null',
+          type: 'CheckboxValue',
           default: true,
-        },
-        {
-          prop: 'modelValue',
-          type: 'unknown[] | Set<unknown> | boolean | string | Record<string, unknown> | number | null',
-          default: undefined,
+          description: 'Value returned when this checkbox is checked',
         },
       ],
       emits: [
@@ -118,6 +146,18 @@ export default {
               description:
                 'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
               type: 'CheckboxValue | readonly CheckboxValue[]',
+            },
+          ],
+        },
+        {
+          event: 'update:indeterminate',
+          description: 'Emitted when the indeterminaate state of the checkbox is changed',
+          args: [
+            {
+              arg: 'checked',
+              description:
+                'Value of the indeterminate state - true for indeterminate, false for determinstic state.',
+              type: 'boolean',
             },
           ],
         },
@@ -127,9 +167,9 @@ export default {
           args: [
             {
               arg: 'checked',
+              type: 'CheckboxValue | readonly CheckboxValue[]',
               description:
                 'Value of the checkbox before the event. Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
-              type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
         },
@@ -139,18 +179,17 @@ export default {
           args: [
             {
               arg: 'checked',
+              type: 'CheckboxValue | readonly CheckboxValue[]',
               description:
                 'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
-              type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
         },
       ],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the label of the form checkbox',
         },
       ],
     },
@@ -158,147 +197,190 @@ export default {
       component: 'BFormCheckboxGroup',
       props: [
         {
-          prop: 'id',
-          type: 'string',
-          default: undefined,
-        },
-        {
-          prop: 'form',
-          type: 'string',
-          default: undefined,
-        },
-        {
-          prop: 'modelValue',
-          type: '(unknown[] | Set<unknown> | boolean | string | Record<string, unknown> | number | null)[]',
-          default: '() => []',
-        },
-        {
           prop: 'ariaInvalid',
           type: 'AriaInvalid',
           default: undefined,
+          description:
+            'Sets the `aria-invalid` attribute value on the wrapper element. When not provided, the `state` prop will control the attribute',
         },
         {
           prop: 'autofocus',
           type: 'Booleanish',
           default: false,
+          description:
+            'When set to `true`, attempts to auto-focus the control when it is mounted, or re-activated when in a keep-alive. Does not set the `autofocus` attribute on the control',
         },
         {
           prop: 'buttonVariant',
           type: 'ButtonVariant | null',
           default: 'secondary',
+          description:
+            'Specifies the Bootstrap contextual color theme variant the apply to the button style checkboxes',
         },
         {
           prop: 'buttons',
           type: 'Booleanish',
           default: false,
+          description: 'When set, renderes the checkboxes in this group with button styling',
         },
         {
           prop: 'disabled',
           type: 'Booleanish',
           default: false,
+          description:
+            "When set to `true`, disables the component's functionality and places it in a disabled state",
         },
         {
           prop: 'disabledField',
           type: 'string',
           default: 'disabled',
+          description:
+            'Field name in the `options` array that should be used for the disabled state',
+        },
+        {
+          prop: 'form',
+          type: 'string',
+          default: undefined,
+          description:
+            'ID of the form that the form control belongs to. Sets the `form` attribute on the control',
         },
         {
           prop: 'htmlField',
           type: 'string',
           default: 'html',
+          description:
+            'Field name in the `options` array that should be used for the html label instead of text field',
+        },
+        {
+          prop: 'id',
+          type: 'string',
+          default: undefined,
+          description:
+            'Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed',
+        },
+        {
+          prop: 'modelValue',
+          type: 'readonly CheckboxValue[]',
+          default: '() => []',
+          description:
+            'The current value of the checked checkboxes in the group. Must be an array when there are multiple checkboxes',
         },
         {
           prop: 'name',
           type: 'string',
           default: undefined,
+          description: 'Sets the value of the `name` attribute on the form control',
         },
         {
           prop: 'options',
-          type: '(string | number | Record<string, unknown>)[]',
+          type: 'readonly CheckboxOptionRaw[]',
           default: '() => []',
+          description: 'Array of items to render in the component',
         },
         {
           prop: 'plain',
           type: 'Booleanish',
           default: false,
+          description: 'Render the form control in plain mode, rather than custom styled mode',
         },
         {
           prop: 'required',
           type: 'Booleanish',
           default: false,
+          description: 'Adds the `required` attribute to the form control',
         },
         {
           prop: 'size',
           type: 'Size',
           default: 'md',
+          description: "Set the size of the component's appearance. 'sm', 'md' (default), or 'lg'",
         },
         {
           prop: 'stacked',
           type: 'Booleanish',
           default: false,
+          description: 'When set, renders the checkbox group in stacked mode',
         },
         {
           prop: 'state',
           type: 'Booleanish | null',
-          default: undefined,
+          default: null,
+          description:
+            'Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state',
         },
         {
           prop: 'switches',
           type: 'Booleanish',
           default: false,
+          description: 'When set, renders the checkboxes in the group with switch styling',
         },
         {
           prop: 'textField',
           type: 'string',
           default: 'text',
+          description: 'Field name in the `options` array that should be used for the text label',
         },
         {
           prop: 'validated',
           type: 'Booleanish',
           default: false,
+          description: 'When set, adds the Bootstrap class `was-validated` to the group wrapper',
         },
         {
           prop: 'valueField',
           type: 'string',
           default: 'value',
+          description: 'Field name in the `options` array that should be used for the value',
         },
       ],
       emits: [
         {
-          event: 'input',
-          description: '',
+          event: 'update:modelValue',
+          description: 'Emitted when the selected value(s) are changed',
           args: [
             {
-              arg: 'input',
-              description: '',
-              type: 'string | number | Record<string, unknown>[]',
+              arg: 'update:modelValue',
+              type: 'CheckboxValue[]',
+              description: 'Value of the checkboxes. Value will be an array.',
             },
           ],
         },
         {
-          event: 'update:modelValue',
-          description: '',
+          event: 'input',
+          description: 'Emitted before the selected value(s) are changed',
           args: [
             {
-              arg: 'update:modelValue',
-              description: '',
-              type: 'string | number | Record<string, unknown>[]',
+              arg: 'input',
+              type: 'CheckboxValue[]',
+              description: 'Value of the checkboxes before the event. Value will be an array.',
             },
           ],
         },
         {
           event: 'change',
-          description: '',
+          description: 'Emitted when the selected value(s) are changed',
           args: [
             {
               arg: 'change',
-              description: '',
-              type: 'string | number | Record<string, unknown>[]',
+              type: 'CheckboxValue[]',
+              description: 'Value of the checkboxes. Value will be an array.',
             },
           ],
         },
       ],
-      slots: [],
+      slots: [
+        {
+          name: 'default',
+          description: 'Content (form checkboxes) to place in the form checkbox group',
+          scope: [],
+        },
+        {
+          name: 'first',
+          description:
+            'Slot to place for checkboxes so that they appear before checks generated from options prop',
+          scope: [],
+        },
+      ],
     },
   ],
 }

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -14,6 +14,132 @@ For cross browser consistency, `BFormCheckboxGroup` and `BFormCheckbox` use Boot
 
 </div>
 
+**Example 1:** Single checkbox
+
+<HighlightCard>
+  <div>
+    <BFormCheckbox
+      id="checkbox-1"
+      v-model="status"
+      name="checkbox-1"
+      value="accepted"
+      unchecked-value="not_accepted"
+    >
+      I accept the terms and use
+    </BFormCheckbox>
+    <div>
+      State: <strong>{{ status }}</strong>
+    </div>
+  </div>
+  <template #html>
+
+```vue
+<template>
+  <div>
+    <BFormCheckbox
+      id="checkbox-1"
+      v-model="status"
+      name="checkbox-1"
+      value="accepted"
+      unchecked-value="not_accepted"
+    >
+      I accept the terms and use
+    </BFormCheckbox>
+
+    <div>
+      State: <strong>{{ status }}</strong>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const status = ref(false)
+</script>
+```
+
+  </template>
+</HighlightCard>
+
+**Example 2:** Multiple choice checkboxes
+
+<HighlightCard>
+  <div>
+    <b-form-group label="Using options array:" v-slot="{ ariaDescribedby }">
+      <b-form-checkbox-group
+        id="checkbox-group-1"
+        v-model="selected"
+        :options="options"
+        :aria-describedby="ariaDescribedby"
+        name="flavour-1"
+      ></b-form-checkbox-group>
+    </b-form-group>
+    <b-form-group label="Using sub-components:" v-slot="{ ariaDescribedby }">
+      <b-form-checkbox-group
+        id="checkbox-group-2"
+        v-model="selected"
+        :aria-describedby="ariaDescribedby"
+        name="flavour-2"
+      >
+        <b-form-checkbox value="orange">Orange</b-form-checkbox>
+        <b-form-checkbox value="apple">Apple</b-form-checkbox>
+        <b-form-checkbox value="pineapple">Pineapple</b-form-checkbox>
+        <b-form-checkbox value="grape">Grape</b-form-checkbox>
+      </b-form-checkbox-group>
+    </b-form-group>
+    <div>Selected: <strong>{{ selected }}</strong></div>
+  </div>
+
+<template #html>
+
+```vue
+<template>
+  <div>
+    <b-form-group label="Using options array:" v-slot="{ariaDescribedby}">
+      <b-form-checkbox-group
+        id="checkbox-group-1"
+        v-model="selected"
+        :options="options"
+        :aria-describedby="ariaDescribedby"
+        name="flavour-1"
+      ></b-form-checkbox-group>
+    </b-form-group>
+
+    <b-form-group label="Using sub-components:" v-slot="{ariaDescribedby}">
+      <b-form-checkbox-group
+        id="checkbox-group-2"
+        v-model="selected"
+        :aria-describedby="ariaDescribedby"
+        name="flavour-2"
+      >
+        <b-form-checkbox value="orange">Orange</b-form-checkbox>
+        <b-form-checkbox value="apple">Apple</b-form-checkbox>
+        <b-form-checkbox value="pineapple">Pineapple</b-form-checkbox>
+        <b-form-checkbox value="grape">Grape</b-form-checkbox>
+      </b-form-checkbox-group>
+    </b-form-group>
+
+    <div>
+      Selected: <strong>{{ selected }}</strong>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const selected = ref([])
+
+const options = [
+  {text: 'Orange', value: 'orange'},
+  {text: 'Apple', value: 'apple'},
+  {text: 'Pineapple', value: 'pineapple'},
+  {text: 'Grape', value: 'grape'},
+]
+</script>
+```
+
+  </template>
+</HighlightCard>
+
 ## Checkbox group options array
 
 `options` can be an array of strings or objects. Available fields:
@@ -130,6 +256,7 @@ If you want to customize the field property names (for example using `name` fiel
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
 const checkEx2Selected = ref(['A'])
 
 const checkEx2Options = [
@@ -186,6 +313,8 @@ Note: the unchecked-value prop does not affect the native `<input>`'s `value` at
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const availableCars = ['BMW', 'Mercedes', 'Toyota']
 const selectedCars = ref([])
 
@@ -256,56 +385,69 @@ or if using individual checkboxes not inside a `BFormCheckboxGroup`, set the `in
   </BFormCheckbox>
   <template #html>
 
-```vue-html
-<div class="my-2">
-  <label>Form-checkbox-group inline checkboxes (default)</label>
-</div>
+```vue
+<template>
+  <div class="my-2">
+    <label>Form-checkbox-group inline checkboxes (default)</label>
+  </div>
 
-<BFormCheckboxGroup
-  v-model="checkEx3Selected"
-  :options="checkEx3Options"
-  name="flavour-1a"
-/>
+  <BFormCheckboxGroup
+    v-model="checkEx3Selected"
+    :options="checkEx3Options"
+    name="flavour-1a"
+  />
 
-<div class="my-2">
-  <label>Form-checkbox-group stacked checkboxes</label>
-</div>
+  <div class="my-2">
+    <label>Form-checkbox-group stacked checkboxes</label>
+  </div>
 
-<BFormCheckboxGroup
-  v-model="checkEx3Selected"
-  :options="checkEx3Options"
-  name="flavour-2a"
-  stacked
-/>
+  <BFormCheckboxGroup
+    v-model="checkEx3Selected"
+    :options="checkEx3Options"
+    name="flavour-2a"
+    stacked
+  />
 
-<div class="my-2">
-  <label>Individual stacked checkboxes (default)</label>
-</div>
+  <div class="my-2">
+    <label>Individual stacked checkboxes (default)</label>
+  </div>
 
-<BFormCheckbox
-  v-for="option in checkEx3Options"
-  v-model="checkEx3Selected"
-  :key="option.value"
-  :value="option.value"
-  name="flavour-3a"
->
-  {{ option.text }}
-</BFormCheckbox>
+  <BFormCheckbox
+    v-for="option in checkEx3Options"
+    v-model="checkEx3Selected"
+    :key="option.value"
+    :value="option.value"
+    name="flavour-3a"
+  >
+    {{ option.text }}
+  </BFormCheckbox>
 
-<div class="my-2">
-  <label>Individual inline checkboxes</label>
-</div>
+  <div class="my-2">
+    <label>Individual inline checkboxes</label>
+  </div>
 
-<BFormCheckbox
-  v-for="option in checkEx3Options"
-  v-model="checkEx3Selected"
-  :key="option.value"
-  :value="option.value"
-  name="flavour-4a"
-  inline
->
-  {{ option.text }}
-</BFormCheckbox>
+  <BFormCheckbox
+    v-for="option in checkEx3Options"
+    v-model="checkEx3Selected"
+    :key="option.value"
+    :value="option.value"
+    name="flavour-4a"
+    inline
+  >
+    {{ option.text }}
+  </BFormCheckbox>
+</tempalte>
+<script setup lang='ts'>
+import {ref} from 'vue'
+const checkEx3Selected = ref(['A'])
+
+const checkEx3Options = [
+  { text: 'Orange', value: 'orange' },
+  { text: 'Apple', value: 'apple' },
+  { text: 'Pineapple', value: 'pineapple' },
+  { text: 'Grape', value: 'grape' }
+]
+</script>
 ```
 
   </template>
@@ -343,26 +485,32 @@ A single checkbox can be rendered with a button appearance by setting the prop b
 Change the button variant by setting the button-variant prop to one of the standard Bootstrap button variants (see `BButton` for supported variants). The default variant is secondary.
 
 <HighlightCard>
-  <BFormCheckbox v-model="button1Checked" class="m-2" button>
-    Button Checkbox (Checked: {{ button1Checked }})
-  </BFormCheckbox>
-  <BFormCheckbox v-model="button2Checked" class="m-2" button button-variant="danger">
-    Button Checkbox (Checked: {{ button2Checked }})
-  </BFormCheckbox>
+  <div class="hstack gap-3">
+    <BFormCheckbox v-model="button1Checked" button>
+      Button Checkbox (Checked: {{ button1Checked }})
+    </BFormCheckbox>
+    <BFormCheckbox v-model="button2Checked" button button-variant="danger">
+      Button Checkbox (Checked: {{ button2Checked }})
+    </BFormCheckbox>
+  </div>
   <template #html>
 
 ```vue
 <template>
-  <BFormCheckbox v-model="button1Checked" button>
-    Button Checkbox (Checked: {{ button1Checked }})
-  </BFormCheckbox>
+  <div class="hstack gap-3">
+    <BFormCheckbox v-model="button1Checked" button>
+      Button Checkbox (Checked: {{ button1Checked }})
+    </BFormCheckbox>
 
-  <BFormCheckbox v-model="button2Checked" button button-variant="danger">
-    Button Checkbox (Checked: {{ button2Checked }})
-  </BFormCheckbox>
+    <BFormCheckbox v-model="button2Checked" button button-variant="danger">
+      Button Checkbox (Checked: {{ button2Checked }})
+    </BFormCheckbox>
+  </div>
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const button1Checked = ref(false)
 const button2Checked = ref(false)
 </script>
@@ -444,13 +592,15 @@ variants). The default `button-variant` is `secondary`.
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const checkEx3Selected = ref(['A'])
 
 const checkEx3Options = [
-  {item: 'A', name: 'Option A'},
-  {item: 'B', name: 'Option B'},
-  {item: 'D', name: 'Option C', notEnabled: true},
-  {item: {d: 1}, name: 'Option D'},
+  {text: 'Orange', value: 'orange'},
+  {text: 'Apple', value: 'apple'},
+  {text: 'Pineapple', value: 'pineapple'},
+  {text: 'Grape', value: 'grape'},
 ]
 </script>
 ```
@@ -481,6 +631,8 @@ A single checkbox can be rendered with a switch appearance by setting the prop s
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const switchChecked = ref(false)
 </script>
 ```
@@ -534,6 +686,8 @@ Render groups of checkboxes with the look of a switches by setting the prop `swi
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const groupSwitchSelected = ref([])
 
 const groupSwitchOptions = [
@@ -599,27 +753,32 @@ by setting the `plain` prop.
   />
   <template #html>
 
-```vue-html
-<div class="my-2">
-  <label>Plain inline checkboxes</label>
-</div>
+```vue
+<template>
+  <div class="my-2">
+    <label>Plain inline checkboxes</label>
+  </div>
 
-<BFormCheckboxGroup
-  v-model="groupSwitchSelected"
-  :options="groupSwitchOptions"
-  plain
-/>
+  <BFormCheckboxGroup v-model="groupSwitchSelected" :options="groupSwitchOptions" plain />
 
-<div class="my-2">
-  <label>Plain stacked checkboxes</label>
-</div>
+  <div class="my-2">
+    <label>Plain stacked checkboxes</label>
+  </div>
 
-<BFormCheckboxGroup
-  v-model="groupSwitchSelected"
-  :options="groupSwitchOptions"
-  plain
-  stacked
-/>
+  <BFormCheckboxGroup v-model="groupSwitchSelected" :options="groupSwitchOptions" plain stacked />
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+
+const groupSwitchSelected = ref([])
+const groupSwitchOptions = [
+  {text: 'Red', value: 'red'},
+  {text: 'Green', value: 'green'},
+  {text: 'Yellow (disabled)', value: 'yellow', disabled: true},
+  {text: 'Blue', value: 'blue'},
+]
+</script>
 ```
 
   </template>
@@ -676,6 +835,8 @@ To apply one of the contextual state icons on `BFormCheckbox`, set the `state` p
 </template>
 
 <script setup lang="ts">
+import {computed, ref} from 'vue'
+
 const contextualStateOptions = [
   {text: 'First Check', value: 'first'},
   {text: 'Second Check', value: 'second'},
@@ -746,8 +907,121 @@ The indeterminate state is **visual only**. The checkbox is still either checked
 </template>
 
 <script setup lang="ts">
+import {ref} from 'vue'
+
 const intermChecked = ref(true)
 const indeterminate = ref(true)
+</script>
+```
+
+  </template>
+</HighlightCard>
+
+**Indeterminate checkbox use-case example:**
+
+<HighlightCard>
+  <div>
+        <BFormGroup>
+          <template #label>
+            <b>Choose your flavors:</b><br />
+            <BFormCheckbox
+              v-model="allSelected"
+              v-model:indeterminate="asIndeterminate"
+              aria-describedby="flavors"
+              aria-controls="flavors"
+              @change="toggleAll"
+            >
+              {{ allSelected ? 'Un-select All' : 'Select All' }}
+            </BFormCheckbox>
+          </template>
+          <template #default="{ariaDescribedby}">
+            <BFormCheckboxGroup
+              id="flavors"
+              v-model="flavorSelected"
+              :options="flavors"
+              :aria-describedby="ariaDescribedby"
+              name="flavors"
+              class="ms-4"
+              aria-label="Individual flavors"
+              stacked
+            />
+          </template>
+        </BFormGroup>
+        <div>
+          Selected: <strong>{{ flavorSelected }}</strong
+          ><br />
+          All Selected: <strong>{{ allSelected }}</strong
+          ><br />
+          Indeterminate: <strong>{{ asIndeterminate }}</strong>
+        </div>
+  </div>
+  <template #html>
+
+```vue
+<template>
+  <BFormGroup>
+    <template #label>
+      <b>Choose your flavors:</b><br />
+      <BFormCheckbox
+        v-model="allSelected"
+        v-model:indeterminate="asIndeterminate"
+        aria-describedby="flavors"
+        aria-controls="flavors"
+        @change="toggleAll"
+      >
+        {{ allSelected ? 'Un-select All' : 'Select All' }}
+      </BFormCheckbox>
+    </template>
+
+    <template #default="{ariaDescribedby}">
+      <BFormCheckboxGroup
+        id="flavors"
+        v-model="flavorSelected"
+        :options="flavors"
+        :aria-describedby="ariaDescribedby"
+        name="flavors"
+        class="ms-4"
+        aria-label="Individual flavors"
+        stacked
+      />
+    </template>
+  </BFormGroup>
+
+  <div>
+    Selected: <strong>{{ flavorSelected }}</strong
+    ><br />
+    All Selected: <strong>{{ allSelected }}</strong
+    ><br />
+    Indeterminate: <strong>{{ asIndeterminate }}</strong>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {ref, watch} from 'vue'
+import {type CheckboxValue} from 'bootstrap-vue-next'
+
+const flavors = ['Orange', 'Grape', 'Apple', 'Lime', 'Very Berry']
+const flavorSelected = ref<string[]>([])
+const allSelected = ref(false)
+const asIndeterminate = ref(false)
+
+const toggleAll = (checked: CheckboxValue | CheckboxValue[]) => {
+  flavorSelected.value = checked ? flavors.slice() : []
+}
+
+watch(flavorSelected, (newValue: string[]) => {
+  // Handle changes in individual flavor checkboxes
+  if (newValue.length === 0) {
+    asIndeterminate.value = false
+    allSelected.value = false
+  } else if (newValue.length === flavors.length) {
+    asIndeterminate.value = false
+    allSelected.value = true
+  } else {
+    asIndeterminate.value = true
+    allSelected.value = false
+  }
+})
 </script>
 ```
 
@@ -758,11 +1032,21 @@ const indeterminate = ref(true)
 
 <script setup lang="ts">
 import {data} from '../../data/components/formCheckbox.data'
-import {ref, computed} from 'vue'
+import {computed, ref, watch} from 'vue'
 import ComponentReference from '../../components/ComponentReference.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarning.vue'
-import {BButton, BFormCheckboxGroup, BFormCheckbox, BCard, BCardBody, BAlert} from 'bootstrap-vue-next'
+import {BButton, BFormCheckboxGroup, BFormCheckbox, BFormGroup, BCard, BCardBody, BAlert} from 'bootstrap-vue-next'
+
+const status = ref(false);
+const selected = ref([]);
+
+const options = [
+  { text: 'Orange', value: 'orange' },
+  { text: 'Apple', value: 'apple' },
+  { text: 'Pineapple', value: 'pineapple' },
+  { text: 'Grape', value: 'grape' }
+]
 
 const button1Checked = ref(false);
 const button2Checked = ref(false);
@@ -806,4 +1090,27 @@ const contextualStateOptions = [
 
 const contextualSelected = ref([]);
 const contextualState = computed(() => contextualSelected.value.length === 2);
+
+const flavors = ['Orange', 'Grape', 'Apple', 'Lime', 'Very Berry']
+const flavorSelected = ref<string[]>([])
+const allSelected = ref(false)
+const asIndeterminate = ref(false)
+
+const toggleAll = (checked: CheckboxValue | CheckboxValue[]) => {
+  flavorSelected.value = checked ? flavors.slice() : []
+}
+
+watch(flavorSelected, (newValue: string[]) => {
+  // Handle changes in individual flavor checkboxes
+  if (newValue.length === 0) {
+    asIndeterminate.value = false
+    allSelected.value = false
+  } else if (newValue.length === flavors.length) {
+    asIndeterminate.value = false
+    allSelected.value = true
+  } else {
+    asIndeterminate.value = true
+    allSelected.value = false
+  }
+})
 </script>


### PR DESCRIPTION
# Describe the PR

Fill out the docs for BFormCheckbox and BFormCheckboxGroup.
- Add the initial two examples from BSV legacy
- Add in the indeterminate checkbox use-case example
- Completely fill out the component reference data for both components
- Fix a number of small bugs in the docs

The thing I didn't fill out in the component reference is the buttonGroup booleanish value.  I need to understand how that works so I can document it, and I don't understand.  It appears to cause the rendering of the component to be skipped, overriding the value coming from the parent group, but I don't see how that works.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
