### PR TITLE
BTable check selection also using primaryKey attribute

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -295,7 +295,20 @@ const selectedItemsSetUtilities = {
   For some reason, the reference of the object gets lost. However, when you use an actual ref(), it works just fine
   Getting the reference properly will fix all outstanding issues
   */
-  has: (item: Readonly<TableItem<T>>) => selectedItemsToSet.value.has(item),
+  has: (item: Readonly<TableItem<T>>) => {
+    if (props.primaryKey) {
+      let isSelected = false
+      const pkey = props.primaryKey as keyof TableItem<T>
+      selectedItemsToSet.value.forEach((selected: TableItem<T>) => {
+        if (selected[pkey] === item[pkey]) {
+          isSelected = true
+        }
+      })
+      return isSelected
+    }
+
+    return selectedItemsToSet.value.has(item)
+  },
 } as const
 
 /**

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -296,19 +296,14 @@ const selectedItemsSetUtilities = {
   Getting the reference properly will fix all outstanding issues
   */
   has: (item: Readonly<TableItem<T>>) => {
-    if (props.primaryKey) {
-      let isSelected = false
-      const pkey = props.primaryKey as keyof TableItem<T>
-      for (const selected of selectedItemsToSet.value) {
-        if (selected[pkey] === item[pkey]) {
-          isSelected = true
-          break
-        }
-      }
-      return isSelected
-    }
+    if (!props.primaryKey) return selectedItemsToSet.value.has(item)
 
-    return selectedItemsToSet.value.has(item)
+    // Resolver for when we are using primary keys
+    const pkey = props.primaryKey as keyof TableItem<T>
+    for (const selected of selectedItemsToSet.value) {
+      if (selected[pkey] === item[pkey]) return true
+    }
+    return false
   },
 } as const
 

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -299,11 +299,12 @@ const selectedItemsSetUtilities = {
     if (props.primaryKey) {
       let isSelected = false
       const pkey = props.primaryKey as keyof TableItem<T>
-      selectedItemsToSet.value.forEach((selected: TableItem<T>) => {
+      for (const selected of selectedItemsToSet.value) {
         if (selected[pkey] === item[pkey]) {
           isSelected = true
+          break
         }
-      })
+      }
       return isSelected
     }
 


### PR DESCRIPTION
# Describe the PR

BTable ```selectable``` works fine but...

using BTable ```provider``` attribute with pagination will loose the row selected class when page is changed.

with this PR when the ```primaryKey``` attribute (already present but unused) is set, the selection is checked by comparing the TableItem primaryKey attribute

Old BootstrapVue has primaryKey attribute:
"Name of a table field that contains a guaranteed unique value per row. Needed for tbody transition support, and also speeds up table rendering"

I think it can be used also for other things like selection which is a new feature 