### PR TITLE
fix(BTable): fixed aria-sort for th gets changed back to 'none' when no longer sorting

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -334,7 +334,9 @@ const computedFields = computed<TableFieldRaw<T>[]>(() =>
           ? 'none'
           : value.order === 'desc'
             ? 'descending'
-            : 'ascending'
+            : value.order === 'asc'
+              ? 'ascending'
+              : 'none'
     return {
       ...el,
       thAttr: {


### PR DESCRIPTION
# Describe the PR

`aria-sort` for _th_ now gets changed back to 'none' when no longer sorting. This didn't work previously as, when clicking a field 3 times; going from sort 'asc' -> 'desc' -> no longer sorting, it removes the `order` key from sortByModel but the object still exists, still contains a key, so the previous check of `value === undefined` is not sufficient for returning `aria-sort` as 'none'. Hence the change, to check for 'desc', check for 'asc' then return 'none' if not. I will use this to help style nonsorted table headers.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
