### PR TITLE
fix: remove unnecessary CSS in nuxt module

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -23,12 +23,9 @@ export default defineNuxtModule<ModuleOptions>({
     // @ts-ignore
     const {resolve} = createResolver(import.meta.url)
     nuxt.options.build.transpile.push(resolve('./runtime'))
-    nuxt.options.css.push('bootstrap-vue-next/dist/bootstrap-vue-next.css')
 
     const normalizedComposableOptions = normalizeConfigurationValue(options.composables)
     const normalizedDirectiveOptions = normalizeConfigurationValue(options.directives)
-
-    nuxt.options.css.push('bootstrap-vue-next/dist/bootstrap-vue-next.css')
 
     nuxt.options.vite.optimizeDeps = nuxt.options.vite.optimizeDeps || {}
     nuxt.options.vite.optimizeDeps.include = nuxt.options.vite.optimizeDeps.include || []


### PR DESCRIPTION
# Describe the PR

In the nuxt module, it is automatically importing unnecessary css and replacing the css of my application! I believe it is unnecessary to add css to the module! Since in the nuxt settings you can add css!

## Small replication

bun i -D @bootstrap-vue-next/nuxt@^0.22.4 bootstrap-vue-next@^0.22.4 bootstrap@^5.3.3

![Screenshot_221](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/25870781/1578a185-d22b-46e1-ad1e-c4aaa812c77c)
![Screenshot_222](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/25870781/5e5981e1-53d9-4020-9b5f-d82c2f665b1a)


config in nuxt.config.ts:
```TYPESCRIPT
 modules: [
    '@bootstrap-vue-next/nuxt',
  ],
  
  bootstrapVueNext: { },
```
  

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
