### PR TITLE
fix(nuxt): optimize `bootstrap-vue-next`

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -56,6 +56,10 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.css.push('bootstrap-vue-next/dist/bootstrap-vue-next.css')
 
+    nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps || {}
+    nuxt.options.vite.optimizeDeps.include = nuxt.options.vite.optimizeDeps.include || []
+    nuxt.options.vite.optimizeDeps.include.push('bootstrap-vue-next')
+
     useComponents()
 
     if (Object.values(normalizedComposableOptions).some((el) => el === true)) {


### PR DESCRIPTION
# Describe the PR

resolves https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1758
see https://github.com/nuxt/nuxt/issues/25735

The issue is not that the plugin is not being called.

![CleanShot 2024-02-11 at 20 46 05@2x](https://github.com/nuxt/nuxt/assets/28706372/3217df97-21b4-4df2-bc78-8257aceb3fa8)

The problem is that Vite optimises the dependencies and so there are effectively two versions of bootstrap vue in your project, one registered and one not registered. (This is why it works when you remove the `node_modules` - you can instead just remove `node_modules/.cache` to reliably reproduce.)

(This is why the problem is only on first load.)

You can read more about this process [in the Vite docs](https://vitejs.dev/config/dep-optimization-options.html#optimizedeps-include).

This resolves the issue by ensuring `bootstrap-vue-next` is optimised, though note that this will require users who use pnpm without shamefully-hoisting their dependencies to install `bootstrap-vue-next` as a top-level dependency. (Vite will otherwise complain it can't find it.)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
