### PR TITLE
feat(BTooltip): add prop interactive

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTooltip.vue
+++ b/packages/bootstrap-vue-next/src/components/BTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <BPopover ref="popover" tooltip v-bind="$props">
+  <BPopover ref="popover" tooltip v-bind="computedProps">
     <template v-for="(_, name) in $slots" #[name]="slotData">
       <slot :name="name" v-bind="slotData" />
     </template>
@@ -7,11 +7,11 @@
 </template>
 
 <script setup lang="ts">
-import {ref} from 'vue'
+import {computed, ref} from 'vue'
 import BPopover from './BPopover.vue'
-import type {BPopoverProps} from '../types'
+import type {BPopoverProps, BTooltipProps} from '../types'
 
-withDefaults(defineProps<Omit<BPopoverProps, 'tooltip'>>(), {
+const props = withDefaults(defineProps<BTooltipProps>(), {
   click: undefined,
   container: undefined,
   content: undefined,
@@ -22,6 +22,7 @@ withDefaults(defineProps<Omit<BPopoverProps, 'tooltip'>>(), {
   html: undefined,
   id: undefined,
   inline: undefined,
+  interactive: undefined,
   manual: undefined,
   modelValue: undefined,
   noAutoClose: undefined,
@@ -29,7 +30,7 @@ withDefaults(defineProps<Omit<BPopoverProps, 'tooltip'>>(), {
   noFlip: undefined,
   noHide: undefined,
   noShift: undefined,
-  noninteractive: true,
+  noninteractive: undefined,
   offset: undefined,
   placement: undefined,
   realtime: undefined,
@@ -38,6 +39,11 @@ withDefaults(defineProps<Omit<BPopoverProps, 'tooltip'>>(), {
   target: undefined,
   title: undefined,
   variant: undefined,
+})
+
+const computedProps = computed<BPopoverProps>(() => {
+  const {interactive, noninteractive, ...rest} = props
+  return {noninteractive: noninteractive !== undefined ? noninteractive : !interactive, ...rest}
 })
 
 const popover = ref<null | InstanceType<typeof BPopover>>(null)

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -272,6 +272,10 @@ export interface BPopoverProps {
   variant?: ColorVariant | null
 }
 
+export interface BTooltipProps extends Omit<BPopoverProps, 'tooltip'> {
+  interactive?: Booleanish
+}
+
 export interface BCardHeadFootProps extends ColorExtendables {
   borderVariant?: ColorVariant | null
   html?: string

--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -100,6 +100,7 @@ export const resolveDirectiveProps = (
           : undefined,
   html: true,
   ...(typeof binding.value === 'object' ? binding.value : {}),
+  ...(binding.modifiers.interactive ? {noninteractive: false} : {}),
   title: null,
   content: null,
 })


### PR DESCRIPTION
# Describe the PR

in bsv2 the prop for tooltip is `noninteractive` which defaults to false. I think booleans which default to false aren't great for us. In bs5 tooltips aren't interactive at all. So I think this is a middle ground.

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
