### PR TITLE
BTable tdAttr as function

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -331,8 +331,8 @@ const itemAttributes = (
   fieldKey: string,
   attr?: TableFieldAttribute<typeof item>
 ) => {
-  const val = get(item, fieldKey) ?? {}
-  return attr && typeof attr === 'function' ? attr(val, fieldKey, item) : val
+  const val = get(item, fieldKey)
+  return attr && typeof attr === 'function' ? attr(val, fieldKey, item) : attr
 }
 
 const headerClicked = (

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -84,7 +84,7 @@
               :key="field.key"
               :variant="item._cellVariants?.[field.key as keyof T] ? null : field.variant"
               :class="getFieldRowClasses(field, item)"
-              v-bind="field.tdAttr"
+              v-bind="itemAttributes(item, String(field.key), field.tdAttr)"
             >
               <label v-if="computedStacked && labelStackedBoolean" class="b-table-stacked-label">
                 {{ getTableFieldHeadLabel(field) }}
@@ -197,6 +197,7 @@ import {useBooleanish} from '../../composables'
 import type {
   BTableLiteProps,
   TableField,
+  TableFieldAttribute,
   TableFieldFormatter,
   TableFieldRaw,
   TableItem,
@@ -323,6 +324,15 @@ const formatItem = (
 ) => {
   const val = get(item, fieldKey)
   return formatter && typeof formatter === 'function' ? formatter(val, fieldKey, item) : val
+}
+
+const itemAttributes = (
+  item: TableItem<T>,
+  fieldKey: string,
+  attr?: TableFieldAttribute<typeof item>
+) => {
+  const val = get(item, fieldKey) ?? {}
+  return attr && typeof attr === 'function' ? attr(val, fieldKey, item) : val
 }
 
 const headerClicked = (

--- a/packages/bootstrap-vue-next/src/types/TableTypes.ts
+++ b/packages/bootstrap-vue-next/src/types/TableTypes.ts
@@ -31,6 +31,11 @@ export type TableFieldFormatter<T = any> =
   | string
   | ((value: unknown, key?: LiteralUnion<keyof T>, item?: T) => string)
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TableFieldAttribute<T = any> =
+  | Record<string, unknown>
+  | ((value: unknown, key?: LiteralUnion<keyof T>, item?: T) => Record<string, unknown>)
+
 export interface TableField<T = Record<string, unknown>> {
   key: LiteralUnion<keyof T>
   label?: string
@@ -47,8 +52,8 @@ export interface TableField<T = Record<string, unknown>> {
   thClass?: ClassValue
   thStyle?: StyleValue
   variant?: ColorVariant | null
-  tdAttr?: Record<string, unknown>
-  thAttr?: Record<string, unknown>
+  tdAttr?: TableFieldAttribute<T>
+  thAttr?: TableFieldAttribute<T>
   isRowHeader?: boolean
   stickyColumn?: boolean
 }


### PR DESCRIPTION
Enable BTable ```tdAttr``` to be a function like old BV2
