### PR TITLE
fix(BForm*): Revert use of defineModel to prevent model warnings (fixed #1846)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -26,10 +26,10 @@
 </template>
 
 <script setup lang="ts">
-import {useFocus} from '@vueuse/core'
+import {useFocus, useVModel} from '@vueuse/core'
 import {computed, inject, ref, toRef} from 'vue'
 import {getClasses, getInputClasses, getLabelClasses, useId} from '../../composables'
-import type {BFormCheckboxProps, CheckboxValue} from '../../types'
+import type {ButtonVariant, CheckboxValue, Size} from '../../types'
 import {checkboxGroupKey, isEmptySlot} from '../../utils'
 import RenderComponentOrSkip from '../RenderComponentOrSkip.vue'
 
@@ -37,39 +37,71 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<BFormCheckboxProps>(), {
-  ariaLabel: undefined,
-  ariaLabelledby: undefined,
-  autofocus: false,
-  button: false,
-  buttonGroup: false,
-  buttonVariant: null,
-  disabled: false,
-  form: undefined,
-  id: undefined,
-  inline: false,
-  name: undefined,
-  plain: false,
-  required: undefined,
-  reverse: false,
-  size: undefined,
-  state: null,
-  switch: false,
-  uncheckedValue: false,
-  value: true,
-})
+const props = withDefaults(
+  defineProps<{
+    ariaLabel?: string
+    ariaLabelledby?: string
+    autofocus?: boolean
+    button?: boolean
+    buttonGroup?: boolean
+    buttonVariant?: ButtonVariant | null
+    disabled?: boolean
+    form?: string
+    id?: string
+    indeterminate?: boolean
+    inline?: boolean
+    modelValue?: CheckboxValue | readonly CheckboxValue[]
+    name?: string
+    plain?: boolean
+    required?: boolean
+    reverse?: boolean
+    size?: Size
+    state?: boolean | null
+    switch?: boolean
+    uncheckedValue?: CheckboxValue
+    // Since the compiler-sfc doesn't crawl external filed, the redundant string/boolean union is
+    //   necessary to tell it that we don't want it to follow Boolean casting rules
+    //  https://vuejs.org/guide/components/props.html#boolean-casting which would cast the empty
+    //  string to true
+    value?: string | boolean | CheckboxValue
+  }>(),
+  {
+    ariaLabel: undefined,
+    ariaLabelledby: undefined,
+    autofocus: false,
+    button: false,
+    buttonGroup: false,
+    buttonVariant: null,
+    disabled: false,
+    form: undefined,
+    id: undefined,
+    indeterminate: false,
+    inline: false,
+    modelValue: undefined,
+    name: undefined,
+    plain: false,
+    required: undefined,
+    reverse: false,
+    size: undefined,
+    state: null,
+    switch: false,
+    uncheckedValue: false,
+    value: true,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: CheckboxValue | CheckboxValue[]]
+  'update:indeterminate': [value: boolean]
+}>()
 
 const slots = defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = defineModel<CheckboxValue | CheckboxValue[]>({
-  default: undefined,
-})
-const indeterminate = defineModel<boolean>('indeterminate', {
-  default: false,
-})
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
+const indeterminate = useVModel(props, 'indeterminate', emit)
 
 const computedId = useId(() => props.id, 'form-check')
 

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckboxGroup.vue
@@ -23,34 +23,65 @@
 <script setup lang="ts">
 import {computed, provide, ref, toRef} from 'vue'
 import BFormCheckbox from './BFormCheckbox.vue'
-import type {BFormCheckboxGroupProps, CheckboxValue} from '../../types'
+import type {AriaInvalid, ButtonVariant, CheckboxOptionRaw, CheckboxValue, Size} from '../../types'
 import {getGroupAttr, getGroupClasses, useId} from '../../composables'
 import {checkboxGroupKey} from '../../utils'
-import {useFocus} from '@vueuse/core'
+import {useFocus, useVModel} from '@vueuse/core'
 
-const props = withDefaults(defineProps<BFormCheckboxGroupProps>(), {
-  ariaInvalid: undefined,
-  autofocus: false,
-  buttonVariant: 'secondary',
-  buttons: false,
-  disabled: false,
-  disabledField: 'disabled',
-  form: undefined,
-  htmlField: 'html',
-  id: undefined,
-  name: undefined,
-  options: () => [],
-  plain: false,
-  required: false,
-  reverse: false,
-  size: 'md',
-  stacked: false,
-  state: null,
-  switches: false,
-  textField: 'text',
-  validated: false,
-  valueField: 'value',
-})
+const props = withDefaults(
+  defineProps<{
+    ariaInvalid?: AriaInvalid
+    autofocus?: boolean
+    buttonVariant?: ButtonVariant | null
+    buttons?: boolean
+    disabled?: boolean
+    disabledField?: string
+    form?: string
+    htmlField?: string
+    id?: string
+    modelValue?: readonly CheckboxValue[]
+    name?: string
+    options?: readonly CheckboxOptionRaw[]
+    plain?: boolean
+    required?: boolean
+    reverse?: boolean
+    size?: Size
+    stacked?: boolean
+    state?: boolean | null
+    switches?: boolean
+    textField?: string
+    validated?: boolean
+    valueField?: string
+  }>(),
+  {
+    ariaInvalid: undefined,
+    autofocus: false,
+    buttonVariant: 'secondary',
+    buttons: false,
+    disabled: false,
+    disabledField: 'disabled',
+    form: undefined,
+    htmlField: 'html',
+    id: undefined,
+    modelValue: () => [],
+    name: undefined,
+    options: () => [],
+    plain: false,
+    required: false,
+    reverse: false,
+    size: 'md',
+    stacked: false,
+    state: null,
+    switches: false,
+    textField: 'text',
+    validated: false,
+    valueField: 'value',
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: CheckboxValue[]]
+}>()
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,9 +90,7 @@ defineSlots<{
   first?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = defineModel<CheckboxValue[]>({
-  default: () => [],
-})
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'checkbox')
 const computedName = useId(() => props.name, 'checkbox')

--- a/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormFile/BFormFile.vue
@@ -40,10 +40,10 @@
 </template>
 
 <script setup lang="ts">
-import {createReusableTemplate, useFocus} from '@vueuse/core'
+import {createReusableTemplate, useFocus, useVModel} from '@vueuse/core'
 import {computed, ref, toRef, watch} from 'vue'
-import type {BFormFileProps} from '../../types'
 import {useId, useStateClass} from '../../composables'
+import type {ClassValue, Size} from '../../types'
 import {isEmptySlot} from '../../utils'
 
 defineOptions({
@@ -55,33 +55,61 @@ const slots = defineSlots<{
   label?: (props: Record<string, never>) => any
 }>()
 
-const props = withDefaults(defineProps<BFormFileProps>(), {
-  ariaLabel: undefined,
-  ariaLabelledby: undefined,
-  accept: '',
-  autofocus: false,
-  browserText: 'Choose',
-  // eslint-disable-next-line vue/require-valid-default-prop
-  capture: false,
-  directory: false,
-  disabled: false,
-  form: undefined,
-  id: undefined,
-  label: '',
-  labelClass: undefined,
-  multiple: false,
-  name: undefined,
-  noDrop: false,
-  noTraverse: false,
-  placement: 'start',
-  required: false,
-  size: undefined,
-  state: null,
-})
+const props = withDefaults(
+  defineProps<{
+    ariaLabel?: string
+    ariaLabelledby?: string
+    accept?: string | readonly string[]
+    autofocus?: boolean
+    browserText?: string
+    capture?: boolean | 'user' | 'environment'
+    directory?: boolean
+    disabled?: boolean
+    form?: string
+    id?: string
+    label?: string
+    labelClass?: ClassValue
+    modelValue?: readonly File[] | File | null
+    multiple?: boolean
+    name?: string
+    noDrop?: boolean
+    noTraverse?: boolean
+    placement?: 'start' | 'end'
+    required?: boolean
+    size?: Size
+    state?: boolean | null
+  }>(),
+  {
+    ariaLabel: undefined,
+    ariaLabelledby: undefined,
+    accept: '',
+    autofocus: false,
+    browserText: 'Choose',
+    // eslint-disable-next-line vue/require-valid-default-prop
+    capture: false,
+    directory: false,
+    disabled: false,
+    form: undefined,
+    id: undefined,
+    label: '',
+    labelClass: undefined,
+    modelValue: null,
+    multiple: false,
+    name: undefined,
+    noDrop: false,
+    noTraverse: false,
+    placement: 'start',
+    required: false,
+    size: undefined,
+    state: null,
+  }
+)
 
-const modelValue = defineModel<File | File[] | null>({
-  default: null,
-})
+const emit = defineEmits<{
+  'update:modelValue': [value: File | File[] | null]
+}>()
+
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 const computedId = useId(() => props.id)
 
 // TODO noTraverse is not implemented yet

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadio.vue
@@ -23,10 +23,10 @@
 </template>
 
 <script setup lang="ts">
-import {useFocus} from '@vueuse/core'
+import {useFocus, useVModel} from '@vueuse/core'
 import {computed, inject, ref, toRef} from 'vue'
 import {getClasses, getInputClasses, getLabelClasses, useId} from '../../composables'
-import type {BFormRadioProps, RadioValue} from '../../types'
+import type {ButtonVariant, RadioValue, Size} from '../../types'
 import {isEmptySlot, radioGroupKey} from '../../utils'
 import RenderComponentOrSkip from '../RenderComponentOrSkip.vue'
 
@@ -34,34 +34,59 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<BFormRadioProps>(), {
-  ariaLabel: undefined,
-  ariaLabelledby: undefined,
-  autofocus: false,
-  button: false,
-  buttonGroup: false,
-  buttonVariant: null,
-  disabled: false,
-  form: undefined,
-  id: undefined,
-  inline: false,
-  name: undefined,
-  plain: false,
-  required: false,
-  reverse: false,
-  size: undefined,
-  state: null,
-  value: true,
-})
+const props = withDefaults(
+  defineProps<{
+    ariaLabel?: string
+    ariaLabelledby?: string
+    autofocus?: boolean
+    button?: boolean
+    buttonGroup?: boolean
+    buttonVariant?: ButtonVariant | null
+    disabled?: boolean
+    form?: string
+    id?: string
+    inline?: boolean
+    modelValue?: RadioValue
+    name?: string
+    plain?: boolean
+    required?: boolean
+    reverse?: boolean
+    size?: Size
+    state?: boolean | null
+    value?: RadioValue
+  }>(),
+  {
+    ariaLabel: undefined,
+    ariaLabelledby: undefined,
+    autofocus: false,
+    button: false,
+    buttonGroup: false,
+    buttonVariant: null,
+    disabled: false,
+    form: undefined,
+    id: undefined,
+    inline: false,
+    modelValue: undefined,
+    name: undefined,
+    plain: false,
+    required: false,
+    reverse: false,
+    size: undefined,
+    state: null,
+    value: true,
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: RadioValue]
+}>()
 
 const slots = defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = defineModel<RadioValue | undefined>({
-  default: undefined,
-})
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'form-check')
 

--- a/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRadio/BFormRadioGroup.vue
@@ -26,35 +26,65 @@
 </template>
 
 <script setup lang="ts">
-import type {BFormRadioGroupProps, RadioValue} from '../../types'
+import type {AriaInvalid, ButtonVariant, RadioOptionRaw, RadioValue, Size} from '../../types'
 import {computed, provide, ref, toRef} from 'vue'
 import {radioGroupKey} from '../../utils'
 import BFormRadio from './BFormRadio.vue'
 import {getGroupAttr, getGroupClasses, useId} from '../../composables'
-import {useFocus} from '@vueuse/core'
+import {useFocus, useVModel} from '@vueuse/core'
 
-const props = withDefaults(defineProps<BFormRadioGroupProps>(), {
-  ariaInvalid: undefined,
-  autofocus: false,
-  buttonVariant: 'secondary',
-  buttons: false,
-  disabled: false,
-  disabledField: 'disabled',
-  form: undefined,
-  htmlField: 'html',
-  id: undefined,
-  name: undefined,
-  options: () => [],
-  plain: false,
-  required: false,
-  reverse: false,
-  size: 'md',
-  stacked: false,
-  state: null,
-  textField: 'text',
-  validated: false,
-  valueField: 'value',
-})
+const props = withDefaults(
+  defineProps<{
+    ariaInvalid?: AriaInvalid
+    autofocus?: boolean
+    buttonVariant?: ButtonVariant | null
+    buttons?: boolean
+    disabled?: boolean
+    disabledField?: string
+    form?: string
+    htmlField?: string
+    id?: string
+    modelValue?: RadioValue
+    name?: string
+    options?: readonly RadioOptionRaw[]
+    plain?: boolean
+    required?: boolean
+    reverse?: boolean
+    size?: Size
+    stacked?: boolean
+    state?: boolean | null
+    textField?: string
+    validated?: boolean
+    valueField?: string
+  }>(),
+  {
+    ariaInvalid: undefined,
+    autofocus: false,
+    buttonVariant: 'secondary',
+    buttons: false,
+    disabled: false,
+    disabledField: 'disabled',
+    form: undefined,
+    htmlField: 'html',
+    id: undefined,
+    modelValue: null,
+    name: undefined,
+    options: () => [],
+    plain: false,
+    required: false,
+    reverse: false,
+    size: 'md',
+    stacked: false,
+    state: null,
+    textField: 'text',
+    validated: false,
+    valueField: 'value',
+  }
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: RadioValue]
+}>()
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,9 +93,7 @@ defineSlots<{
   first?: (props: Record<string, never>) => any
 }>()
 
-const modelValue = defineModel<RadioValue | null>({
-  default: null,
-})
+const modelValue = useVModel(props, 'modelValue', emit, {passive: true})
 
 const computedId = useId(() => props.id, 'radio')
 const computedName = useId(() => props.name, 'checkbox')


### PR DESCRIPTION
# Describe the PR

Using defineModel with a type defined outside of the .vue file is causing the sfc to infer the wrong type.  I was unable to get defineModel to work for the BFrom* classes, so this PR is reverting to useVModel.  See my comment [here](https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1846#issuecomment-2057882089) for more details.

## Small replication

This repros in the playground examples for BFromRadio* and BFromCheckbox* as well as the smaller repro in #1846.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
