### PR TITLE
docs: fix warnings by replacing direct DOM manipulation fixes #1703

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -41,7 +41,7 @@
       </BNavbarNav>
     </BCollapse>
     <div class="d-flex align-items-center gap-2">
-      <VPNavBarSearch />
+      <VPNavBarSearch :class="{dark: colorMode === 'dark'}" />
       <div class="d-flex gap-2 flex-wrap socials">
         <BNav class="d-flex">
           <BNavItem
@@ -62,11 +62,16 @@
                 <component
                   :is="currentIcon"
                   height="1.1rem"
-                  :aria-label="`Toggle theme (${dark})`"
+                  :aria-label="`Toggle theme (${colorMode})`"
                   class="d-inline-block"
                 />
               </template>
-              <BDropdownItem v-for="el in options" :key="el" :active="dark === el" @click="set(el)">
+              <BDropdownItem
+                v-for="el in options"
+                :key="el"
+                :active="colorMode === el"
+                @click="set(el)"
+              >
                 <component :is="map[el]" /> {{ el }}
               </BDropdownItem>
             </BNavItemDropdown>
@@ -234,16 +239,8 @@ const headerExternalLinks = [
   },
 ]
 
-const dark = useColorMode({
+const colorMode = useColorMode({
   persist: true,
-  onChanged(mode, defaultHandler) {
-    defaultHandler(mode)
-    if (mode === 'dark') {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  },
 })
 
 const map = {
@@ -254,10 +251,10 @@ const map = {
 
 const options = Object.keys(map) as (keyof typeof map)[]
 
-const currentIcon = computed(() => map[dark.value])
+const currentIcon = computed(() => map[colorMode.value])
 
 const set = (newValue: keyof typeof map) => {
-  dark.value = newValue
+  colorMode.value = newValue
 }
 
 watch(isLargeScreen, (newValue) => {


### PR DESCRIPTION
# Describe the PR

When search was added to the docs in #1577 color mode was propagated to the search control by manually adding the 'dark' class to the root document. This the doc builds to emit a whole bunch of `document not defined` errors.

The fix is to use a more vue-like method of adding the `dark` class to the `VPNavBarSearch` component.  I also renamed the variable that holds the result of the call to `useColorMode` to `colorMode` from `dark` as that makes the code more readable.

Docs now build clean, so this fixes #1703.
## Small replication

`pnpm build` from the docs directory should not produce warnings.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
