### PR TITLE
docs(Global Options) update example code

### DIFF
--- a/apps/docs/src/docs/configurations/global-options.md
+++ b/apps/docs/src/docs/configurations/global-options.md
@@ -4,20 +4,22 @@ Global configurations allow you to set default prop values for all Vue component
 
 ```ts
 createBootstrap({
-  components: {
-    global: {
-      type: 'grow', // Caution: This impacts BFormInput, which does not support this value!
+  plugins: {
+    components: {
+      global: {
+        type: 'grow', // Caution: This impacts BFormInput, which does not support this value!
+      },
+      BAccordion: {
+        flush: true,
+      },
+      BFormText: {
+        text: 'foobar!',
+      },
+      BSpinner: {
+        type: 'grow',
+      },
     },
-    BAccordion: {
-      flush: true,
-    },
-    BFormText: {
-      text: 'foobar!',
-    },
-    BSpinner: {
-      type: 'grow',
-    },
-  },
+  }
 })
 ```
 


### PR DESCRIPTION
# Describe the PR

According to [source code of defaultsPlugin](https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/8e73b177051d4403ca7a159e7c11707de15e638c/packages/bootstrap-vue-next/src/plugins/defaultsPlugin.ts#L6), we need to use `plugins` key to specify global properties of components.

I have spend some time to figure out that there is a typo in the docs.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
