### PR TITLE
feat(BOffcanvas): allow specifying a width

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -20,6 +20,7 @@
         aria-modal="true"
         role="dialog"
         :class="computedClasses"
+        :style="computedStyles"
         tabindex="-1"
         :aria-labelledby="`${computedId}-offcanvas-label`"
         data-bs-backdrop="false"
@@ -116,6 +117,7 @@ const _props = withDefaults(defineProps<BOffcanvasProps>(), {
   teleportDisabled: false,
   teleportTo: 'body',
   title: undefined,
+  width: undefined,
 })
 const props = useDefaults(_props, 'BOffcanvas')
 
@@ -204,6 +206,10 @@ const computedClasses = computed(() => [
     [`shadow-${props.shadow}`]: !!props.shadow,
   },
 ])
+
+const computedStyles = computed(() => ({
+  width: props.width,
+}))
 
 const sharedSlots = computed<SharedSlotsData>(() => ({
   visible: modelValue.value,

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -494,6 +494,7 @@ export interface BOffcanvasProps extends TeleporterProps {
   title?: string
   // responsive?: Breakpoint
   // TODO responsive doesn't work
+  width: string
 }
 
 export interface BOverlayProps extends RadiusElementExtendables {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -494,7 +494,7 @@ export interface BOffcanvasProps extends TeleporterProps {
   title?: string
   // responsive?: Breakpoint
   // TODO responsive doesn't work
-  width: string
+  width?: string
 }
 
 export interface BOverlayProps extends RadiusElementExtendables {


### PR DESCRIPTION
# Describe the PR

Allow specifying the width of the sidebar with a prop. This could be achieved with passing the `style` attribute, but it would be simpler for migrations if it could use the same props as `bootstrap-vue` (I think the aliases should be built in, too)

## Small replication

```vue
<template>
  <BContainer>
    <BButton @click="click">Show OffCanvas</BButton>
    <BOffcanvas v-model="show" width="20em" />
  </BContainer>
</template>

<script setup lang="ts">
import {BContainer, BOffcanvas, BButton} from './components'
import {ref} from 'vue'

const show = ref(false)

const click = () => {
  show.value = !show.value
}
</script>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
