### PR TITLE
BTable - allow dot in sortby key

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -385,7 +385,7 @@ const computedItems = computed<T[]>(() => {
 
             return false
           })
-          const val = ob[sortOption.key as keyof TableItem]
+          const val = get(ob, sortOption.key as keyof TableItem)
           if (isTableField(sortField) && !!sortField.sortByFormatted) {
             const formatter =
               typeof sortField.sortByFormatted === 'function'


### PR DESCRIPTION
# Describe the PR

This PR allow dot syntax in BTable ```sortBy```

```vue
<template>
  <BContainer>
    <BRow>
      <BCol>
        <BTable :items="items" :sort-by="[{key: 'address.city', order: 'desc'}]" />
      </BCol>
    </BRow>
  </BContainer>
</template>

<script setup lang="ts">
const items = [
  {
    id: 1,
    name: 'John',
    address: {
      city: 'Rome',
    },
  },
  {
    id: 2,
    name: 'Aron',
    address: {
      city: 'Turin',
    },
  },
  {
    id: 3,
    name: 'Zoe',
    address: {
      city: 'Turin',
    },
  },
  {
    id: 4,
    name: 'Paul',
    address: {
      city: 'Milan',
    },
  },
]
</script>

```