### PR TITLE
fix(docs): Enable Syntax Highlighting fixes #1738

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -284,6 +284,10 @@ watch(
 @import 'vitepress/dist/client/theme-default/styles/vars.css';
 @import 'vitepress/dist/client/theme-default/styles/base.css';
 @import 'vitepress/dist/client/theme-default/styles/utils.css';
+@import 'vitepress/dist/client/theme-default/styles/components/custom-block.css';
+@import 'vitepress/dist/client/theme-default/styles/components/vp-code.css';
+@import 'vitepress/dist/client/theme-default/styles/components/vp-code-group.css';
+@import 'vitepress/dist/client/theme-default/styles/components/vp-doc.css';
 
 :root {
   --vp-c-brand-1: hsla(237, 31%, 35%, 1);


### PR DESCRIPTION
# Describe the PR

Get Syntax Highlighting working again in the documentation.  This fixes #1738 

I'm explicitly pulling in the `vp-code.css` as well as several other files that seem appropriate.  It's unclear to me why https://github.com/vuejs/vitepress/pull/3237 caused this issue, as the file had been created and consumed by the default theme a couple of years ago.  In any case, this fixes the issue.  I haven't nailed down what each of the additional files does and if we're currently consuming them, but they seem like reasonable functionality.  We are using `custom-block.css` in `badge.md` and leaving out that file makes the tip section just disappear from the docs. So while I would normally go for the minimal fix it seems like including all of these files makes sense in this case.

## Small replication

Syntax highlighting is broken in all the documentation.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [X] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
