### PR TITLE
feat(BCheckBox): Implement reverse and without label

### DIFF
--- a/apps/docs/src/data/components/ComponentReference.ts
+++ b/apps/docs/src/data/components/ComponentReference.ts
@@ -17,7 +17,7 @@ export interface ComponentReference {
     description?: string
   }[]
   slots: {
-    scope: SlotScopeReference[]
+    scope?: SlotScopeReference[]
     name: string
     description?: string
   }[]

--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -161,30 +161,6 @@ export default {
             },
           ],
         },
-        {
-          event: 'input',
-          description: 'Emitted before the checked value is changed',
-          args: [
-            {
-              arg: 'checked',
-              type: 'CheckboxValue | readonly CheckboxValue[]',
-              description:
-                'Value of the checkbox before the event. Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
-            },
-          ],
-        },
-        {
-          event: 'change',
-          description: 'Emitted when the checked value is changed',
-          args: [
-            {
-              arg: 'checked',
-              type: 'CheckboxValue | readonly CheckboxValue[]',
-              description:
-                'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
-            },
-          ],
-        },
       ],
       slots: [
         {
@@ -340,28 +316,6 @@ export default {
           args: [
             {
               arg: 'update:modelValue',
-              type: 'CheckboxValue[]',
-              description: 'Value of the checkboxes. Value will be an array.',
-            },
-          ],
-        },
-        {
-          event: 'input',
-          description: 'Emitted before the selected value(s) are changed',
-          args: [
-            {
-              arg: 'input',
-              type: 'CheckboxValue[]',
-              description: 'Value of the checkboxes before the event. Value will be an array.',
-            },
-          ],
-        },
-        {
-          event: 'change',
-          description: 'Emitted when the selected value(s) are changed',
-          args: [
-            {
-              arg: 'change',
               type: 'CheckboxValue[]',
               description: 'Value of the checkboxes. Value will be an array.',
             },

--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -117,6 +117,12 @@ export default {
             'Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state',
         },
         {
+          prop: 'reverse',
+          type: 'boolean',
+          default: false,
+          description: 'When set, renders the checkboxe or switch on the opposite side',
+        },
+        {
           prop: 'switch',
           type: 'boolean',
           default: false,
@@ -264,6 +270,12 @@ export default {
           type: 'boolean',
           default: false,
           description: 'Adds the `required` attribute to the form control',
+        },
+        {
+          prop: 'reverse',
+          type: 'boolean',
+          default: false,
+          description: 'When set, renders the checkboxes and switches on the opposite side',
         },
         {
           prop: 'size',

--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -120,7 +120,7 @@ export default {
           prop: 'reverse',
           type: 'boolean',
           default: false,
-          description: 'When set, renders the checkboxe or switch on the opposite side',
+          description: 'When set, renders the checkbox or switch on the opposite side',
         },
         {
           prop: 'switch',

--- a/apps/docs/src/data/components/formRadio.data.ts
+++ b/apps/docs/src/data/components/formRadio.data.ts
@@ -81,6 +81,12 @@ export default {
           default: false,
         },
         {
+          prop: 'reverse',
+          type: 'boolean',
+          default: false,
+          description: 'When set, renders the radio button on the opposite side',
+        },
+        {
           prop: 'state',
           type: 'boolean | null',
           default: undefined,

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -934,7 +934,7 @@ const indeterminate = ref(true)
               v-model:indeterminate="asIndeterminate"
               aria-describedby="flavors"
               aria-controls="flavors"
-              @change="toggleAll"
+              @update:modelValue="toggleAll"
             >
               {{ allSelected ? 'Un-select All' : 'Select All' }}
             </BFormCheckbox>
@@ -972,7 +972,7 @@ const indeterminate = ref(true)
         v-model:indeterminate="asIndeterminate"
         aria-describedby="flavors"
         aria-controls="flavors"
-        @change="toggleAll"
+        @update:modelValue="toggleAll"
       >
         {{ allSelected ? 'Un-select All' : 'Select All' }}
       </BFormCheckbox>

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -412,6 +412,25 @@ Use the `size` prop to control the size of the checkbox. The default size is med
   </template>
 </HighlightCard>
 
+## Reverse
+
+Use the `reverse` prop to put your checkboxes and switches on the opposite side of the label.
+
+<HighlightCard>
+  <BFormCheckbox reverse>Reverse checkbox</BFormCheckbox>
+  <BFormCheckbox reverse disabled>Disabled reverse checkbox</BFormCheckbox>
+  <BFormCheckbox reverse switch>Reverse switch ceckbox input</BFormCheckbox>
+  <template #html>
+
+```vue-html
+<BFormCheckbox reverse>Reverse checkbox</BFormCheckbox>
+<BFormCheckbox reverse disabled>Disabled reverse checkbox</BFormCheckbox>
+<BFormCheckbox reverse switch>Reverse switch ceckbox input</BFormCheckbox>
+```
+
+  </template>
+</HighlightCard>
+
 ## Checkbox values and `v-model`
 
 By default, `BFormCheckbox` value will be true when checked and false when unchecked. You can customize the checked and unchecked values by specifying the `value` and `unchecked-value` properties, respectively.

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -54,6 +54,7 @@ const props = withDefaults(
     name?: string
     plain?: boolean
     required?: boolean
+    reverse?: boolean
     size?: Size
     state?: boolean | null
     switch?: boolean
@@ -76,6 +77,7 @@ const props = withDefaults(
     name: undefined,
     plain: false,
     required: undefined,
+    reverse: false,
     size: undefined,
     state: null,
     switch: false,
@@ -138,6 +140,7 @@ const classesObject = computed(() => ({
   plain: props.plain || (parentData?.plain.value ?? false),
   button: props.button || (parentData?.buttons.value ?? false),
   inline: props.inline || (parentData?.inline.value ?? false),
+  reverse: props.reverse || (parentData?.reverse.value ?? false),
   switch: props.switch || (parentData?.switch.value ?? false),
   state: props.state || parentData?.state.value,
   size: props.size ?? parentData?.size.value ?? 'md', // This is where the true default is made

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -145,6 +145,7 @@ const classesObject = computed(() => ({
   state: props.state || parentData?.state.value,
   size: props.size ?? parentData?.size.value ?? 'md', // This is where the true default is made
   buttonVariant: props.buttonVariant ?? parentData?.buttonVariant.value ?? 'secondary', // This is where the true default is made
+  hasDefaultSlot: hasDefaultSlot.value,
 }))
 const computedClasses = getClasses(classesObject)
 const inputClasses = getInputClasses(classesObject)

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
     options?: readonly CheckboxOptionRaw[]
     plain?: boolean
     required?: boolean
+    reverse?: boolean
     size?: Size
     stacked?: boolean
     state?: boolean | null
@@ -67,6 +68,7 @@ const props = withDefaults(
     options: () => [],
     plain: false,
     required: false,
+    reverse: false,
     size: 'md',
     stacked: false,
     state: null,
@@ -109,6 +111,7 @@ provide(checkboxGroupKey, {
   plain: toRef(() => props.plain),
   size: toRef(() => props.size),
   inline: toRef(() => !props.stacked),
+  reverse: toRef(() => props.reverse),
   required: toRef(() => props.required),
   buttons: toRef(() => props.buttons),
   disabled: toRef(() => props.disabled),

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, nextTick, provide, ref, toRef, watch} from 'vue'
+import {computed, provide, ref, toRef} from 'vue'
 import BFormCheckbox from './BFormCheckbox.vue'
 import type {AriaInvalid, ButtonVariant, CheckboxOptionRaw, CheckboxValue, Size} from '../../types'
 import {getGroupAttr, getGroupClasses, useId} from '../../composables'
@@ -78,8 +78,6 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  'change': [value: CheckboxValue[]]
-  'input': [value: CheckboxValue[]]
   'update:modelValue': [value: CheckboxValue[]]
 }>()
 
@@ -114,13 +112,6 @@ provide(checkboxGroupKey, {
   required: toRef(() => props.required),
   buttons: toRef(() => props.buttons),
   disabled: toRef(() => props.disabled),
-})
-
-watch(modelValue, (newValue) => {
-  emit('input', [...newValue])
-  nextTick(() => {
-    emit('change', [...newValue])
-  })
 })
 
 const normalizeOptions = computed(() =>

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -5,7 +5,7 @@ import BFormCheckbox from './BFormCheckbox.vue'
 describe('form-checkbox', () => {
   enableAutoUnmount(afterEach)
 
-  describe('useFormCHeck attributes', () => {
+  describe('useFormCheck attributes', () => {
     it('tag is div', () => {
       const wrapper = mount(BFormCheckbox)
       expect(wrapper.element.tagName).toBe('DIV')
@@ -46,11 +46,25 @@ describe('form-checkbox', () => {
       expect(wrapper.classes()).toContain('form-check-inline')
     })
 
-    it('has class form-check-inline when prop inline', () => {
+    it('does not have class form-check-inline when prop inline', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {inline: false},
       })
       expect(wrapper.classes()).not.toContain('form-check-inline')
+    })
+
+    it('has class form-check-reverse when prop inline', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {reverse: true},
+      })
+      expect(wrapper.classes()).toContain('form-check-reverse')
+    })
+
+    it('does not have class form-check-reverse when prop inline', () => {
+      const wrapper = mount(BFormCheckbox, {
+        props: {reverse: false},
+      })
+      expect(wrapper.classes()).not.toContain('form-check-reverse')
     })
 
     it('does not have class form-switch when prop switch is false', () => {

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/form-checkbox.spec.ts
@@ -14,6 +14,9 @@ describe('form-checkbox', () => {
     it('has class form-check if prop plain and prop button are false', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {plain: false, button: false},
+        slots: {
+          default: 'checkbox',
+        },
       })
       expect(wrapper.classes()).toContain('form-check')
     })
@@ -22,6 +25,11 @@ describe('form-checkbox', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {plain: true, button: true},
       })
+      expect(wrapper.classes()).not.toContain('form-check')
+    })
+
+    it('does not have class form-check if default slot is empty', () => {
+      const wrapper = mount(BFormCheckbox, {})
       expect(wrapper.classes()).not.toContain('form-check')
     })
 
@@ -53,14 +61,14 @@ describe('form-checkbox', () => {
       expect(wrapper.classes()).not.toContain('form-check-inline')
     })
 
-    it('has class form-check-reverse when prop inline', () => {
+    it('has class form-check-reverse when prop reverse', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {reverse: true},
       })
       expect(wrapper.classes()).toContain('form-check-reverse')
     })
 
-    it('does not have class form-check-reverse when prop inline', () => {
+    it('does not have class form-check-reverse when prop reverse', () => {
       const wrapper = mount(BFormCheckbox, {
         props: {reverse: false},
       })

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -50,6 +50,7 @@ const props = withDefaults(
     name?: string
     plain?: boolean
     required?: boolean
+    reverse?: boolean
     size?: Size
     state?: boolean | null
     value?: RadioValue
@@ -69,6 +70,7 @@ const props = withDefaults(
     name: undefined,
     plain: false,
     required: false,
+    reverse: false,
     size: undefined,
     state: null,
     value: true,
@@ -121,8 +123,10 @@ const classesObject = computed(() => ({
   button: props.button || (parentData?.buttons.value ?? false),
   inline: props.inline || (parentData?.inline.value ?? false),
   state: props.state || parentData?.state.value,
+  reverse: props.reverse || (parentData?.reverse.value ?? false),
   size: props.size ?? parentData?.size.value ?? 'md', // This is where the true default is made
   buttonVariant: props.buttonVariant ?? parentData?.buttonVariant.value ?? 'secondary', // This is where the true default is made
+  hasDefaultSlot: hasDefaultSlot.value,
 }))
 const computedClasses = getClasses(classesObject)
 const inputClasses = getInputClasses(classesObject)

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
@@ -49,6 +49,7 @@ const props = withDefaults(
     options?: readonly RadioOptionRaw[]
     plain?: boolean
     required?: boolean
+    reverse?: boolean
     size?: Size
     stacked?: boolean
     state?: boolean | null
@@ -71,6 +72,7 @@ const props = withDefaults(
     options: () => [],
     plain: false,
     required: false,
+    reverse: false,
     size: 'md',
     stacked: false,
     state: null,
@@ -114,6 +116,7 @@ provide(radioGroupKey, {
   plain: toRef(() => props.plain),
   size: toRef(() => props.size),
   inline: toRef(() => !props.stacked),
+  reverse: toRef(() => !props.reverse),
   required: toRef(() => props.required),
   disabled: toRef(() => props.disabled),
 })

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/form-radio.spec.ts
@@ -13,6 +13,9 @@ describe('form-radio', () => {
   it('has class form-check if prop plain and prop button are false', () => {
     const wrapper = mount(BFormRadio, {
       props: {plain: false, button: false},
+      slots: {
+        default: 'checkbox',
+      },
     })
     expect(wrapper.classes()).toContain('form-check')
   })
@@ -38,6 +41,13 @@ describe('form-radio', () => {
     expect(wrapper.classes()).not.toContain('form-check')
   })
 
+  it('does not have class form-check if default slot is empty', () => {
+    const wrapper = mount(BFormRadio, {
+      props: {plain: true, button: false},
+    })
+    expect(wrapper.classes()).not.toContain('form-check')
+  })
+
   it('has class form-check-inline when prop inline', () => {
     const wrapper = mount(BFormRadio, {
       props: {inline: true},
@@ -50,6 +60,20 @@ describe('form-radio', () => {
       props: {inline: false},
     })
     expect(wrapper.classes()).not.toContain('form-check-inline')
+  })
+
+  it('has class form-check-reverse when prop reverse', () => {
+    const wrapper = mount(BFormRadio, {
+      props: {reverse: true},
+    })
+    expect(wrapper.classes()).toContain('form-check-reverse')
+  })
+
+  it('does not have class form-check-reverse when prop reverse', () => {
+    const wrapper = mount(BFormRadio, {
+      props: {reverse: false},
+    })
+    expect(wrapper.classes()).not.toContain('form-check-reverse')
   })
 
   it('does not have class form-switch when prop switch is false', () => {

--- a/packages/bootstrap-vue-next/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormCheck.ts
@@ -7,6 +7,7 @@ interface ClassesItemsInput {
   plain?: boolean
   button?: boolean
   inline?: boolean
+  reverse?: boolean
   switch?: boolean
   size?: Size
 }
@@ -16,6 +17,7 @@ const getClasses = (items: MaybeRefOrGetter<ClassesItemsInput>) =>
     const resolvedItems = toValue(items)
     return {
       'form-check': resolvedItems.plain === false && resolvedItems.button === false,
+      'form-check-reverse': resolvedItems.reverse === true,
       'form-check-inline': resolvedItems.inline === true,
       'form-switch': resolvedItems.switch === true,
       [`form-control-${resolvedItems.size}`]:

--- a/packages/bootstrap-vue-next/src/composables/useFormCheck.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormCheck.ts
@@ -10,13 +10,17 @@ interface ClassesItemsInput {
   reverse?: boolean
   switch?: boolean
   size?: Size
+  hasDefaultSlot?: boolean
 }
 
 const getClasses = (items: MaybeRefOrGetter<ClassesItemsInput>) =>
   computed(() => {
     const resolvedItems = toValue(items)
     return {
-      'form-check': resolvedItems.plain === false && resolvedItems.button === false,
+      'form-check':
+        resolvedItems.plain === false &&
+        resolvedItems.button === false &&
+        resolvedItems.hasDefaultSlot,
       'form-check-reverse': resolvedItems.reverse === true,
       'form-check-inline': resolvedItems.inline === true,
       'form-switch': resolvedItems.switch === true,

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -109,6 +109,7 @@ export const radioGroupKey: InjectionKey<{
   plain: Readonly<Ref<boolean>>
   size: Readonly<Ref<Size>>
   inline: Readonly<Ref<boolean>>
+  reverse: Readonly<Ref<boolean>>
   required: Readonly<Ref<boolean>>
   disabled: Readonly<Ref<boolean>>
 }> = Symbol('radioGroup')

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -93,6 +93,7 @@ export const checkboxGroupKey: InjectionKey<{
   plain: Readonly<Ref<boolean>>
   size: Readonly<Ref<Size>>
   inline: Readonly<Ref<boolean>>
+  reverse: Readonly<Ref<boolean>>
   required: Readonly<Ref<boolean>>
   buttons: Readonly<Ref<boolean>>
   disabled: Readonly<Ref<boolean>>


### PR DESCRIPTION
# Describe the PR

Implement the [reverse](https://getbootstrap.com/docs/5.3/forms/checks-radios/#reverse) and [without-label](https://getbootstrap.com/docs/5.3/forms/checks-radios/#without-labels) features of checkboxes and radio buttons.

Reverse is implemented as a property on BFormCheckbox and BFormCheckboxGroup
Without Labels is implemented by not including the form-checkbox class when there is no default slot

In addition:
- Implemented and tested the same properties in BFormRadio and BFormRadioGroup
- Updated the documentation for BFromCheckbox and BFGormCheckboxGroup
- Made scope option in the ComponentReference data (because it is)
- Removed input and change events from BFormCheckboxGroup - these events were removed from BFromCheckbox so it doesn't seem like it makes sense to keep them in the group.

I believe that this PR brings us to parity with BSV legacy and BS5. There is some more clean-up to do with BFormRadio, I didn't intend to touch that at all, but since there was a shared component I did the minimum to get the core feature I was working on to work with Radio controls. 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ x ] Bugfix :bug: - `fix(...)`
- [ x ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ x ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ x ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
