### PR TITLE
fix(events): update events for BTransition in component BOverlay

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BOverlay/BOverlay.vue
+++ b/packages/bootstrap-vue-next/src/components/BOverlay/BOverlay.vue
@@ -5,8 +5,8 @@
       :no-fade="noFade"
       :trans-props="{enterToClass: 'show'}"
       name="fade"
-      @on-after-enter="emit('shown')"
-      @on-after-leave="emit('hidden')"
+      @after-enter="emit('shown')"
+      @after-leave="emit('hidden')"
     >
       <component
         :is="overlayTag"


### PR DESCRIPTION
# Describe the PR

Replaced events for the BTransition component with @after-enter and @after-leave.

Errors of the type are occurring in the `BOverlay` component: 
` Uncaught (in promise) TypeError: Cannot read properties of null (reading 'Symbol(_leaveCb)') ` 
and 
` Uncaught (in promise) TypeError: Cannot read properties of null (reading 'insertBefore') `.

This happens when the `showBoolean` state is rapidly changed in the child `Transition` block, after which everything inside `Transition` breaks until the page is fully reloaded. After investigating this case, I discovered that currently, in `Transition`, non-existent events `@on-after-enter` and `@on-after-leave` are being listened to, and this, along with the fact that inside `BTransition` there is a temporary slot node, i.e., `Transition` does not have a stable root element, leads to the described error.
`Vue` tries to remove event handlers for non-existent events `@on-after-enter` and `@on-after-leave` when unmounting the component passed into `Transition`.

When you quickly toggle the visibility of an element, `Vue` creates and destroys the component in `Transition` very quickly. Because of this, Vue does not have enough time to remove the event handlers for non-existent events before the component is destroyed.

There are actually several solutions to this problem, but the correct one, I believe, is only the first:
- Replace `@on-after-enter` and `@on-after-leave` with events from the documentation `@after-enter` and `@after-leave`, this will not only solve the described problem but also allow these events to be handled. (Currently, since they do not exist in `Transition`, they are accordingly non-functional). This is the option I suggest using.
- Wrap the `slot` in a `div`, then there will be a stable root element inside `Transition`, and any events, even non-existent ones, will have time to be registered and removed.
- For the child `Transition` block, use the `v-show` directive instead of `v-if`, which will also create a stable root element inside `Transition`.

## Small replication

https://stackblitz.com/edit/nuxt-starter-reu7jc?file=nuxt.config.ts,package.json,app.vue

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
