### PR TITLE
fix(BPopover and Btooltip): Fixes bootstrap-vue-next#1232 - do not create a new app fro each tooltip or popover

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BPopover.ts
+++ b/packages/bootstrap-vue-next/src/directives/BPopover.ts
@@ -31,21 +31,12 @@ export default {
 
     if (!text.content && !text.title) return
 
-    if (!el.$__state) {
-      // Same binding as above
-      // This happens when mounting occurs, but binding does not happen ie (if (!text.content && !text.title) return)
-      // So mounting occurs without a title or content set
-      el.$__state = ref({
-        ...resolveDirectiveProps(binding, el),
-        ...text,
-      })
-      bind(el, binding)
-      return
-    }
-    el.$__state.value = {
+    unbind(el)
+    el.$__state = ref({
       ...resolveDirectiveProps(binding, el),
       ...text,
-    }
+    })
+    bind(el, binding)
   },
   beforeUnmount(el) {
     unbind(el)

--- a/packages/bootstrap-vue-next/src/directives/BPopover.ts
+++ b/packages/bootstrap-vue-next/src/directives/BPopover.ts
@@ -1,4 +1,4 @@
-import {type Directive, ref} from 'vue'
+import {type Directive} from 'vue'
 import {
   bind,
   type ElementWithPopper,
@@ -16,12 +16,10 @@ export default {
     const text = resolveContent(binding.value, el)
 
     if (!text.content && !text.title) return
-
-    el.$__state = ref({
+    bind(el, binding, {
       ...resolveDirectiveProps(binding, el),
       ...text,
     })
-    bind(el, binding)
   },
   updated(el, binding) {
     const isActive = resolveActiveStatus(binding.value)
@@ -32,11 +30,10 @@ export default {
     if (!text.content && !text.title) return
 
     unbind(el)
-    el.$__state = ref({
+    bind(el, binding, {
       ...resolveDirectiveProps(binding, el),
       ...text,
     })
-    bind(el, binding)
   },
   beforeUnmount(el) {
     unbind(el)

--- a/packages/bootstrap-vue-next/src/directives/BTooltip.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip.ts
@@ -32,26 +32,15 @@ export default {
     const text = resolveContent(binding.value, el)
 
     if (!text.content && !text.title) return
+    unbind(el)
 
-    if (!el.$__state) {
-      // Same binding as above
-      // This happens when mounting occurs, but binding does not happen ie (if (!text.content && !text.title) return)
-      // So mounting occurs without a title or content set
-      el.$__state = ref({
-        noninteractive: true,
-        ...resolveDirectiveProps(binding, el),
-        title: text.title ?? text.content ?? '',
-        tooltip: isActive,
-      })
-      bind(el, binding)
-      return
-    }
-    el.$__state.value = {
+    el.$__state = ref({
       noninteractive: true,
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.content ?? '',
       tooltip: isActive,
-    }
+    })
+    bind(el, binding)
   },
   beforeUnmount(el) {
     unbind(el)

--- a/packages/bootstrap-vue-next/src/directives/BTooltip.ts
+++ b/packages/bootstrap-vue-next/src/directives/BTooltip.ts
@@ -1,4 +1,4 @@
-import {type Directive, ref} from 'vue'
+import {type Directive} from 'vue'
 import {
   bind,
   type ElementWithPopper,
@@ -16,14 +16,13 @@ export default {
     const text = resolveContent(binding.value, el)
 
     if (!text.content && !text.title) return
-
-    el.$__state = ref({
+    
+    bind(el, binding, {
       noninteractive: true,
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.content ?? '',
       tooltip: isActive,
     })
-    bind(el, binding)
   },
   updated(el, binding) {
     const isActive = resolveActiveStatus(binding.value)
@@ -34,13 +33,12 @@ export default {
     if (!text.content && !text.title) return
     unbind(el)
 
-    el.$__state = ref({
+    bind(el, binding, {
       noninteractive: true,
       ...resolveDirectiveProps(binding, el),
       title: text.title ?? text.content ?? '',
       tooltip: isActive,
     })
-    bind(el, binding)
   },
   beforeUnmount(el) {
     unbind(el)

--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -4,6 +4,7 @@ export {autoUpdate} from '@floating-ui/vue'
 import {type App, type DirectiveBinding, h, type Ref, render} from 'vue'
 import {DefaultAllowlist, sanitizeHtml} from './sanitizer'
 import BPopover from '../components/BPopover.vue'
+import type {BPopoverProps} from '../types'
 
 // TODO this function doesn't currently resolve with RTL in mind. Once Bootstrap finalizes their RTL, we should make this change here
 /**
@@ -106,24 +107,21 @@ export const resolveDirectiveProps = (
 })
 
 export interface ElementWithPopper extends HTMLElement {
-  $__state?: Ref<{title: string; target: HTMLElement}>
-  $__app?: App
   $__element?: HTMLElement
 }
 
-export const bind = (el: ElementWithPopper, binding: Readonly<DirectiveBinding>) => {
+export const bind = (el: ElementWithPopper, binding: Readonly<DirectiveBinding>, props: BPopoverProps) => {
   const div = document.createElement('span')
   if (binding.modifiers.body) document.body.appendChild(div)
   else if (binding.modifiers.child) el.appendChild(div)
   else el.parentNode?.insertBefore(div, el.nextSibling)
-  render(h(BPopover, el.$__state?.value), div)
+  render(h(BPopover, props), div)
   el.$__element = div
 }
 
 export const unbind = (el: ElementWithPopper) => {
   const div = el.$__element
   if (div) render(null, div)
-  delete el.$__state
   setTimeout(() => {
     div?.remove()
   }, 0)

--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -1,7 +1,7 @@
 import type {Placement} from '@floating-ui/vue'
 export {autoUpdate} from '@floating-ui/vue'
 
-import {type App, createApp, type DirectiveBinding, h, type Ref} from 'vue'
+import {type App, type DirectiveBinding, h, type Ref, render} from 'vue'
 import {DefaultAllowlist, sanitizeHtml} from './sanitizer'
 import BPopover from '../components/BPopover.vue'
 
@@ -116,15 +116,13 @@ export const bind = (el: ElementWithPopper, binding: Readonly<DirectiveBinding>)
   if (binding.modifiers.body) document.body.appendChild(div)
   else if (binding.modifiers.child) el.appendChild(div)
   else el.parentNode?.insertBefore(div, el.nextSibling)
-  el.$__app = createApp({render: () => h(BPopover, {...el.$__state?.value})})
-  el.$__app.mount(div)
+  render(h(BPopover, el.$__state?.value), div)
   el.$__element = div
 }
 
 export const unbind = (el: ElementWithPopper) => {
   const div = el.$__element
-  el.$__app?.unmount()
-  delete el.$__app
+  if (div) render(null, div)
   delete el.$__state
   setTimeout(() => {
     div?.remove()

--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -1,7 +1,7 @@
 import type {Placement} from '@floating-ui/vue'
 export {autoUpdate} from '@floating-ui/vue'
 
-import {type App, type DirectiveBinding, h, type Ref, render} from 'vue'
+import {type DirectiveBinding, h, render} from 'vue'
 import {DefaultAllowlist, sanitizeHtml} from './sanitizer'
 import BPopover from '../components/BPopover.vue'
 import type {BPopoverProps} from '../types'


### PR DESCRIPTION
# Describe the PR
The PR fixes #1232 (One App for each tooltip), by eliminating the need to create a new app for each tooltip or popover. I used the `render` function from Vue to achieve this. One issue I experienced with this method was it did not update when props changed. 

To get around this I had to remove the old rendered component, then re-render it on update

## Small replication
check #1232 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**

PS: this is my first open-source contribution, please be easy on me :))
