### PR TITLE
fix(BTable): Pass through original records to slots when primary key is defined

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -434,7 +434,11 @@ const computedItems = computed<T[]>(() => {
 
   let mappedItems = usesProvider.value ? internalItems.value : (props.items as T[])
   mappedItems = mappedItems.map((item) => {
-    if (typeof item === 'object' && item !== null) {
+    if (
+      typeof item === 'object' &&
+      item !== null &&
+      Object.keys(item).some((key) => key.includes('.'))
+    ) {
       // We use any here because the TS doesn't isn't certain that "item" is the same type as our newItem.
       // But we've determined that it's an object, so we can ignore it since they will always be the same "object"
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -63,7 +63,7 @@
       <slot
         name="custom-body"
         :fields="computedFields"
-        :items="internalItems"
+        :items="items"
         :columns="computedFields.length"
       >
         <BTr v-if="!props.stacked && $slots['top-row']">
@@ -99,9 +99,9 @@
                 "
                 :value="get(item, String(field.key))"
                 :index="itemIndex"
-                :item="item"
+                :item="original(item)"
                 :field="field"
-                :items="internalItems"
+                :items="items"
                 :toggle-details="
                   () => {
                     toggleRowDetails(item)
@@ -122,7 +122,7 @@
               <BTd :colspan="computedFieldsTotal">
                 <slot
                   name="row-details"
-                  :item="item"
+                  :item="original(item)"
                   :toggle-details="
                     () => {
                       toggleRowDetails(item)
@@ -137,7 +137,7 @@
         </template>
         <BTr v-if="props.showEmpty && internalItems.length === 0" class="b-table-empty-slot">
           <BTd :colspan="computedFieldsTotal">
-            <slot name="empty" :items="internalItems">
+            <slot name="empty" :items="items">
               {{ emptyText }}
             </slot>
           </BTd>
@@ -183,7 +183,7 @@
       <slot
         name="custom-foot"
         :fields="computedFields"
-        :items="internalItems"
+        :items="items"
         :columns="computedFields.length"
       />
     </BTfoot>
@@ -272,6 +272,26 @@ watch(
     internalItems.value = JSON.parse(JSON.stringify(newItems))
   }
 )
+
+const itemMap = computed(() => {
+  const map = new Map<string | number, T>()
+  const key = props.primaryKey
+  if (key) {
+    props.items.forEach((item) => {
+      if (isTableItem(item)) {
+        map.set(item[key] as string | number, item)
+      }
+    })
+  }
+  return map
+})
+
+const original = (item: T) => {
+  const key = props.primaryKey
+  return key
+    ? itemMap.value.get((item as Record<string, unknown>)[key] as string | number) ?? item
+    : item
+}
 
 const computedTableClasses = computed(() => [
   props.tableClass,

--- a/packages/bootstrap-vue-next/src/components/BTable/table-lite.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BTable/table-lite.spec.ts
@@ -2,6 +2,20 @@ import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import BTableLite from './BTableLite.vue'
 
+class Person {
+  constructor(
+    public id: number,
+    public firstName: string,
+    public lastName: string,
+    public age: number
+  ) {
+    this.id = id
+    this.firstName = firstName
+    this.lastName = lastName
+    this.age = age
+  }
+}
+
 describe('btablelite', () => {
   enableAutoUnmount(afterEach)
 
@@ -193,5 +207,64 @@ describe('btablelite', () => {
     await $third.trigger('click')
 
     expect((wrapper.html().match(/THE ROW!/g) || []).length).toBe(2)
+  })
+
+  it('Passes the original object for scoped cell slot item', () => {
+    const items = [new Person(1, 'John', 'Doe', 30), new Person(2, 'Jane', 'Smith', 25)]
+    const wrapper = mount(BTableLite, {
+      props: {
+        primaryKey: 'id',
+        items,
+      },
+      slots: {
+        'cell()': `<template #cell()="row">{{ row.item.constructor.name }}</template>`,
+      },
+    })
+    const $tbody = wrapper.get('tbody')
+    const $tr = $tbody.findAll('tr')
+    $tr.forEach((el) => {
+      const $tds = el.findAll('td')
+      expect($tds.length).toBe(4)
+      $tds.forEach(($td) => {
+        expect($td.text()).toBe('Person')
+      })
+    })
+  })
+
+  it('Passes the original objects for scoped cell slot items', () => {
+    const items = [new Person(1, 'John', 'Doe', 30), new Person(2, 'Jane', 'Smith', 25)]
+    const wrapper = mount(BTableLite, {
+      props: {
+        primaryKey: 'id',
+        items,
+      },
+      slots: {
+        'cell()': `<template #cell()="row">{{ row.items[0].constructor.name }}</template>`,
+      },
+    })
+    const $tbody = wrapper.get('tbody')
+    const $tr = $tbody.findAll('tr')
+    $tr.forEach((el) => {
+      const $tds = el.findAll('td')
+      expect($tds.length).toBe(4)
+      $tds.forEach(($td) => {
+        expect($td.text()).toBe('Person')
+      })
+    })
+  })
+
+  it('Passes the original objects for scoped custom table body', () => {
+    const items = [new Person(1, 'John', 'Doe', 30), new Person(2, 'Jane', 'Smith', 25)]
+    const wrapper = mount(BTableLite, {
+      props: {
+        primaryKey: 'id',
+        items,
+      },
+      slots: {
+        'custom-body': `<template #custom-body="table">{{ table.items[0].constructor.name }}</template>`,
+      },
+    })
+    const $tbody = wrapper.get('tbody')
+    expect($tbody.text()).toBe('Person')
   })
 })


### PR DESCRIPTION
# Describe the PR

For use cases when row items are defined as functional objects, it's convenient for the original object to be passed through to the scoped slots. The object still has to not contain loops and correctly transform through the JSON.parse(JSON.stringify()) loop, but it is returned to the client code intact.

The requirements for this to work are:
1. The table must contain a primary-key property
2. The object keys must not contain "." - I don't believe this is an issue, because the use case for this kind of pass-through is well-behaved typescript objects, which should have property names containing "."

If this is acceptable, I'll get documentation including the limitations (and probably some stuff around it) in as a follow-up PR.

## Small replication

Included in the test cases in the PR.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
