### PR TITLE
docs(BCheckBox*): Small changes to get documentation to parity

### DIFF
--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -40,7 +40,7 @@ export default {
         {
           prop: 'buttonVariant',
           type: 'ButtonVariant | null',
-          default: null,
+          default: 'secondary',
           description: "Applies one of Bootstrap's theme colors when in `button` mode",
         },
         {
@@ -83,7 +83,7 @@ export default {
           type: 'CheckboxValue | readonly CheckboxValue[]',
           default: undefined,
           description:
-            'The current value of the checkbox(es). Must be an array when there are multiple checkboxes bound to the same v-model',
+            'The current value of the checkbox(es). Must be an array when there are multiple checkboxes bound to the same v-model. Looking for `value` - use `modelValue` instead.',
         },
         {
           prop: 'name',
@@ -150,7 +150,7 @@ export default {
             {
               arg: 'checked',
               description:
-                'Value of the checkbox.  Value will be an array for grouped checkboxes or a single value for standalone checkboxes.',
+                'Value of the checkbox. Value will be an array for grouped checkboxes or a single value for standalone checkboxes. Looking for the `input` or `change` event - use `update:modelValue` instead.',
               type: 'CheckboxValue | readonly CheckboxValue[]',
             },
           ],
@@ -245,7 +245,7 @@ export default {
           type: 'readonly CheckboxValue[]',
           default: '() => []',
           description:
-            'The current value of the checked checkboxes in the group. Must be an array when there are multiple checkboxes',
+            'The current value of the checked checkboxes in the group. Must be an array when there are multiple checkboxes. . Looking for `value` - use `modelValue` instead.',
         },
         {
           prop: 'name',
@@ -324,7 +324,8 @@ export default {
       emits: [
         {
           event: 'update:modelValue',
-          description: 'Emitted when the selected value(s) are changed',
+          description:
+            'Emitted when the selected value(s) are changed. . Looking for the `input` or `change` event - use `update:modelValue` instead.',
           args: [
             {
               arg: 'update:modelValue',

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -433,7 +433,7 @@ Use the `reverse` prop to put your checkboxes and switches on the opposite side 
 
 ## Without Labels
 
-In order to ommit labels as described in the
+In order to omit labels as described in the
 [bootstrap documentation](https://getbootstrap.com/docs/5.3/forms/checks-radios/#without-labels)
 just leave the default slot empty. Remember to still provide some form of accessible name for
 assistive technologies (for instance, using aria-label).

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -431,6 +431,28 @@ Use the `reverse` prop to put your checkboxes and switches on the opposite side 
   </template>
 </HighlightCard>
 
+## Without Labels
+
+In order to ommit labels as described in the
+[bootstrap documentation](https://getbootstrap.com/docs/5.3/forms/checks-radios/#without-labels)
+just leave the default slot empty. Remember to still provide some form of accessible name for
+assistive technologies (for instance, using aria-label).
+
+<HighlightCard>
+  <BFormCheckbox></BFormCheckbox>
+  <BFormCheckbox disabled></BFormCheckbox>
+  <BFormCheckbox switch></BFormCheckbox>
+  <template #html>
+
+```vue-html
+  <BFormCheckbox></BFormCheckbox>
+  <BFormCheckbox disabled></BFormCheckbox>
+  <BFormCheckbox switch></BFormCheckbox>
+```
+
+  </template>
+</HighlightCard>
+
 ## Checkbox values and `v-model`
 
 By default, `BFormCheckbox` value will be true when checked and false when unchecked. You can customize the checked and unchecked values by specifying the `value` and `unchecked-value` properties, respectively.

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -1,10 +1,82 @@
 # Migration Guide
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+## Overview
+
+`bootstrap-vue-next` is an entirely new implementation of [bootrap-vue](https://bootstrap-vue.org/) based on [Vue 3](https://vuejs.org/) and [Bootstrap 5](https://getbootstrap.com/). Therefore, you should not expect this to be a drop-in replacement. Where possible compatibility has been maintained, but providing a clean developer experience when working with `Vue 3`, `Bootstrap 5` and this library is a higher priority.
+
+You should start by familiarizing yourself with the [Vue 3 Migration Guide](https://v3-migration.vuejs.org/), espectially
+the [breaking changes](https://v3-migration.vuejs.org/breaking-changes/) section and the
+[Bootstrap 5 migration guide](https://getbootstrap.com/docs/5.3/migration/#v530). While there are
+some places where this library will insulate you from the changes to the underlying libraries,
+a general familiarity with the changes in the core dependencies will serve you well.
+
+For instance, there are likely many places where you use `Bootstrap` utility classes in order to style your components.
+`Bootstrap 5` change made a [breaking change](https://getbootstrap.com/docs/5.3/migration/#utilities-3) to all utility
+classes that involve `left` and `right` (or `l` and `r`) to be `start` and `end` (or `s` and `e`). This
+will affect compents such as `BNavBar` in unexpected ways that BSVN has no control over.
+
+## Sync modifier
+
+A number of components in `bootstrap-vue` use `v-bind`'s `.sync` modifier. This modifier has been replaced by properties
+on the the model (generally named models).
+
+For instance, in order to two-way bind to the `indeterminate` property in `BFormCheckBox` you `v-bind` to the the model
+named `indeterminate` rather than adding the sync modifier to the `indeterminate` property:
+
+<HighlightCard>
+  <template #html>
+
+```vue-html
+    <b-form-checkbox v-model="checked" :indeterminate.sync="indeterminate">
+      Click me to see what happens
+    </b-form-checkbox>
+```
+
+  </template>
+</HighlightCard>
+
+becomes
+
+<HighlightCard>
+  <template #html>
+
+```vue-html
+  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate"
+    >Click me to see what happens</BFormCheckbox
+  >
+```
+
+  </template>
+</HighlightCard>
+
+See the [Vue 3 migration guide](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
+for more info.
+
+## BForm Components
+
+`Vue 3` changed the the way that `v-model` binding works and in the process changed the guidance
+when naming the main model property and events for the primary model. `bootstrap-vue-next` follows
+this guidance, which affects all of the wrappers for form input. If you're looking for the `value`
+property or the `change` and `input` events, you'll find that functionality in the `modelValue`
+property and `update:modelValue` events.
+
+See the [Vue 3 migration guide](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
+for more info.
+
 <MigrationWrapper v-for="(item, i) in changes" :key="i" v-bind="item" />
 
 <script setup lang="ts">
 import {computed} from 'vue'
 import MigrationWrapper from '../components/MigrationWrapper.vue'
+import HighlightCard from '../components/HighlightCard.vue'
 
 const changes = computed<{
   component: string

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -35,9 +35,9 @@ named `indeterminate` rather than adding the sync modifier to the `indeterminate
   <template #html>
 
 ```vue-html
-    <b-form-checkbox v-model="checked" :indeterminate.sync="indeterminate">
+    <BFormCheckbox v-model="checked" :indeterminate.sync="indeterminate">
       Click me to see what happens
-    </b-form-checkbox>
+    </BFormCheckbox>
 ```
 
   </template>

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -19,6 +19,16 @@
 <BCard class="bg-body-tertiary">
 
 ```ts
+type AriaInvalid = boolean | 'grammar' | 'spelling'
+```
+
+</BCard>
+
+## AriaInvalid
+
+<BCard class="bg-body-tertiary">
+
+```ts
 type CommonAlignment = 'start' | 'end' | 'center' | 'fill'
 type Vertical = CommonAlignment | 'baseline' | 'stretch'
 type Horizontal = CommonAlignment | 'between' | 'around'
@@ -105,6 +115,47 @@ type ButtonVariant =
   | 'outline-info'
   | 'outline-light'
   | 'outline-dark'
+```
+
+</BCard>
+
+## CheckboxOption
+
+<BCard class="bg-body-tertiary">
+
+```ts
+type CheckboxOption = {
+  text: string
+  value: CheckboxValue
+  disabled?: boolean
+}
+```
+
+</BCard>
+
+## CheckboxOptionRaw
+
+<BCard class="bg-body-tertiary">
+
+```ts
+type CheckboxOptionRaw = string | number | (Partial<CheckboxOption> & Record<string, unknown>)
+```
+
+</BCard>
+
+## CheckboxValue
+
+<BCard class="bg-body-tertiary">
+
+```ts
+type CheckboxValue =
+  | readonly unknown[]
+  | ReadonlySet<unknown>
+  | string
+  | boolean
+  | Readonly<Record<string, unknown>>
+  | number
+  | null
 ```
 
 </BCard>

--- a/packages/bootstrap-vue-next/src/types/exports/index.ts
+++ b/packages/bootstrap-vue-next/src/types/exports/index.ts
@@ -6,6 +6,7 @@ export type {
   AlignmentTextHorizontal,
   AlignmentVertical,
   Animation,
+  AriaInvalid,
   BTableProvider,
   BTableProviderContext,
   BaseButtonVariant,


### PR DESCRIPTION
# Describe the PR

This PR should get the documents up to date and confirm that they are [at parity](https://1drv.ms/x/s!AiUqzkjNYGL6ieBPpQpcR41wo1laZQ?e=DYykFl) with BSV and BS5

- Document 'Without Labels'
- Document all types
- Export `AriaInvalid`, which was used but not exported
- Start general migration docs to cover cases that are used in these components

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [X] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
