### PR TITLE
docs: get dark mode working again

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -265,12 +265,10 @@ const map = {
 
 const options = Object.keys(map) as (keyof typeof map)[]
 
-const currentIcon = computed(() => map[colorMode?.value ?? 'light'])
+const currentIcon = computed(() => map[colorMode.value])
 
 const set = (newValue: keyof typeof map) => {
-  if (colorMode) {
-    colorMode.value = newValue
-  }
+  colorMode.value = newValue
 }
 
 watch(isLargeScreen, (newValue) => {

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -239,20 +239,22 @@ const headerExternalLinks = [
   },
 ]
 
-let colorMode: UseColorModeReturn<BasicColorMode> | null = null
+const colorMode = useColorMode({
+  persist: true,
+})
 
 onMounted(() => {
-  colorMode = useColorMode({
-    persist: true,
-    onChanged(mode, defaultHandler) {
-      defaultHandler(mode)
-      if (mode === 'dark') {
+  watch(
+    colorMode,
+    (newValue) => {
+      if (newValue === 'dark') {
         document.documentElement.classList.add('dark')
       } else {
         document.documentElement.classList.remove('dark')
       }
     },
-  })
+    {immediate: true}
+  )
 })
 
 const map = {

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -241,6 +241,14 @@ const headerExternalLinks = [
 
 const colorMode = useColorMode({
   persist: true,
+  onChanged(mode, defaultHandler) {
+    defaultHandler(mode)
+    if (mode === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  },
 })
 
 const map = {

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -169,7 +169,7 @@ import {
   BToastOrchestrator,
   BModalOrchestrator,
 } from 'bootstrap-vue-next'
-import {inject, ref, computed, watch} from 'vue'
+import {inject, ref, computed, onMounted, watch} from 'vue'
 import GithubIcon from '~icons/bi/github'
 import OpencollectiveIcon from '~icons/simple-icons/opencollective'
 import DiscordIcon from '~icons/bi/discord'
@@ -179,7 +179,7 @@ import ChevronRight from '~icons/bi/chevron-right'
 import CircleHalf from '~icons/bi/circle-half'
 import {useData, useRoute, withBase} from 'vitepress'
 import {appInfoKey} from './keys'
-import {useMediaQuery} from '@vueuse/core'
+import {useMediaQuery, type BasicColorMode, type UseColorModeReturn} from '@vueuse/core'
 import TableOfContentsNav from '../../src/components/TableOfContentsNav.vue'
 // @ts-ignore
 import VPNavBarSearch from 'vitepress/dist/client/theme-default/components/VPNavBarSearch.vue'
@@ -239,16 +239,20 @@ const headerExternalLinks = [
   },
 ]
 
-const colorMode = useColorMode({
-  persist: true,
-  onChanged(mode, defaultHandler) {
-    defaultHandler(mode)
-    if (mode === 'dark') {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  },
+let colorMode: UseColorModeReturn<BasicColorMode> | null = null
+
+onMounted(() => {
+  colorMode = useColorMode({
+    persist: true,
+    onChanged(mode, defaultHandler) {
+      defaultHandler(mode)
+      if (mode === 'dark') {
+        document.documentElement.classList.add('dark')
+      } else {
+        document.documentElement.classList.remove('dark')
+      }
+    },
+  })
 })
 
 const map = {
@@ -259,10 +263,12 @@ const map = {
 
 const options = Object.keys(map) as (keyof typeof map)[]
 
-const currentIcon = computed(() => map[colorMode.value])
+const currentIcon = computed(() => map[colorMode?.value ?? 'light'])
 
 const set = (newValue: keyof typeof map) => {
-  colorMode.value = newValue
+  if (colorMode) {
+    colorMode.value = newValue
+  }
 }
 
 watch(isLargeScreen, (newValue) => {


### PR DESCRIPTION
# Describe the PR

Code blocks are currently not respecting dark mode (the text in the code block is using the light-mode colors).

The current solution is to go back to manually setting/removing `class='dark'` on the `HTML` tag, but to set it up in the `onMounted` hook, which only runs on the client.

----

I'm keeping the notes below in case I (or someone else) wants to take a stab at a more elegant solution in the future.

@VividLemon - This fixes dark mode, but regresses the documentation warning fix, I've done a bunch of exploration and haven't found a better fix. If you've got a chance to take a look and point me in the right direction, that would be great; otherwise, I'll sleep on it and take another look later.

I broke this with #1703 - specifically the code that pulled out setting/clearing class="dark" on the document element.
But I think this code was only coincidentally working and must have covered a change in Vitepress that broke us.

I can't figure out the mechanism that does this, but it appears that either [shiki](https://github.com/shikijs/shiki)  or vitepress' use of shiki required that the <HTML> element have class='dark' to render in dark mode. Setting class='dark' further down in the document doesn't work, but manually setting `class='dark'` on the document node makes everything work.
Vitepress' default theme's use of `useColorScheme` sets `class='dark', and it works. We use `data-bs-theme` instead of adding a class and it fails. 

I went down a path of exploring setting `color-scheme:dark`, since vitepress has some css that does that

I also tried calling `useColorMode` with `attribute='class'` and `selector = 'html'` to change the class attribute rather than the `data-bs-theme` attribute on `body`, but then most of the BSVN components just ignore dark mode. I'm still seeing color-`scheme:dark` show up in the debug tools, so I guess there is some other mechanism that I'm missing?

I don't know if there is a way to get the call in the onChanged handler to execute only on the client? That would fix both the warning and dark mode - it still feels like a kludge, but I'd take that at this point.

Otherwise, the only path I can think of is to continue to figure out how BSVN and VitePress handle dark/light mode and figure out how to get them to play well together.

## Small replication

Set dark mode in docs and see code block.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
