### PR TITLE
docs(BForm): Update docs and checked parity

### DIFF
--- a/apps/docs/src/components/NotYetImplemented.vue
+++ b/apps/docs/src/components/NotYetImplemented.vue
@@ -1,0 +1,7 @@
+<template>
+  <a
+    href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#developing"
+    style="color: red"
+    >Not yet implemented</a
+  >
+</template>

--- a/apps/docs/src/data/components/form.data.ts
+++ b/apps/docs/src/data/components/form.data.ts
@@ -1,4 +1,5 @@
 import type {ComponentReference} from '../../types'
+import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
@@ -6,42 +7,38 @@ export default {
       component: 'BForm',
       props: {
         '': {
-          id: {
-            type: 'string',
-            default: undefined,
-          },
-          floating: {
-            type: 'boolean',
-            default: false,
-          },
           novalidate: {
             type: 'boolean',
             default: false,
+            description:
+              'When set, disables browser native HTML5 validation on controls in the form',
           },
           validated: {
             type: 'boolean',
             default: false,
+            description:
+              "When set, adds the Bootstrap class 'was-validated' on the form, triggering the native browser validation states",
           },
+          ...pick(buildCommonProps(), ['id']),
         },
       },
       emits: [
         {
+          event: 'submit',
+          description: 'Emitted when the form is submitted',
           args: [
             {
               arg: 'submit',
-              description: '',
               type: 'Event',
+              description: 'Native submit event',
             },
           ],
-          description: '',
-          event: 'submit',
         },
       ],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Contet to place in the form',
         },
       ],
     },
@@ -49,31 +46,27 @@ export default {
       component: 'BFormFloatingLabel',
       props: {
         '': {
-          labelFor: {
-            type: 'string',
-            default: undefined,
-          },
           label: {
             type: 'string',
             default: undefined,
+            description: 'The text of the floating label',
           },
-          text: {
+          labelFor: {
             type: 'string',
             default: undefined,
+            description: 'The id of the input control that the floating label is for',
           },
         },
       },
       emits: [],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'The input control that contains the floating label',
         },
         {
-          description: '',
           name: 'label',
-          scope: [],
+          description: 'The content to display in the floating label',
         },
       ],
     },
@@ -81,46 +74,29 @@ export default {
       component: 'BFormInvalidFeedback',
       props: {
         '': {
-          ariaLive: {
-            type: 'string',
-            default: undefined,
-          },
           forceShow: {
             type: 'boolean',
             default: false,
-          },
-          id: {
-            type: 'string',
-            default: undefined,
+            description: "Shows the feedback text, regardless of the value of the 'state' prop",
           },
           text: {
             type: 'string',
             default: undefined,
-          },
-          role: {
-            type: 'string',
-            default: undefined,
-          },
-          state: {
-            type: 'boolean',
-            default: null,
-          },
-          tag: {
-            type: 'string',
-            default: 'div',
+            description: 'The feedback text to display',
           },
           tooltip: {
             type: 'boolean',
             default: false,
+            description: 'Renders the feedback text in a rudimentary tooltip style',
           },
+          ...pick(buildCommonProps(), ['ariaLive', 'id', 'role', 'state', 'tag']),
         },
       },
       emits: [],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the form invalid feedback',
         },
       ],
     },
@@ -128,19 +104,14 @@ export default {
       component: 'BFormRow',
       props: {
         '': {
-          tag: {
-            description: '',
-            type: 'string',
-            default: 'div',
-          },
+          ...pick(buildCommonProps(), ['tag']),
         },
       },
       emits: [],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the form row',
         },
       ],
     },
@@ -148,34 +119,25 @@ export default {
       component: 'BFormText',
       props: {
         '': {
-          id: {
-            type: 'string',
-            default: undefined,
-          },
           inline: {
             type: 'boolean',
             default: false,
-          },
-          tag: {
-            type: 'string',
-            default: 'small',
+            description:
+              'When set, renders the help text as an inline element, rather than a block element',
           },
           text: {
             type: 'string',
             default: undefined,
+            description: 'The text to display',
           },
-          textVariant: {
-            type: 'TextColorVariant | null',
-            default: 'body-secondary',
-          },
+          ...pick(buildCommonProps(), ['id', 'tag', 'textVariant']),
         },
       },
       emits: [],
       slots: [
         {
           description: '',
-          name: 'default',
-          scope: [],
+          name: 'Content to place in the form text',
         },
       ],
     },
@@ -183,46 +145,29 @@ export default {
       component: 'BFormValidFeedback',
       props: {
         '': {
-          ariaLive: {
-            type: 'string',
-            default: undefined,
-          },
           forceShow: {
             type: 'boolean',
             default: false,
-          },
-          id: {
-            type: 'string',
-            default: undefined,
-          },
-          role: {
-            type: 'string',
-            default: undefined,
+            description: "Shows the feedback text, regardless of the value of the 'state' prop",
           },
           text: {
             type: 'string',
             default: undefined,
-          },
-          state: {
-            type: 'boolean',
-            default: null,
-          },
-          tag: {
-            type: 'string',
-            default: 'div',
+            description: 'The feedback text to display',
           },
           tooltip: {
             type: 'boolean',
             default: false,
+            description: 'Renders the feedback text in a rudimentary tooltip style',
           },
+          ...pick(buildCommonProps(), ['ariaLive', 'id', 'role', 'state', 'tag']),
         },
       },
       emits: [],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the form invalid feedback',
         },
       ],
     },

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -149,9 +149,12 @@ const onReset = (event) => {
 
 ## Inline form
 
-Bootstrap 5 has dropped form-specific layout classes for the grid system. See [this](https://getbootstrap.com/docs/5.3/migration/#forms).
+Bootstrap 5 has dropped form-specific layout classes for the grid system. See the
+[Bootstrap 5 Changelog](https://getbootstrap.com/docs/5.3/migration/#forms).
 
-To create horizontal forms with the grid by add the `.row` class to form groups and use the `.col-_-_` classes to specify the width of your labels and controls. Be sure to add `.col-form-label` to your `<label>`s as well, so they’re vertically centered with their associated form controls.
+To create horizontal forms with the grid add the `.row` class to form groups and use the `.col-_-_` classes
+to specify the width of your labels and controls. Be sure to add `.col-form-label` to your `<label>`s as well,
+so they’re vertically centered with their associated form controls.
 
 You may need to manually address the width and alignment of individual form controls with
 [spacing utilities](/docs/reference/spacing-classes) (as shown below). Lastly, be sure to always
@@ -275,14 +278,60 @@ Custom form controls and selects are also supported.
   </template>
 </HighlightCard>
 
-### Alternatives to hidden labels
+## Floating Labels
 
-Assistive technologies such as screen readers will have trouble with your forms if you do not include
-a label for every input. For these inline forms, you can hide the labels using the `.sr-only` class.
-There are further alternative methods of providing a label for assistive technologies, such as the
-`aria-label`, `aria-labelledby` or `title` attributes. If none of these are present, assistive
-technologies may resort to using the `placeholder` attribute, if present, but note that use of
-`placeholder` as a replacement for other labelling methods is not advised.
+Wrap a `BFormInput`, `BFormTextarea`, or `BFormSelect` in a `BFormFloatingLable` to enable floating labesl. A `placeholder`
+is required on each input in order to make the Bootstrap 5 `css` work correctly.
+
+<HighlightCard>
+    <BForm>
+      <BFormFloatingLabel label="Email address" label-for="floatingEmail" class="my-2">
+        <input id="floatingEmail" type="email" class="form-control" placeholder="Email address" />
+      </BFormFloatingLabel>
+      <BFormFloatingLabel label="Password" label-for="floatingPassword" class="my-2">
+        <input id="floatingPassword" type="password" class="form-control" placeholder="Password" />
+      </BFormFloatingLabel>
+    </BForm>
+  <template #html>
+
+```vue-html
+<BForm>
+  <BFormFloatingLabel label="Email address" label-for="floatingEmail" class="my-2">
+    <input id="floatingEmail" type="email" class="form-control" placeholder="Email address" />
+  </BFormFloatingLabel>
+  <BFormFloatingLabel label="Password" label-for="floatingPassword" class="my-2">
+    <input id="floatingPassword" type="password" class="form-control" placeholder="Password" />
+  </BFormFloatingLabel>
+</BForm>
+```
+
+  </template>
+</HighlightCard>
+
+Floating labels work correclty for the disable state, readonly plaintext and input groups.
+See the [Bootstrap 5 documentation](https://getbootstrap.com/docs/5.3/forms/floating-labels) for more details.
+
+## Accessibility
+
+Ensure that all form controls have an appropriate accessible name so that their purpose can be conveyed to users of
+assistive technologies. The simplest way to achieve this is to use a `<label>` element, or—in the case of buttons—to
+include sufficiently descriptive text as part of the `<button>...</button>` content.
+
+For situations where it’s not possible to include a visible `<label>` or appropriate text content, there are
+alternative ways of still providing an accessible name, such as:
+
+- `<label>` elements hidden using the `.visually-hidden` class
+- Pointing to an existing element that can act as a label using `aria-labelledby`
+- Providing a title attribute
+- Explicitly setting the accessible name on an element using aria-label
+
+If none of these are present, assistive technologies may resort to using the placeholder attribute as a fallback for
+the accessible name on `<input>` and `<textarea>` elements. The examples in this section provide a few suggested, case-specific approaches.
+
+While using visually hidden content (`.visually-hidden`, `aria-label`, and even placeholder content, which
+disappears once a form field has content) will benefit assistive technology users, a lack of visible label text may
+still be problematic for certain users. Some form of visible label is generally the best approach,
+both for accessibility and usability.
 
 ## Related form control and layout components
 
@@ -294,17 +343,15 @@ See also:
 - [`BFormRadio`](/docs/components/form-radio) Radio Inputs
 - [`BFormCheckbox`](/docs/components/form-checkbox) Checkbox Inputs
 - [`BFormFile`](/docs/components/form-file) File Input
-- [`BFormDatepicker`](/docs/components/form-datepicker) Date picker input
 - [`BFormSpinbutton`](/docs/components/form-spinbutton) Numerical range spinbutton input
-- [`BFormTags`](/docs/components/form-tags) Customizable tag input~~
-- [`BFormTimepicker`](/docs/components/form-timepicker) Time picker custom form input
-- [`BFormRating`](/docs/components/form-rating) Star rating custom form input and display
+- [`BFormTags`](/docs/components/form-tags) Customizable tag input
+- `BFormRating` Star rating custom form input and display (<NotYetImplemented/>)
 - [`BButton`](/docs/components/button) Buttons
 - [`BFormGroup`](/docs/components/form-group) Form Input wrapper to generate form-groups that
   support labels, help text and feedback
-- [`BInputGroup`](/docs/components/input) Form Inputs with add-ons
-- [`BFormRow`](/docs/components/layout) Create grid rows and columns with tighter margins
-  (available via the [Layout and grid components](/docs/components/layout))
+- [`BInputGroup`](/docs/components/input-group) Form Inputs with add-ons
+- [`BFormRow`](/docs/components/grid-system) Create grid rows and columns with tighter margins
+  (available via the [Layout and grid components](/docs/components/grid-system))
 
 ## Form helper components
 
@@ -313,7 +360,7 @@ The following helper components are available with the `Form` plugin:
 - `BFormText` Help text blocks for inputs
 - `BFormInvalidFeedback` Invalid feedback text blocks for input `invalid` states
 - `BFormValidFeedback` Valid feedback text blocks for input `valid` states
-- `BFormDatalist` Easily create a `<datalist>` for use with `BFormInput` or plain `<input>`
+- `BFormDatalist` Easily create a `<datalist>` for use with `BFormInput` or plain `<input>` (<NotYetImplemented/>)
 
 ### Form text helper
 
@@ -373,10 +420,9 @@ class). Note that tooltip style feedback may, since its positioning is static, o
 labels, etc.
 
 **Note:** Some form controls, such as
-[`BFormRadio`](/docs/components/form-radio#contextual-states),
-[`BFormCheckbox`](/docs/components/form-checkbox#contextual-states), and
-~~[`BFormFile`](/docs/components/form-file)~~ have wrapper elements which will prevent the feedback
-text from automatically showing (as the feedback component is not a direct sibling of the form
+[`BFormRadio`](/docs/components/form-radio#contextual-states) and
+[`BFormCheckbox`](/docs/components/form-checkbox#contextual-states) have wrapper elements which will prevent
+the feedback text from automatically showing (as the feedback component is not a direct sibling of the form
 control's input). Use the feedback component's `state` prop (bound to the state of the form control)
 or the `force-show` prop to display the feedback.
 
@@ -442,6 +488,7 @@ import {data} from '../../data/components/form.data'
 import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
+import NotYetImplemented from '../../components/NotYetImplemented.vue'
 import {
   BFormValidFeedback,
   BFormInvalidFeedback,
@@ -453,6 +500,7 @@ import {
   BForm,
   BFormCheckboxGroup,
   BFormCheckbox,
+  BFormFloatingLabel,
   BFormGroup,
   BFormInput,
   BFormSelect

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -13,6 +13,12 @@ export const commonProps = () =>
       default: undefined,
       description: 'Sets the value of `aria-label` attribute on the rendered element',
     },
+    ariaLive: {
+      type: 'string',
+      default: undefined,
+      description:
+        "When the rendered element is an `aria-live` region (for screen reader users), set to either 'polite' or 'assertive'",
+    },
     ariaLabelledBy: {
       type: 'string',
       default: undefined,
@@ -73,6 +79,11 @@ export const commonProps = () =>
       default: undefined,
       description: 'Adds the `required` attribute to the form control',
     },
+    role: {
+      type: 'string',
+      default: undefined,
+      description: 'Sets the ARIA attribute `role` to a specific value',
+    },
     size: {
       type: 'Size',
       default: 'md',
@@ -84,10 +95,20 @@ export const commonProps = () =>
       description:
         'Controls the validation state appearance of the component. `true` for valid, `false` for invalid, or `null` for no validation state',
     },
+    tag: {
+      type: 'string',
+      default: 'div',
+      description: 'Specify the HTML tag to render instead of the default tag',
+    },
     textField: {
       type: 'string',
       default: 'text',
       description: 'Field name in the `options` array that should be used for the text label',
+    },
+    textVariant: {
+      type: 'TextColorVariant | null',
+      default: null,
+      description: 'Applies one of the Bootstrap theme color variants to the text',
     },
     valueField: {
       type: 'string',


### PR DESCRIPTION
# Describe the PR

I went through the BSVN docs and component references for BForm and its helpers and updated them based on BS5 changes. The biggest changes were inline and floating labels.  I've also updated the parity report.

I'll be pushing a couple of small code changes against BFormFloatingLabel and BForm to get these up-to-date. Trying to keep code and docs separate where possible.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
