### PR TITLE
fix(BAvatar): replace useToNumber in useAvatarSize composable

### DIFF
--- a/apps/playground/src/components/Comps/TAvatar.vue
+++ b/apps/playground/src/components/Comps/TAvatar.vue
@@ -1,6 +1,6 @@
 <template>
   <BContainer fluid>
-    <BRow>
+    <!-- <BRow>
       <BCol>
         <BAvatar button class="me-1" icon="person-fill" variant="secondary" />
       </BCol>
@@ -16,7 +16,7 @@
       <BCol>
         <BAvatar button class="me-5" src="https://placekitten.com/300/300" />
       </BCol>
-    </BRow>
+    </BRow> -->
 
     <BRow>
       <BCol>

--- a/packages/bootstrap-vue-next/src/components/BAvatar/avatar.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/avatar.spec.ts
@@ -43,5 +43,37 @@ describe('avatar', () => {
     expect(wrapper.element.tagName).toBe('SPAN')
   })
 
+  it('`size` prop should work as expected', () => {
+    const wrapper1 = mount(BAvatar)
+    expect(wrapper1.attributes('style')).toEqual(undefined)
+
+    const wrapper2 = mount(BAvatar, {props: {size: 'sm'}})
+    expect(wrapper2.attributes('style')).toEqual('')
+    expect(wrapper2.classes()).toContain('b-avatar-sm')
+
+    const wrapper3 = mount(BAvatar, {props: {size: 'md'}})
+    expect(wrapper3.attributes('style')).toEqual('')
+    expect(wrapper3.classes()).not.toContain('b-avatar-md')
+
+    const wrapper4 = mount(BAvatar, {props: {size: 'lg'}})
+    expect(wrapper4.attributes('style')).toEqual('')
+    expect(wrapper4.classes()).toContain('b-avatar-lg')
+
+    const wrapper5 = mount(BAvatar, {props: {size: 20}})
+    expect(wrapper5.attributes('style')).toEqual('width: 20px; height: 20px;')
+
+    const wrapper6 = mount(BAvatar, {props: {size: '24.5'}})
+    expect(wrapper6.attributes('style')).toEqual('width: 24.5px; height: 24.5px;')
+
+    const wrapper7 = mount(BAvatar, {props: {size: '5em'}})
+    expect(wrapper7.attributes('style')).toEqual('width: 5em; height: 5em;')
+
+    const wrapper8 = mount(BAvatar, {props: {size: '36px'}})
+    expect(wrapper8.attributes('style')).toEqual('width: 36px; height: 36px;')
+
+    const wrapper9 = mount(BAvatar, {props: {size: '0x123'}})
+    expect(wrapper9.attributes('style')).toEqual('')
+  })
+
   // TODO not done
 })

--- a/packages/bootstrap-vue-next/src/components/BAvatar/avatar.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/avatar.spec.ts
@@ -43,36 +43,43 @@ describe('avatar', () => {
     expect(wrapper.element.tagName).toBe('SPAN')
   })
 
-  it('`size` prop should work as expected', () => {
-    const wrapper1 = mount(BAvatar)
-    expect(wrapper1.attributes('style')).toEqual(undefined)
+  it('has class `b-avatar-sm` when prop size is `sm`', () => {
+    const wrapper = mount(BAvatar, {props: {size: 'sm'}})
+    expect(wrapper.attributes('style')).toEqual('')
+    expect(wrapper.classes()).toContain('b-avatar-sm')
+  })
 
-    const wrapper2 = mount(BAvatar, {props: {size: 'sm'}})
-    expect(wrapper2.attributes('style')).toEqual('')
-    expect(wrapper2.classes()).toContain('b-avatar-sm')
+  it('does not include default class `b-avatar-md` when prop size is `md`', () => {
+    const wrapper = mount(BAvatar, {props: {size: 'md'}})
+    expect(wrapper.attributes('style')).toEqual('')
+    expect(wrapper.classes()).not.toContain('b-avatar-md')
+  })
 
-    const wrapper3 = mount(BAvatar, {props: {size: 'md'}})
-    expect(wrapper3.attributes('style')).toEqual('')
-    expect(wrapper3.classes()).not.toContain('b-avatar-md')
+  it('has class `b-avatar-lg` when prop size is `lg`', () => {
+    const wrapper = mount(BAvatar, {props: {size: 'lg'}})
+    expect(wrapper.attributes('style')).toEqual('')
+    expect(wrapper.classes()).toContain('b-avatar-lg')
+  })
 
-    const wrapper4 = mount(BAvatar, {props: {size: 'lg'}})
-    expect(wrapper4.attributes('style')).toEqual('')
-    expect(wrapper4.classes()).toContain('b-avatar-lg')
+  it('converts to `px` when prop size is a numeric value', () => {
+    const wrapper1 = mount(BAvatar, {props: {size: 20}})
+    expect(wrapper1.attributes('style')).toEqual('width: 20px; height: 20px;')
+    const wrapper2 = mount(BAvatar, {props: {size: '24.5'}})
+    expect(wrapper2.attributes('style')).toEqual('width: 24.5px; height: 24.5px;')
+  })
 
-    const wrapper5 = mount(BAvatar, {props: {size: 20}})
-    expect(wrapper5.attributes('style')).toEqual('width: 20px; height: 20px;')
+  it('applies correct styles when prop size ends in `px`, `em` or `rem`', () => {
+    const wrapper1 = mount(BAvatar, {props: {size: '5px'}})
+    expect(wrapper1.attributes('style')).toEqual('width: 5px; height: 5px;')
+    const wrapper2 = mount(BAvatar, {props: {size: '5em'}})
+    expect(wrapper2.attributes('style')).toEqual('width: 5em; height: 5em;')
+    const wrapper3 = mount(BAvatar, {props: {size: '5rem'}})
+    expect(wrapper3.attributes('style')).toEqual('width: 5rem; height: 5rem;')
+  })
 
-    const wrapper6 = mount(BAvatar, {props: {size: '24.5'}})
-    expect(wrapper6.attributes('style')).toEqual('width: 24.5px; height: 24.5px;')
-
-    const wrapper7 = mount(BAvatar, {props: {size: '5em'}})
-    expect(wrapper7.attributes('style')).toEqual('width: 5em; height: 5em;')
-
-    const wrapper8 = mount(BAvatar, {props: {size: '36px'}})
-    expect(wrapper8.attributes('style')).toEqual('width: 36px; height: 36px;')
-
-    const wrapper9 = mount(BAvatar, {props: {size: '0x123'}})
-    expect(wrapper9.attributes('style')).toEqual('')
+  it('does not apply styles when prop size is a non-decimal numeric value', () => {
+    const wrapper = mount(BAvatar, {props: {size: '0x123'}})
+    expect(wrapper.attributes('style')).toEqual('')
   })
 
   // TODO not done

--- a/packages/bootstrap-vue-next/src/composables/useAvatarSize.ts
+++ b/packages/bootstrap-vue-next/src/composables/useAvatarSize.ts
@@ -1,14 +1,12 @@
 import {computed, type MaybeRefOrGetter, toRef} from 'vue'
 import type {LiteralUnion, Numberish, Size} from '../types'
-import {useToNumber} from '@vueuse/core'
+import {RX_NUMBER} from '../constants/regex'
 
 export default (el: MaybeRefOrGetter<LiteralUnion<Size, Numberish> | undefined>) => {
   const val = toRef(el)
 
-  const num = useToNumber(() => val.value ?? NaN)
-
   return computed(() =>
     // If num is non-numeric, return val as-is (sm, md, lg, undefined or any other custom value), otherwise return num as a px value
-    Number.isNaN(num.value) ? val.value : `${num.value}px`
+    RX_NUMBER.test(String(val.value)) ? `${Number(val.value)}px` : val.value
   )
 }

--- a/packages/bootstrap-vue-next/src/composables/useAvatarSize.ts
+++ b/packages/bootstrap-vue-next/src/composables/useAvatarSize.ts
@@ -1,12 +1,10 @@
-import {computed, type MaybeRefOrGetter, toRef} from 'vue'
+import {computed, type MaybeRefOrGetter, toValue} from 'vue'
 import type {LiteralUnion, Numberish, Size} from '../types'
 import {RX_NUMBER} from '../constants/regex'
 
-export default (el: MaybeRefOrGetter<LiteralUnion<Size, Numberish> | undefined>) => {
-  const val = toRef(el)
-
-  return computed(() =>
+export default (el: MaybeRefOrGetter<LiteralUnion<Size, Numberish> | undefined>) =>
+  computed(() => {
+    const value = toValue(el)
     // If num is non-numeric, return val as-is (sm, md, lg, undefined or any other custom value), otherwise return num as a px value
-    RX_NUMBER.test(String(val.value)) ? `${Number(val.value)}px` : val.value
-  )
-}
+    return RX_NUMBER.test(String(value)) ? `${Number(value)}px` : value
+  })

--- a/packages/bootstrap-vue-next/src/constants/regex.ts
+++ b/packages/bootstrap-vue-next/src/constants/regex.ts
@@ -1,5 +1,6 @@
 export const RX_UNDERSCORE = /_/g
 export const RX_LOWER_UPPER = /([a-z])([A-Z])/g
+export const RX_NUMBER = /^[0-9]*\.?[0-9]+$/
 export const RX_START_SPACE_WORD = /(\s|^)(\w)/g
 export const RX_FIRST_START_SPACE_WORD = /(\s|^)(\w)/
 export const RX_SPACE_SPLIT = /\s+/


### PR DESCRIPTION
# Describe the PR
Passing a string value that ends in `em` or`rem` to the `size` prop `BAvatar` converts them to `px` instead of their expected values.

The `BAvatar` component uses the `size` prop to change its size. The component applies styles based on the `size` prop. This prop does not properly parse string values that end in `em` and `rem` because of the `useAvatarSize` composable. This composable uses [VueUse's `useToNumber`](https://vueuse.org/shared/useToNumber/) method to determine if the `size` prop is a numeric value or not. [`useToNumber` source code](https://github.com/vueuse/vueuse/blob/4f84d63730e18d8408a9f05f72809f3de4a9315e/packages/shared/useToNumber/index.ts#L12) uses the [`parseFloat` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat) method, which according to the docs:

>However, parseFloat() is more lenient than Number() because it ignores trailing invalid characters, which would cause Number() to return NaN

This means trailing characters like `36rem` or `15em` will be parsed as `36` and `15` respectively, resulting in a valid number and having `px` appended to these characters.

This PR will add a new constant to the regex file so that we can a regex test to check values before they are parsed. We will then use the `Number` constructor and convert the value to a number once it passes the test. The regex test will also prevent values that have non-decimal literals with 0x, 0b, or 0o prefixes.

**Related: #1748** 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
