### PR TITLE
BTable delete selection when primary-key

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -262,7 +262,19 @@ const selectedItemsSetUtilities = {
   },
   delete: (item: T) => {
     const value = new Set(selectedItemsToSet.value)
-    value.delete(item)
+    if (props.primaryKey) {
+      const pkey: string = props.primaryKey
+      selectedItemsModel.value.forEach((v, i) => {
+        const selectedKey = get(v, pkey)
+        const itemKey = get(item, pkey)
+
+        if (!!selectedKey && !!itemKey && selectedKey === itemKey) {
+          value.delete(selectedItemsModel.value[i])
+        }
+      })
+    } else {
+      value.delete(item)
+    }
     selectedItemsToSet.value = value
     emit('row-unselected', item)
   },


### PR DESCRIPTION
# Describe the PR

This PR partially solves #1875 

It allows BTable internal selection delete when ```primaryKey``` prop is provided

