### PR TITLE
feat(BDropdown): add prop for max height and width for the dropdown menu

### DIFF
--- a/apps/docs/src/data/components/dropdown.data.ts
+++ b/apps/docs/src/data/components/dropdown.data.ts
@@ -105,6 +105,18 @@ export default {
           type: 'number | string | {mainAxis?: number; crossAxis?: number; alignmentAxis?: number | null',
           default: 0,
         },
+        {
+          prop: 'maxHeight',
+          type: 'number | string',
+          default: undefined,
+          description: 'The max-height to use for the dropdown menu',
+        },
+        {
+          prop: 'maxWidth',
+          type: 'number | string',
+          default: undefined,
+          description: 'The max-width to use for the dropdown menu',
+        },
       ],
       emits: [
         {

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -548,6 +548,60 @@ const show4 = ref(false)
 
 **Note:** _changing the size of the button(s) does not affect the size of the menu items!_
 
+### Menu sizing
+
+The `max-height` and `max-width` of the menu element can be controlled indirectly by using the `boundary` prop, or directly with the `max-height` and `max-width` props.
+
+<HighlightCard>
+  <BDropdown v-model="show41" text="No max height" class="me-2">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 20}, (_, i) => i + 1)" :key="i">{{ i }}</BDropdownItem>
+  </BDropdown>
+  <BDropdown v-model="show42" text="Max height" class="me-2" max-height="10em">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 20}, (_, i) => i + 1)" :key="i">{{ i }}</BDropdownItem>
+  </BDropdown>
+  <BDropdown v-model="show43" text="No max width" class="me-2">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 5}, (_, i) => i + 1)" :key="i">Really, really long text {{ i }}</BDropdownItem>
+  </BDropdown>
+  <BDropdown v-model="show44" text="Max width" class="me-2" max-width="2em">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 5}, (_, i) => i + 1)" :key="i">Really, really long text {{ i }}</BDropdownItem>
+  </BDropdown>
+  <template #html>
+
+```vue
+<template>
+  <BDropdown v-model="show1" text="No max height or width">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 20}, (_, i) => i + 1)" :key="i">{{
+      i
+    }}</BDropdownItem>
+  </BDropdown>
+  <BDropdown v-model="show2" text="Max height" max-height="10em">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 20}, (_, i) => i + 1)" :key="i">{{
+      i
+    }}</BDropdownItem>
+  </BDropdown>
+  <BDropdown v-model="show3" text="No max width">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 5}, (_, i) => i + 1)" :key="i"
+      >Really, really long text {{ i }}</BDropdownItem
+    >
+  </BDropdown>
+  <BDropdown v-model="show4" text="Max width" max-width="2em">
+    <BDropdownItem href="#" v-for="i in Array.from({length: 5}, (_, i) => i + 1)" :key="i"
+      >Really, really long text {{ i }}</BDropdownItem
+    >
+  </BDropdown>
+</template>
+
+<script setup lang="ts">
+const show1 = ref(false)
+const show2 = ref(false)
+const show3 = ref(false)
+const show4 = ref(false)
+</script>
+```
+
+  </template>
+</HighlightCard>
+
 ### Dropdown color variants
 
 The dropdown toggle button can have one of the standard Bootstrap contextual variants applied by setting the prop `variant` to `success`, `primary`, `info`, `danger`, `link`, `outline-dark`, etc. (or custom variants, if defined). The default variant is `secondary`.
@@ -1255,4 +1309,9 @@ const show38 = ref(false)
 const show39 = ref(false)
 
 const show40 = ref(false)
+
+const show41 = ref(false)
+const show42 = ref(false)
+const show43 = ref(false)
+const show44 = ref(false)
 </script>

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -91,6 +91,8 @@ const _props = withDefaults(defineProps<BDropdownProps>(), {
   id: undefined,
   isNav: false,
   lazy: false,
+  maxHeight: undefined,
+  maxWidth: undefined,
   menuClass: undefined,
   noCaret: false,
   noFlip: false,
@@ -207,6 +209,8 @@ const floatingPlacement = computed(() =>
   })
 )
 const sizeStyles = ref<CSSProperties>({})
+const maxHeightToNumber = useToNumber(props.maxHeight)
+const maxWidthToNumber = useToNumber(props.maxWidth)
 const floatingMiddleware = computed<Middleware[]>(() => {
   if (props.floatingMiddleware !== undefined) {
     return props.floatingMiddleware
@@ -242,8 +246,14 @@ const floatingMiddleware = computed<Middleware[]>(() => {
         padding: props.boundaryPadding,
         apply({availableWidth, availableHeight}) {
           sizeStyles.value = {
-            maxHeight: availableHeight && modelValue.value ? `${availableHeight}px` : undefined,
-            maxWidth: availableWidth && modelValue.value ? `${availableWidth}px` : undefined,
+            maxHeight:
+              availableHeight && modelValue.value
+                ? maxHeightToNumber.value ?? `${availableHeight}px`
+                : undefined,
+            maxWidth:
+              availableWidth && modelValue.value
+                ? maxWidthToNumber.value ?? `${availableWidth}px`
+                : undefined,
           }
         },
       })

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1137,6 +1137,8 @@ export interface BDropdownProps extends TeleporterProps {
   id?: string
   isNav?: boolean
   lazy?: boolean
+  maxHeight?: number
+  maxWidth?: number
   menuClass?: ClassValue
   modelValue?: boolean
   noCaret?: boolean


### PR DESCRIPTION
# Describe the PR

Add `max-height` and `max-width` props to the `BDropdown` component, to allow overriding the size calculated by `@floating-ui/vue`

## Small replication

An example was added to the docs

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
