### PR TITLE
feat(BTable): adds the ability to filter by formatter

### DIFF
--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -281,7 +281,7 @@ interface TableField<T = Record<string, unknown>> {
   sortKey?: string
   sortDirection?: string
   sortByFormatted?: boolean | TableFieldFormatter<T>
-  filterByFormatted?: boolean
+  filterByFormatted?: boolean | TableFieldFormatter<T>
   tdClass?: ClassValue
   thClass?: ClassValue
   thStyle?: StyleValue

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -446,8 +446,24 @@ const computedItems = computed<T[]>(() => {
               (!props.filterable?.includes(key) && !!props.filterable?.length)
             )
               return false
-            const itemValue: string =
-              typeof val === 'object' ? JSON.stringify(Object.values(val)) : val.toString()
+            const realVal = (): string => {
+              const filterField = computedFields.value.find((el) => {
+                if (isTableField(el)) return el.key === key
+
+                return false
+              })
+              if (isTableField(filterField) && !!filterField.filterByFormatted) {
+                const formatter =
+                  typeof filterField.filterByFormatted === 'function'
+                    ? filterField.filterByFormatted
+                    : filterField.formatter
+                if (formatter) {
+                  return formatter(val, String(filterField.key), item) as string
+                }
+              }
+              return typeof val === 'object' ? JSON.stringify(Object.values(val)) : val.toString()
+            }
+            const itemValue: string = realVal()
             return itemValue.toLowerCase().includes(props.filter?.toLowerCase() ?? '')
           })
         : true

--- a/packages/bootstrap-vue-next/src/types/TableTypes.ts
+++ b/packages/bootstrap-vue-next/src/types/TableTypes.ts
@@ -48,7 +48,7 @@ export type TableField<T = any> = {
   sortKey?: string
   sortDirection?: string
   sortByFormatted?: boolean | TableFieldFormatter<T>
-  filterByFormatted?: boolean
+  filterByFormatted?: boolean | TableFieldFormatter<T>
   tdClass?: ClassValue
   thClass?: ClassValue
   thStyle?: StyleValue


### PR DESCRIPTION
# Describe the PR

Adds the ability to filter BTables by a formatter function; either with a `TableFieldFormatter<T>` function supplied to the `filterByFormatted` prop or by a similar function supplied to the corresponding `formatter` prop when `filterByFormatted` is set to `true`. The code is very similar to the implementation for `sortByFormatted` in the codebase. Solves #1413 .

## Small replication

```
<template>
  <BContainer>
     <BTable :items="items" :fields="fields" :filter="filter" :filterable="['gender']" />
  </BContainer>
</template>
<script setup lang="ts">
import {ref} from 'vue'
import type {TableItem} from './types'

const items = [
  {name: 'John', age: 10, gender: 'm'},
  {name: 'Abby', age: 20, gender: 'f'},
  {name: 'Tom', age: 47, gender: 'm'},
  {name: 'Jane', age: 26, gender: 'f'},
]
const fields = [
  {key: 'name', label: 'Name'},
  {key: 'age', label: 'Age'},
  {
    key: 'gender',
    label: 'Gender',
    formatter: (value: string) => (value === 'm' ? '1' : '2')
    filterByFormatted: true,
  },
]
const filter = ref('1') // will filter all items with gender 'm'
</script>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
