### PR TITLE
feat(BTable): add noSortReset option

### DIFF
--- a/apps/docs/src/data/components/table.data.ts
+++ b/apps/docs/src/data/components/table.data.ts
@@ -42,6 +42,12 @@ export default {
           description: 'Do not select row when clicked',
         },
         {
+          prop: 'noSortReset',
+          type: 'boolean',
+          default: false,
+          description: 'Do not reset sort',
+        },
+        {
           prop: 'sortBy',
           type: 'string',
           default: undefined,

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -146,7 +146,7 @@ const props = withDefaults(
       // noFooterSorting?: boolean
       noLocalSorting?: boolean
       noSelectOnClick?: boolean
-      // noSortReset?: boolean
+      noSortReset?: boolean
       // selectedVariant?: ColorVariant | null
       // showEmpty?: boolean
       sortCompareLocale?: string | string[]
@@ -174,6 +174,7 @@ const props = withDefaults(
     noProviderFiltering: false,
     noLocalSorting: false,
     noSelectOnClick: false,
+    noSortReset: false,
     sortDesc: false,
     selectable: false,
     stickySelect: false,
@@ -562,8 +563,10 @@ const handleFieldSorting = (field: Readonly<TableFieldRaw<T>>) => {
     if (sortDescModel.value === false) {
       sortDescModel.value = true
     } else {
-      sortByModel.value = undefined
       sortDescModel.value = false
+      if (props.noSortReset === false) {
+        sortByModel.value = undefined
+      }
     }
   }
   emit('sorted', fieldKey, sortByModel.value === undefined ? false : !sortDescModel.value)

--- a/packages/bootstrap-vue-next/src/components/BTable/table.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BTable/table.spec.ts
@@ -197,4 +197,34 @@ describe('tbody', () => {
       .map((row) => row.find('td').text())
     expect(text).toStrictEqual(['Havij', 'Robert', 'Cyndi'])
   })
+
+  it('resets sort when noSortReset === false', async () => {
+    const wrapper = mount(BTable, {
+      props: {items: simpleItems, fields: simpleFields, sortDesc: true, noSortReset: false},
+    })
+    const [names] = wrapper.get('table').findAll('th')
+    await names.trigger('click')
+    await names.trigger('click')
+    await names.trigger('click')
+    const text = wrapper
+      .get('tbody')
+      .findAll('tr')
+      .map((row) => row.find('td').text())
+    expect(text).toStrictEqual(['Havij', 'Cyndi', 'Robert'])
+  })
+
+  it('does not reset sort when noSortReset === true', async () => {
+    const wrapper = mount(BTable, {
+      props: {items: simpleItems, fields: simpleFields, sortDesc: true, noSortReset: true},
+    })
+    const [names] = wrapper.get('table').findAll('th')
+    await names.trigger('click')
+    await names.trigger('click')
+    await names.trigger('click')
+    const text = wrapper
+      .get('tbody')
+      .findAll('tr')
+      .map((row) => row.find('td').text())
+    expect(text).toStrictEqual(['Cyndi', 'Havij', 'Robert'])
+  })
 })


### PR DESCRIPTION
# Describe the PR

Implements the noSortReset option for BTable. When enabled, sorting by a field only toggles between ascending and descending, and the sortBy value is not reset.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
