### PR TITLE
docs: Add component reference link in the page table of contents sidebar

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -2,7 +2,7 @@
   <BContainer fluid class="p-0 component-reference">
     <BRow>
       <BCol>
-        <h2>Component Reference</h2>
+        <h2 id="component-reference">Component Reference</h2>
       </BCol>
     </BRow>
     <BRow>

--- a/apps/docs/src/components/ComponentSidebar.vue
+++ b/apps/docs/src/components/ComponentSidebar.vue
@@ -1,0 +1,20 @@
+<template>
+  <ContentsSidebar>
+    <template #default>
+      <slot />
+    </template>
+    <template #after>
+      <nav class="table-of-contents">
+        <ul>
+          <li>
+            <a href="#component-reference">Component Reference</a>
+          </li>
+        </ul>
+      </nav>
+    </template>
+  </ContentsSidebar>
+</template>
+
+<script setup lang="ts">
+import ContentsSidebar from './ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/components/ContentsSidebar.vue
+++ b/apps/docs/src/components/ContentsSidebar.vue
@@ -1,0 +1,5 @@
+<template>
+  <ClientOnly>
+    <Teleport to=".bd-toc"><slot /><slot name="after" /></Teleport>
+  </ClientOnly>
+</template>

--- a/apps/docs/src/docs/components/accordion.md
+++ b/apps/docs/src/docs/components/accordion.md
@@ -1,12 +1,10 @@
 # Accordion
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -171,5 +169,6 @@ Add `free` property to make accordion items stay open when another item is opene
 import {data} from '../../data/components/accordion.data'
 import {BAccordion, BAccordionItem, BAlert} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -1,12 +1,10 @@
 # Alert
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -345,6 +343,7 @@ const stop = () => myAlert.value?.stop()
 import {data} from '../../data/components/alert.data'
 import {BAlert, BProgress, BButton, BButtonGroup} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {ref, computed} from 'vue'
 

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -1,12 +1,10 @@
 # Avatar
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -763,6 +761,7 @@ Avatars are based upon `BBadge` and `BButton` components, and as such, rely upon
 import {data} from '../../data/components/avatar.data'
 import {BAvatar, BAvatarGroup, BListGroup, BBadge, BListGroupItem} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 
 const alertEvent = (event: PointerEvent) => {

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -1,12 +1,10 @@
 # Badge
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -215,5 +213,6 @@ Quickly provide actionable badges with ~~hover~~ and ~~focus~~ states by specify
 import {data} from '../../data/components/badge.data'
 import {BButton, BBadge} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -1,12 +1,10 @@
 # Breadcrumb
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -138,6 +136,7 @@ import {data} from '../../data/components/breadcrumb.data'
 import {ref} from 'vue';
 import {BBreadcrumbItem, BBreadcrumb} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import type {BreadcrumbItem} from 'bootstrap-vue-next'
 

--- a/apps/docs/src/docs/components/button-group.md
+++ b/apps/docs/src/docs/components/button-group.md
@@ -1,12 +1,10 @@
 # Button Group
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -188,5 +186,6 @@ toolbars containing button groups and input groups.
 import {data} from '../../data/components/buttonGroup.data'
 import {BDropdownItem, BDropdownDivider, BButton, BButtonGroup, BDropdown} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/button-toolbar.md
+++ b/apps/docs/src/docs/components/button-toolbar.md
@@ -1,12 +1,10 @@
 # Button Toolbar
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -265,5 +263,6 @@ input groups and dropdowns, by setting the prop `justify`.
 import {data} from '../../data/components/buttonToolbar.data'
 import {BButtonGroup, BDropdown, BInputGroup, BDropdownItem, BButton, BButtonToolbar, BFormInput} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -1,12 +1,10 @@
 # Button
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -380,6 +378,7 @@ import {data} from '../../data/components/button.data'
 import {ref, computed} from 'vue'
 import {BButtonGroup, BButton} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 
 const buttonToggle = ref(false);

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -1,12 +1,10 @@
 # Card
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -1146,6 +1144,7 @@ set them to display: inline-block as column-break-inside: avoid is not a bulletp
 <script setup lang="ts">
 import {data} from '../../data/components/card.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BCard,

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -1,12 +1,10 @@
 # Carousel
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -527,6 +525,7 @@ const next = () => myCarousel.value?.next()
 <script setup lang="ts">
 import {data} from '../../data/components/carousel.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BButton, BButtonGroup, BAlert, BCarouselSlide, BCarousel} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -1,12 +1,10 @@
 # Collapse
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -274,6 +272,7 @@ apply those roles for you automatically, as it depends on your final document ma
 <script setup lang="ts">
 import {data} from '../../data/components/collapse.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BCard,

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -1,12 +1,10 @@
 # Dropdown
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -1182,6 +1180,7 @@ The dropdown menu is rendered with semantic `<ul>` and `<li>` elements for acces
 <script setup lang="ts">
 import {data} from '../../data/components/dropdown.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BDropdownGroup,

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -1,12 +1,10 @@
 # Form Checkbox
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -1058,6 +1056,7 @@ watch(flavorSelected, (newValue: string[]) => {
 import {data} from '../../data/components/formCheckbox.data'
 import {computed, ref, watch} from 'vue'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarning.vue'
 import {BButton, BFormCheckboxGroup, BFormCheckbox, BFormGroup, BCard, BCardBody, BAlert} from 'bootstrap-vue-next'

--- a/apps/docs/src/docs/components/form-file.md
+++ b/apps/docs/src/docs/components/form-file.md
@@ -1,12 +1,10 @@
 # Form File
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -233,6 +231,7 @@ The BFormFile exposes functions to control the component: `focus(), blur(), rese
 <script setup lang="ts">
 import {data} from '../../data/components/formFile.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BFormFile, BAlert, BLink} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -1,12 +1,10 @@
 # Form Group
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -515,6 +513,7 @@ scoped `default` slot.
 <script setup lang="ts">
 import {data} from '../../data/components/formGroup.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BFormRadioGroup, BFormGroup, BFormInput} from 'bootstrap-vue-next'
 import {computed, ref} from 'vue'

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -1,12 +1,10 @@
 # Form Input
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -630,6 +628,7 @@ const selectAllText = () => inputRef.value.input.select()
 <script setup lang="ts">
 import {data} from '../../data/components/formInput.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BButton, BFormText, BFormInvalidFeedback, BRow, BCol, BContainer, BCard, BCardBody, BFormInput} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'

--- a/apps/docs/src/docs/components/form-radio.md
+++ b/apps/docs/src/docs/components/form-radio.md
@@ -1,12 +1,10 @@
 # Form Radio
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -702,6 +700,7 @@ Supported `aria-invalid` values are:
 <script setup lang="ts">
 import {data} from '../../data/components/formRadio.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarning.vue'
 import {BFormRadioGroup, BCard, BCardBody, BFormRadio, BAlert} from 'bootstrap-vue-next'

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -1,12 +1,10 @@
 # Form Select
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -553,6 +551,7 @@ When `state` is set to `false`, aria-invalid will also be set to true.
 <script setup lang="ts">
 import {data} from '../../data/components/formSelect.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarning.vue'
 import {BFormSelectOptionGroup, BFormSelectOption, BCard, BCardBody, BFormSelect, BAlert, BBadge} from 'bootstrap-vue-next'

--- a/apps/docs/src/docs/components/form-spinbutton.md
+++ b/apps/docs/src/docs/components/form-spinbutton.md
@@ -1,12 +1,10 @@
 # Form Spinbutton
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -195,14 +193,7 @@ By default `BFormSpinbutton` will format the displayed number in the users brows
   <label for="sb-locales">Locale</label>
   <BFormSelect id="sb-locales" v-model="locale" :options="locales" />
   <label for="sb-local" class="mt-2">Spin button with locale</label>
-  <BFormSpinbutton
-    id="sb-locale"
-    v-model="value"
-    :locale="locale"
-    min="0"
-    max="10"
-    step="0.125"
-  />
+  <BFormSpinbutton id="sb-locale" v-model="value" :locale="locale" min="0" max="10" step="0.125" />
   <p>Value: {{ value }}</p>
 </template>
 
@@ -211,11 +202,11 @@ const value = ref(0)
 
 const locale = ref('fr-CA')
 const locales = [
-  { value: 'en', text: 'English' },
-  { value: 'de', text: 'German' },
-  { value: 'fr-CA', text: 'French (Canadian)' },
-  { value: 'fa', text: 'Persian' },
-  { value: 'ar-EG', text: 'Arabic (Egyptian)' }
+  {value: 'en', text: 'English'},
+  {value: 'de', text: 'German'},
+  {value: 'fr-CA', text: 'French (Canadian)'},
+  {value: 'fa', text: 'Persian'},
+  {value: 'ar-EG', text: 'Arabic (Egyptian)'},
 ] as const
 </script>
 ```
@@ -242,13 +233,7 @@ To provide a formatter function, set the prop `formatter-fn` to a method referen
 
 ```vue
 <template>
-  <BFormSpinbutton
-    v-model="value"
-    :formatter-fn="dayFormatter"
-    min="0"
-    max="6"
-    wrap
-  />
+  <BFormSpinbutton v-model="value" :formatter-fn="dayFormatter" min="0" max="6" wrap />
   <p>Value: {{ value }}</p>
 </template>
 
@@ -330,12 +315,7 @@ The following example illustrates the difference between the `update:modelValue`
 ```vue
 <template>
   <label for="sb-input">Spin button - input and change events</label>
-  <BFormSpinbutton
-    id="sb-input"
-    v-model="value1"
-    @change="value2 = $event"
-    wrap
-  />
+  <BFormSpinbutton id="sb-input" v-model="value1" @change="value2 = $event" wrap />
   <p>Input event: {{ value1 }}</p>
   <p>Change event: {{ value2 }}</p>
 </template>
@@ -367,6 +347,7 @@ Note the the `repeat-delay`, `repeat-threshold` and `repeat-interval` only appli
 <script setup lang="ts">
 import {data} from '../../data/components/formSpinbutton.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BButton, BProgressBar, BCard, BCardBody, BProgress, BFormSpinbutton, BFormSelect, BRow, BCol} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -1,12 +1,10 @@
 # Form Tags
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -1267,6 +1265,7 @@ Note `<BFormTag>` requires BootstrapVue's custom CSS/SCSS for proper styling.
 <script setup lang="ts">
   import {data} from '../../data/components/formTags.data'
   import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
   import HighlightCard from '../../components/HighlightCard.vue'
   import {BFormTags, BFormText, BFormGroup, BInputGroupAppend, BButton, BCard, BInputGroup, BFormTag, BFormInput, BFormSelect, BFormCheckbox, BFormInvalidFeedback, BDropdownForm, BDropdownDivider, BDropdownItemButton, BDropdownText, BDropdown} from 'bootstrap-vue-next'
   import {ref, computed, watch} from 'vue'

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -1,12 +1,10 @@
 # Form Textarea
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -467,6 +465,7 @@ these methods and properties. Support will vary based on input type.
 import {data} from '../../data/components/formTextarea.data'
 import {ref, computed} from 'vue'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BFormGroup, BRow, BCol, BFormTextarea, BCard, BCardBody} from 'bootstrap-vue-next'
 

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -1,12 +1,10 @@
 # Form
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -442,6 +440,7 @@ for details on the Bootstrap v5 validation states.
 <script setup lang="ts">
 import {data} from '../../data/components/form.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BFormValidFeedback,

--- a/apps/docs/src/docs/components/grid-system.md
+++ b/apps/docs/src/docs/components/grid-system.md
@@ -1,12 +1,10 @@
 # Grid System
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -176,6 +174,7 @@ For more detailed documentation and understanding, please visit Bootstrap's offi
 <script setup lang="ts">
 import {data} from '../../data/components/gridSystem.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BContainer, BRow, BCol, BImg} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -1,12 +1,10 @@
 # Image
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -287,6 +285,7 @@ Lazy loaded images are actived through the `lazy` prop. Eventually, the componen
 <script setup lang="ts">
 import {data} from '../../data/components/image.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BRow, BCol, BCard, BCardBody, BImg} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -1,12 +1,10 @@
 # Input Group
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -498,6 +496,7 @@ input groups. However, the inputs inside the input group do support contextual s
 <script setup lang="ts">
 import {data} from '../../data/components/inputGroup.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BFormRadio,

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -1,12 +1,10 @@
 # Link
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -131,6 +129,7 @@ You can use the `variant` prop to colorize links. Some of the link styles use a 
 <script setup lang="ts">
 import {data} from '../../data/components/link.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BLink, BCard, BCardBody} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/list-group.md
+++ b/apps/docs/src/docs/components/list-group.md
@@ -1,12 +1,10 @@
 # List Group
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -573,6 +571,7 @@ help of [flexbox utility classes](/docs/reference/utility-classes).
 <script setup lang="ts">
 import {data} from '../../data/components/listGroup.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BListGroup, BBadge, BCardGroup, BListGroupItem} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -1,12 +1,10 @@
 # Modal
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -223,6 +221,7 @@ To programmatically create modals, refer to the documentation at [useModalContro
 <script setup lang="ts">
 import {data} from '../../data/components/modal.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BModal, BButton, vBModal} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/nav.md
+++ b/apps/docs/src/docs/components/nav.md
@@ -1,12 +1,10 @@
 # Nav
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -191,6 +189,7 @@ Use the `BNavText` child component to place plain text content into the nav:
 <script setup lang="ts">
 import {data} from '../../data/components/nav.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BNav,

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -1,12 +1,10 @@
 # Navbar
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -447,6 +445,7 @@ Navbars are hidden by default when printing. Force them to be printed by setting
 <script setup lang="ts">
 import {data} from '../../data/components/navbar.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BNavText, BInputGroup, BNavbar, BNavbarBrand, BNavbarToggle, BCollapse, BNavbarNav, BNavForm, BNavItem, BFormInput, BNavItemDropdown, BDropdownItem, BButton, vBColorMode} from 'bootstrap-vue-next'
 import ChevronBarUpIcon from '~icons/bi/chevron-bar-up'

--- a/apps/docs/src/docs/components/offcanvas.md
+++ b/apps/docs/src/docs/components/offcanvas.md
@@ -1,12 +1,10 @@
 # Offcanvas
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -84,6 +82,7 @@ const click = (place = 'start') => {
 <script setup lang="ts">
 import {data} from '../../data/components/offcanvas.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BOffcanvas, BButton} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'

--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -1,12 +1,10 @@
 # Overlay
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -899,6 +897,7 @@ also set the `rounded` prop on `BOverlay`.
 <script setup lang="ts">
 import {data} from '../../data/components/overlay.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BForm, BProgress, BRow, BImg, BFormInput, BFormSelect, BOverlay, BCol, BButton, BCard, BCardBody, BCardText, BAlert} from 'bootstrap-vue-next'
 import {ref, nextTick} from 'vue';

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -1,12 +1,10 @@
 # Pagination
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -408,6 +406,7 @@ recommended unless the content of the button textually conveys its purpose.
 <script setup lang="ts">
 import {data} from '../../data/components/pagination.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BProgress, BSpinner, BCard, BCardBody, BPagination} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'

--- a/apps/docs/src/docs/components/placeholder.md
+++ b/apps/docs/src/docs/components/placeholder.md
@@ -1,12 +1,10 @@
 # Placeholder
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -342,6 +340,7 @@ Optionally, you can manually adjust any scope of the table using slots. The foll
 <script setup lang="ts">
 import {data} from '../../data/components/placeholder.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BPlaceholderButton,

--- a/apps/docs/src/docs/components/popover.md
+++ b/apps/docs/src/docs/components/popover.md
@@ -1,12 +1,10 @@
 # Popover
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 ## Docs to be written
 
@@ -15,4 +13,5 @@
 <script setup lang="ts">
 import {data} from '../../data/components/popover.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 </script>

--- a/apps/docs/src/docs/components/progress.md
+++ b/apps/docs/src/docs/components/progress.md
@@ -1,12 +1,10 @@
 # Progress
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -250,6 +248,7 @@ const animate = ref(false)
 <script setup lang="ts">
 import {data} from '../../data/components/progress.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import {BButton, BProgressBar, BCard, BProgress} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
 import { ref } from 'vue';

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -1,12 +1,10 @@
 # Spinners
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -296,6 +294,7 @@ As well, when no label is provided, the spinner will automatically have the attr
 <script setup lang="ts">
 import {data} from '../../data/components/spinner.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BButton, BSpinner} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -1,12 +1,10 @@
 # Tables
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -1099,6 +1097,7 @@ function onAddSort() {
 <script setup lang="ts">
 import {data} from '../../data/components/table.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BButton,

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -1,12 +1,10 @@
 # Tabs
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 ## Docs to be written
 
@@ -15,4 +13,5 @@
 <script setup lang="ts">
 import {data} from '../../data/components/tabs.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 </script>

--- a/apps/docs/src/docs/components/toast.md
+++ b/apps/docs/src/docs/components/toast.md
@@ -1,12 +1,10 @@
 # Toast
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ComponentSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
+</ComponentSidebar>
 
 <div class="lead mb-5">
 
@@ -250,6 +248,7 @@ If you just need a single simple message to appear along the bottom or top of th
 <script setup lang="ts">
 import {data} from '../../data/components/toast.data'
 import ComponentReference from '../../components/ComponentReference.vue'
+import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import {BButtonGroup, BButton, BToast, useToast} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {ref, h, onMounted} from 'vue'

--- a/apps/docs/src/docs/composables/useBreadcrumb.md
+++ b/apps/docs/src/docs/composables/useBreadcrumb.md
@@ -1,13 +1,10 @@
 # useBreadcrumb
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 `useBreadcrumb` is a helper utility for the `BBreadcrumb` component. It provides a **globally** changable context so you can modify a breadcrumb. It should be noted that the breacrumb component will automatically use the global context by default. `useBreadcrumb` is shared globally, one modification to the state will be recognized throughout the app. As noted in the BBreadcrumb documentation, the items prop for the component takes precedence over `useBreadcrumb`
@@ -53,6 +50,7 @@ const addItem = () => {
 <script setup lang="ts">
 import {ref} from 'vue'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {BBreadcrumb, BButton, BFormInput, BFormGroup, BCard, BCardBody, useBreadcrumb} from 'bootstrap-vue-next'
 

--- a/apps/docs/src/docs/composables/useColorMode.md
+++ b/apps/docs/src/docs/composables/useColorMode.md
@@ -1,13 +1,10 @@
 # useColorMode
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 `useColorMode` provides a convenient utility to adjust the global color theme of your application. You can also use it to target specific components by using a [template ref](https://vuejs.org/guide/essentials/template-refs.html#template-refs) or a selector. Bootstrap's default behavior dictates that color modes are applied to all children in the branch. `useColorMode` is simply a wrapper for the [vueuse](https://vueuse.org/core/useColorMode/#usecolormode) utility.

--- a/apps/docs/src/docs/composables/useModal.md
+++ b/apps/docs/src/docs/composables/useModal.md
@@ -1,13 +1,10 @@
 # useModal
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 You can use `useModal` to get the closest modal in **child component** and hide it. It can also be supplied a target id to show or hide a specific modal
@@ -70,6 +67,7 @@ const {show, hide, modal} = useModal('my-modal')
 <script setup lang="ts">
 import {BButton, BModal, useModal} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import {ref, onMounted} from 'vue'
 
 const someConditions = ref(false)

--- a/apps/docs/src/docs/composables/useModalController.md
+++ b/apps/docs/src/docs/composables/useModalController.md
@@ -1,13 +1,10 @@
 # useModalController
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 `useModalController` can hide modals everywhere in the app, as well as creating modals on the fly
@@ -228,6 +225,7 @@ const {hide, hideAll} = useModalController()
 <script setup lang="ts">
 import {BButton, BModal, useModalController, BButtonGroup, useToast} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {ref, computed, h, onMounted} from 'vue'
 

--- a/apps/docs/src/docs/composables/useToast.md
+++ b/apps/docs/src/docs/composables/useToast.md
@@ -1,13 +1,10 @@
 # useToast
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Often times one may want to open a `Toast` in a global context, without the need for declaring a component, perhaps to display an error after a function threw an error. `useToast` is used to create `Toasts` on demand. You must have initialized the `BToastOrchestrator` component once in your application. The following functionality requires the existance of that component
@@ -210,6 +207,7 @@ const hideMe = () => {
 import {data} from '../../data/components/toast.data'
 import {BButton, useToast, BButtonGroup, BToast} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {ref, computed, h, onMounted} from 'vue'
 

--- a/apps/docs/src/docs/directives/BColorMode.md
+++ b/apps/docs/src/docs/directives/BColorMode.md
@@ -1,13 +1,10 @@
 # BColorMode
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 The `BColorMode` directive is similar to [useColorMode](../composables/useColorMode.md) but provides a more low level directive for placement on individual components. It is useful when you want to make an element have one color mode, but do not want the overhead of the composable variant.
@@ -51,6 +48,7 @@ const changeColor = () => {
 import {ref} from 'vue'
 import {vBColorMode, BButton, BCard} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 
 const currentColor = ref<'light' | 'dark'>('dark')
 

--- a/apps/docs/src/docs/directives/BTooltip.md
+++ b/apps/docs/src/docs/directives/BTooltip.md
@@ -1,13 +1,10 @@
 # Tooltip
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <BCard class="bg-body-tertiary">
 
 ```vue-html
@@ -177,4 +174,5 @@ We should use the value type when the component is not setting to the root compo
 
 <script setup lang="ts">
 import {BCard, BCardBody} from 'bootstrap-vue-next'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 </script>

--- a/apps/docs/src/docs/icons.md
+++ b/apps/docs/src/docs/icons.md
@@ -1,13 +1,10 @@
 # Icons
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <BAlert variant="danger" :model-value="true" class="my-5">
 
 The icon components from BootstrapVue are deprecated. While migrating to BootstrapVueNext the icon components will not be supported as there are better, more modern solutions to incorporating icon packages into your application. Continue reading BootstrapVueNext's suggestion on how to incorporate Bootstrap-icons into your application! This documentation only serves as a reference, BootstrapVueNext has no part in the mentioned libraries and some content may be out of date.
@@ -241,6 +238,8 @@ import IBiActivity from '~icons/bi/activity'
 <script setup lang="ts">
 import {BCard, BCardBody, BTab, BTabs, BAlert} from 'bootstrap-vue-next'
 import {useLocalStorage} from '@vueuse/core'
+import ContentsSidebar from '../components/ContentsSidebar.vue'
+
 
 const codePreference = useLocalStorage('code-group-preference', 0)
 </script>

--- a/apps/docs/src/docs/reference/accessibility.md
+++ b/apps/docs/src/docs/reference/accessibility.md
@@ -1,13 +1,10 @@
 # Accessibility
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 A brief overview of BootstrapVueNext's features and limitations for the creation of accessible content.
@@ -97,4 +94,5 @@ Steps you should do for testing:
 
 <script setup lang="ts">
 import {BCard} from 'bootstrap-vue-next'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 </script>

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -1,13 +1,10 @@
 # Color variants and CSS class mapping
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 <p>Color variants are available when using the default Bootstrap v5 CSS and their mappings to CSS classes</p>
@@ -240,6 +237,7 @@ $dark: $gray-900;
 <script setup lang="ts">
 import {BCard} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 </script>
 
 <style lang="scss">

--- a/apps/docs/src/docs/reference/contributing.md
+++ b/apps/docs/src/docs/reference/contributing.md
@@ -1,13 +1,10 @@
 # Contributing
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 👍🎉 First off, thanks for taking the time to contribute! 🎉👍
@@ -112,4 +109,5 @@ increase version in package.json, commit
 <script setup lang="ts">
 import {BAlert} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 </script>

--- a/apps/docs/src/docs/reference/form-validation.md
+++ b/apps/docs/src/docs/reference/form-validation.md
@@ -1,15 +1,16 @@
 # Form validation
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 BootstrapVueNext does not include form validation by default; we leave that up to the many existing form validation plugins. Included here are some examples of validation plugins and how they may be integrated.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/router-links.md
+++ b/apps/docs/src/docs/reference/router-links.md
@@ -1,13 +1,10 @@
 # Router link support
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Several BootstrapVue components support rendering `RouterLink` components compatible with Vue Router and Nuxt.js. For more information, see the official [Vue Router docs](https://router.vuejs.org) and official [Nuxt.js docs](https://nuxt.com/docs/api/components/nuxt-link#props).
@@ -203,5 +200,6 @@ router: { prefetchLinks: false }
 
 <script setup lang="ts">
 import HighlightCard from '../../components/HighlightCard.vue'
+import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import {BAlert} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/reference/settings.md
+++ b/apps/docs/src/docs/reference/settings.md
@@ -1,15 +1,16 @@
 # Settings
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 BootstrapVue provides a few options for customizing component default values, and more.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/size-props-and-classes.md
+++ b/apps/docs/src/docs/reference/size-props-and-classes.md
@@ -1,15 +1,16 @@
 # Size props and classes
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS provides several classes that control the sizing of elements, of which some of these have been translated into props on components.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/spacing-classes.md
+++ b/apps/docs/src/docs/reference/spacing-classes.md
@@ -1,15 +1,16 @@
 # Spacing classes
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS includes a wide range of shorthand responsive margin and padding utility classes to modify an element's appearance.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/starter-templates.md
+++ b/apps/docs/src/docs/reference/starter-templates.md
@@ -1,15 +1,16 @@
 # Starter Templates
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 There are several ways you can create your app, from basic client side HTML all the way up to using a build system and compilers.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/theming-bootstrap.md
+++ b/apps/docs/src/docs/reference/theming-bootstrap.md
@@ -1,15 +1,16 @@
 # Theming Bootstrap
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Theming is accomplished by SASS variables, SASS maps, and custom CSS. There is no dedicated theme stylesheet; instead, you can enable the built-in theme to add gradients, shadows, and more.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/third-party-libraries.md
+++ b/apps/docs/src/docs/reference/third-party-libraries.md
@@ -1,15 +1,16 @@
 # Third party libraries
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 There are several 3rd party libraries that you can use to add additional functionality and features to your BootstrapVue project.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/reference/utility-classes.md
+++ b/apps/docs/src/docs/reference/utility-classes.md
@@ -1,15 +1,16 @@
 # Utility Classes
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS provides various utility classes to control color, spacing, flex-box, text alignment, floating, position, responsive display/hiding and much more.
 
 </div>
+
+<script setup lang="ts">
+    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+</script>

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -1,13 +1,10 @@
 # Types
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
+<ContentsSidebar>
 
 [[toc]]
 
-  </Teleport>
-</ClientOnly>
-
+</ContentsSidebar>
 <div class="lead mb-5">
 
 `BootstrapVueNext` is a complete rewrite that strives for full TypeScript compatibility. This is a list of types we use in this library and that you can use too.
@@ -357,4 +354,5 @@ New values can be used now and the type check will be successful:
 
 <script setup lang="ts">
 import {BCard, BCardBody} from 'bootstrap-vue-next'
+import ContentsSidebar from '../components/ContentsSidebar.vue'
 </script>


### PR DESCRIPTION
# Describe the PR

As I'm spending more time in the component docs, I find it annoying that there isn't a link to the component reference in the page contents sidebar.  This is one solution to that problem (although I'm not sure it's the right one).

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
