### PR TITLE
fix(BTable): BTable rowDblClicked event not working

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -8,6 +8,11 @@
     :tbody-tr-class="getRowClasses"
     :field-column-class="getFieldColumnClasses"
     @head-clicked="onFieldHeadClick"
+    @row-dbl-clicked="
+      (row, index, e) => {
+        emit('row-dbl-clicked', row, index, e)
+      }
+    "
     @row-clicked="onRowClick"
     @row-hovered="
       (row, index, e) => {
@@ -83,7 +88,7 @@
 
 <script setup lang="ts" generic="T = Record<string, unknown>">
 import {useToNumber, useVModel} from '@vueuse/core'
-import {computed, onMounted, ref, type Ref, type StyleValue, toRef, watch} from 'vue'
+import {computed, onMounted, type Ref, ref, type StyleValue, toRef, watch} from 'vue'
 import type {
   BTableLiteProps,
   BTableProvider,
@@ -96,12 +101,12 @@ import type {
   TableFieldRaw,
   TableItem,
 } from '../../types'
-import BSpinner from '../BSpinner.vue'
+import {formatItem, get, getTableFieldHeadLabel} from '../../utils'
 import BOverlay from '../BOverlay/BOverlay.vue'
+import BSpinner from '../BSpinner.vue'
 import BTableLite from './BTableLite.vue'
 import BTd from './BTd.vue'
 import BTr from './BTr.vue'
-import {formatItem, get, getTableFieldHeadLabel} from '../../utils'
 
 type NoProviderTypes = 'paging' | 'sorting' | 'filtering'
 

--- a/packages/bootstrap-vue-next/src/components/BTable/table.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BTable/table.spec.ts
@@ -1,7 +1,7 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
+import type {LiteralUnion, TableField, TableItem} from 'src/types'
 import {afterEach, describe, expect, it} from 'vitest'
 import BTable from './BTable.vue'
-import type {LiteralUnion, TableField, TableItem} from 'src/types'
 
 interface SimplePerson {
   first_name: string
@@ -66,7 +66,7 @@ describe('tbody', () => {
     expect(heads[1].text()).toBe('Age')
   })
 
-  it('shows sortable columns when sortalbe === true', () => {
+  it('shows sortable columns when sortable === true', () => {
     const wrapper = mount(BTable, {
       props: {items: simpleItems, fields: simpleFields},
     })
@@ -75,7 +75,7 @@ describe('tbody', () => {
     expect(heads[1].classes()).toContain('b-table-sortable-column')
   })
 
-  it('does not show sortable columns when sortalbe undefined', () => {
+  it('does not show sortable columns when sortable undefined', () => {
     const wrapper = mount(BTable, {
       props: {items: simpleItems},
     })


### PR DESCRIPTION
Add row-dbl-clicked event on BTable component

# Describe the PR

Fix #1795

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
