### PR TITLE
docs(BFormSelect): Fix bugs in docs and fill out component data

### DIFF
--- a/apps/docs/src/data/components/formSelect.data.ts
+++ b/apps/docs/src/data/components/formSelect.data.ts
@@ -9,148 +9,155 @@ export default {
           prop: 'ariaInvalid',
           type: 'AriaInvalid',
           default: undefined,
+          description:
+            "Optional value to set for the 'aria-invalid' attribute. Supported values are 'true' and 'false'. If not set, the 'state' prop will dictate the value",
         },
         {
           prop: 'autofocus',
           type: 'boolean',
           default: false,
+          description:
+            'When set to `true`, attempts to auto-focus the control when it is mounted, or re-activated when in a keep-alive. Does not set the `autofocus` attribute on the control',
         },
         {
           prop: 'disabled',
           type: 'boolean',
           default: false,
+          description:
+            "When set to `true`, disables the component's functionality and places it in a disabled state",
         },
         {
           prop: 'disabledField',
           type: 'string',
           default: 'disabled',
+          description:
+            'Field name in the `options` array that should be used for the disabled state',
         },
         {
           prop: 'form',
           type: 'string',
           default: undefined,
+          description:
+            'ID of the form that the form control belongs to. Sets the `form` attribute on the control',
         },
         {
           prop: 'htmlField',
           type: 'string',
           default: 'html',
+          description:
+            'Field name in the `options` array that should be used for the html label instead of text field',
         },
         {
           prop: 'id',
           type: 'string',
           default: undefined,
+          description:
+            'Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed',
         },
         {
           prop: 'labelField',
           type: 'string',
           default: 'label',
+          description: 'When set, allows multiple options to be selected (multi-select)',
         },
         {
           prop: 'multiple',
           type: 'boolean',
           default: false,
+          description: 'When set, allows multiple options to be selected (multi-select)',
         },
         {
           prop: 'name',
           type: 'string',
           default: undefined,
+          description: 'Sets the value of the `name` attribute on the form control',
         },
         {
           prop: 'options',
           type: 'unknown[] | Record<string, unknown>',
           default: '() => []',
+          description: 'Array of items to render in the component',
         },
         {
           prop: 'optionsField',
           type: 'string',
           default: 'options',
+          description: 'The key to use from the option object to get the options',
         },
         {
           prop: 'plain',
           type: 'boolean',
           default: false,
+          description: 'Render the form control in plain mode, rather than custom styled mode',
         },
         {
           prop: 'required',
           type: 'boolean',
           default: false,
+          description: 'Adds the `required` attribute to the form control',
         },
         {
           prop: 'selectSize',
-          type: 'number | string',
+          type: 'Numberish',
           default: 0,
+          description:
+            'When set to a number larger than 0, will set the number of display option rows. Note not all browser will respect this setting',
         },
         {
           prop: 'size',
           type: 'Size',
           default: 'md',
+          description: "Set the size of the component's appearance. 'sm', 'md' (default), or 'lg'",
         },
         {
           prop: 'state',
           type: 'boolean | null',
           default: undefined,
+          description:
+            'Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state',
         },
         {
           prop: 'textField',
           type: 'string',
           default: 'text',
+          description: 'Field name in the `options` array that should be used for the text label',
         },
         {
           prop: 'valueField',
           type: 'string',
           default: 'value',
+          description: 'Field name in the `options` array that should be used for the value',
         },
         {
           prop: 'modelValue',
-          type: 'string | unknown[] | Record<string, unknown> | number | null',
+          type: `boolean| string | readonly unknown[] | Readonly<Record<string, unknown>> | number | null`,
           default: '',
+          description: 'The value of the select control',
         },
       ],
       emits: [
         {
-          args: [
-            {
-              arg: 'input',
-              description: '',
-              type: 'unknown',
-            },
-          ],
-          description: '',
-          event: 'input',
-        },
-        {
-          args: [
-            {
-              arg: 'update:modelValue',
-              description: '',
-              type: 'unknown',
-            },
-          ],
-          description: '',
           event: 'update:modelValue',
-        },
-        {
           args: [
             {
-              arg: 'change',
-              description: '',
-              type: 'unknown',
+              arg: 'value',
+              description: 'Currently selected value of the select control.',
+              type: 'boolean| string | readonly unknown[] | Readonly<Record<string, unknown>> | number | null',
             },
           ],
-          description: '',
-          event: 'change',
+          description:
+            'Emitted when the selected value(s) are changed. Looking for the `input` or `change` event - use `update:modelValue` instead.',
         },
       ],
       slots: [
         {
-          description: '',
+          description: 'Content to place in the form select',
           name: 'default',
-          scope: [],
         },
         {
-          description: '',
+          description:
+            "Slot to place options or option groups above options provided via the 'options' prop",
           name: 'first',
-          scope: [],
         },
       ],
     },
@@ -162,18 +169,19 @@ export default {
           prop: 'value',
           type: 'any',
           default: undefined,
+          description: 'The value of the option',
         },
         {
           prop: 'disabled',
           type: 'boolean',
           default: false,
+          description: 'The disabled state of the option',
         },
       ],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the form select option',
         },
       ],
     },
@@ -184,44 +192,50 @@ export default {
           prop: 'label',
           type: 'string',
           default: undefined,
+          description: 'The label for the option group',
         },
         {
           prop: 'disabledField',
           type: 'string',
           default: 'disabled',
+          description:
+            'Field name in the `options` array that should be used for the disabled state',
         },
         {
           prop: 'htmlField',
           type: 'string',
           default: 'html',
+          description:
+            'Field name in the `options` array that should be used for the html label instead of text field',
         },
         {
           prop: 'options',
-          type: 'unknown[] | Record<string, unknown>',
+          type: 'readonly (unknown | Record<string, unknown>)[]',
           default: '() => []',
+          description: 'Array of items to render in the component',
         },
         {
           prop: 'textField',
           type: 'string',
           default: 'text',
+          description: 'Field name in the `options` array that should be used for the text label',
         },
         {
           prop: 'valueField',
           type: 'string',
           default: 'value',
+          description: 'Field name in the `options` array that should be used for the value',
         },
       ],
       emits: [],
       slots: [
         {
-          description: '',
           name: 'first',
-          scope: [],
+          description: 'Content to place in the form select option group',
         },
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: "Slot to place options above options provided via the 'options' prop",
         },
       ],
     },

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -40,7 +40,7 @@ const ex1Options = [
   {value: 'd', text: 'This one is disabled', disabled: true},
 ]
 
-const ex1Selected = ref()
+const ex1Selected = ref(null)
 </script>
 ```
 
@@ -258,46 +258,6 @@ const options = [
 
 </BCard>
 
-### Options as an object
-
-<BBadge variant="warning">Deprecated</BBadge>
-
-Keys are mapped to `value` and values are mapped to option `text`.
-
-<BCard class="bg-body-tertiary mb-4">
-
-```ts
-const options = {
-  a: 'Item A',
-  b: 'Item B',
-  c: {html: 'Item C', disabled: true},
-  d: {text: 'Item D', value: 'overridden_value'},
-  e: {text: 'Item E', value: {foo: 'bar', baz: true}},
-}
-```
-
-</BCard>
-
-Internally, BootstrapVueNext will convert the above object to the following array (the
-[array of objects](#options-as-an-array-of-objects)) format:
-
-<BCard class="bg-body-tertiary mb-4">
-
-```ts
-const options = [
-  {text: 'Item A', value: 'a', disabled: false},
-  {text: 'Item B', value: 'b', disabled: false},
-  {html: 'Item C', value: 'c', disabled: false},
-  {text: 'Item D', value: 'overridden_value', disabled: true},
-  {text: 'Item E', value: {foo: 'bar', baz: true}, disabled: false},
-]
-```
-
-</BCard>
-
-**Note:** When using the Object format, the order of the final array is **not** guaranteed. For this
-reason, it is recommended to use either of the previously mentioned array formats.
-
 ### Changing the option field names
 
 If you want to customize the field property names (for example using `name` field for display
@@ -306,20 +266,20 @@ If you want to customize the field property names (for example using `name` fiel
 
 <HighlightCard>
   <BFormSelect
-    v-model="exFirstSlotSelected"
+    v-model="exFieldNamesSelected"
     :options="exFieldNamesOptions"
     class="mb-3"
     value-field="item"
     text-field="name"
     disabled-field="notEnabled"
   />
-  <div class="mt-3">Selected: <strong>{{ exFirstSlotSelected }}</strong></div>
+  <div class="mt-3">Selected: <strong>{{ exFieldNamesSelected }}</strong></div>
   <template #html>
 
 ```vue
 <template>
   <BFormSelect
-    v-model="exFirstSlotSelected"
+    v-model="exFieldNamesSelected"
     :options="exFieldNamesOptions"
     class="mb-3"
     value-field="item"
@@ -328,7 +288,7 @@ If you want to customize the field property names (for example using `name` fiel
   />
 
   <div class="mt-3">
-    Selected: <strong>{{ exFirstSlotSelected }}</strong>
+    Selected: <strong>{{ exFieldNamesSelected }}</strong>
   </div>
 </template>
 
@@ -531,7 +491,7 @@ screen readers - or to colorblind users.
 
 Ensure that an alternative indication of state is also provided. For instance, you could include a
 hint about state in the form control's `<label>` text itself, or by providing an additional help
-text block (via `BFormGroup` or `<BForm*Feedback>`). Specifically for assistive technologies,
+text block (via `BFormGroup` or `BForm*Feedback`). Specifically for assistive technologies,
 invalid form controls can also be assigned an `aria-invalid="true"` attribute (see below).
 
 ### ARIA `aria-invalid` attribute
@@ -546,6 +506,14 @@ Supported `invalid` values are:
 
 When `state` is set to `false`, aria-invalid will also be set to true.
 
+## Non custom style select
+
+Set the prop `plain` to have a native browser `<select>` rendered (although the class
+`.form-control` will always be placed on the select).
+
+A `plain` select will always be rendered for non `multiple` selects which have the `select-size`
+prop set to a value greater than 1.
+
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
@@ -557,7 +525,7 @@ import CrossSiteScriptingWarning from '../../components/CrossSiteScriptingWarnin
 import {BFormSelectOptionGroup, BFormSelectOption, BCard, BCardBody, BFormSelect, BAlert, BBadge} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'
 
-const ex1Selected = ref()
+const ex1Selected = ref(null)
 const ex1Options = [
   {value: null, text: 'Please select an option'},
   {value: 'a', text: 'This is First option'},

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -71,6 +71,10 @@ property and `update:modelValue` events.
 See the [Vue 3 migration guide](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
 for more info.
 
+## BFormSelect
+
+[Options as an object](https://bootstrap-vue.org/docs/components/form-select#options-as-an-object) was deprecated in BootstrapVue and never implemented in BootstrapVueNext
+
 <MigrationWrapper v-for="(item, i) in changes" :key="i" v-bind="item" />
 
 <script setup lang="ts">


### PR DESCRIPTION
# Describe the PR

Check `BFormSelect*` components and docs for parity, fix minor bugs in the docs, fill out the component data and update the migration guide.

I also updated the parity spreadsheet to reflect the status of these components.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
