### PR TITLE
fix(BFormFloatingLabel): Clean up props

### DIFF
--- a/apps/playground/src/components/Comps/TForm.vue
+++ b/apps/playground/src/components/Comps/TForm.vue
@@ -17,5 +17,16 @@
         </BForm>
       </BCol>
     </BRow>
+    <BRow
+      ><BCol>
+        <BForm>
+          <BFormFloatingLabel label="Email address" label-for="floatingEmail" class="my-2">
+            <BFormInput id="floatingEmail" type="email" placeholder="Email address" />
+          </BFormFloatingLabel>
+          <BFormFloatingLabel label="Password" label-for="floatingPassword" class="my-2">
+            <BFormInput id="floatingPassword" type="password" placeholder="Password" />
+          </BFormFloatingLabel>
+        </BForm> </BCol
+    ></BRow>
   </BContainer>
 </template>

--- a/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
@@ -17,6 +17,7 @@ import {computed, ref} from 'vue'
 
 const _props = withDefaults(defineProps<BFormProps>(), {
   id: undefined,
+  floating: false,
   novalidate: false,
   validated: false,
 })
@@ -34,6 +35,7 @@ defineSlots<{
 }>()
 
 const computedClasses = computed(() => ({
+  'form-floating': props.floating,
   'was-validated': props.validated,
 }))
 

--- a/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
@@ -16,7 +16,6 @@ import type {BFormProps} from '../../types'
 import {computed, ref} from 'vue'
 
 const _props = withDefaults(defineProps<BFormProps>(), {
-  floating: false,
   id: undefined,
   novalidate: false,
   validated: false,
@@ -35,7 +34,6 @@ defineSlots<{
 }>()
 
 const computedClasses = computed(() => ({
-  'form-floating': props.floating,
   'was-validated': props.validated,
 }))
 

--- a/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormFloatingLabel.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="form-floating">
-    <slot>
-      {{ props.text }}
-    </slot>
+    <slot />
     <label :for="props.labelFor">
       <slot name="label">
         {{ props.label }}
@@ -24,7 +22,7 @@ const props = useDefaults(_props, 'BFormFloatingLabel')
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default?: (props: Record<string, never>) => any
+  default: (props: Record<string, never>) => any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   label?: (props: Record<string, never>) => any
 }>()

--- a/packages/bootstrap-vue-next/src/components/BForm/BFormRow.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormRow.vue
@@ -15,6 +15,6 @@ const props = useDefaults(_props, 'BFormRow')
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default?: (props: Record<string, never>) => any
+  default: (props: Record<string, never>) => any
 }>()
 </script>

--- a/packages/bootstrap-vue-next/src/components/BForm/form-floating-label.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form-floating-label.spec.ts
@@ -22,13 +22,6 @@ describe('form-floating-label', () => {
     expect(wrapper.text()).toBe('foobar')
   })
 
-  it('renders prop text', () => {
-    const wrapper = mount(BFormFloatingLabel, {
-      props: {text: 'foobar'},
-    })
-    expect(wrapper.text()).toBe('foobar')
-  })
-
   it('prefers to render slot default over prop text', () => {
     const wrapper = mount(BFormFloatingLabel, {
       props: {text: 'props'},
@@ -55,7 +48,7 @@ describe('form-floating-label', () => {
 
   it('child label renders slot label', () => {
     const wrapper = mount(BFormFloatingLabel, {
-      slots: {label: 'foobar'},
+      slots: {label: 'foobar', default: 'slots'},
     })
     const $label = wrapper.get('label')
     expect($label.text()).toBe('foobar')
@@ -72,7 +65,7 @@ describe('form-floating-label', () => {
   it('child label prefers to render slot label over prop label', () => {
     const wrapper = mount(BFormFloatingLabel, {
       props: {label: 'props'},
-      slots: {label: 'slots'},
+      slots: {label: 'slots', default: 'slots'},
     })
     const $label = wrapper.get('label')
     expect($label.text()).toBe('slots')

--- a/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
@@ -28,6 +28,15 @@ describe('form', () => {
     expect(wrapper.attributes('novalidate')).toBeUndefined()
   })
 
+it('has class form-floating when prop floating', async () => {
+    const wrapper = mount(BForm, {
+      props: {floating: true},
+    })
+    expect(wrapper.classes()).toContain('form-floating')
+    await wrapper.setProps({floating: false})
+    expect(wrapper.classes()).not.toContain('form-floating')
+  })
+
   it('has class was-validated when prop validated', async () => {
     const wrapper = mount(BForm, {
       props: {validated: true},

--- a/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
@@ -28,15 +28,6 @@ describe('form', () => {
     expect(wrapper.attributes('novalidate')).toBeUndefined()
   })
 
-  it('has class form-floating when prop floating', async () => {
-    const wrapper = mount(BForm, {
-      props: {floating: true},
-    })
-    expect(wrapper.classes()).toContain('form-floating')
-    await wrapper.setProps({floating: false})
-    expect(wrapper.classes()).not.toContain('form-floating')
-  })
-
   it('has class was-validated when prop validated', async () => {
     const wrapper = mount(BForm, {
       props: {validated: true},

--- a/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form.spec.ts
@@ -28,7 +28,7 @@ describe('form', () => {
     expect(wrapper.attributes('novalidate')).toBeUndefined()
   })
 
-it('has class form-floating when prop floating', async () => {
+  it('has class form-floating when prop floating', async () => {
     const wrapper = mount(BForm, {
       props: {floating: true},
     })

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -120,7 +120,6 @@ export interface BDropdownTextProps {
 export interface BFormFloatingLabelProps {
   label?: string
   labelFor?: string
-  text?: string
 }
 
 export interface BFormRowProps {
@@ -945,7 +944,6 @@ export interface BImgProps extends RadiusElementExtendables {
 }
 
 export interface BFormProps {
-  floating?: boolean
   id?: string
   novalidate?: boolean
   validated?: boolean

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -944,6 +944,7 @@ export interface BImgProps extends RadiusElementExtendables {
 }
 
 export interface BFormProps {
+  floating?: boolean
   id?: string
   novalidate?: boolean
   validated?: boolean


### PR DESCRIPTION
# Describe the PR

- The `text` prop on `BFormFloatingLabel` used the value of that property as the fallback content of the `default` slot. This doesn't work, that slot has to contain one of select few form controls. Putting plain text there just generates ugliness.
- Make slots required where appropriate (`BForm`, `BFormFloatingLabel` and `BFormRow`)

## Small replication

[stackblitz](https://stackblitz.com/edit/github-llmgfm?file=src%2Fcomponents%2FComp.vue)

```
<template>
  <Container>
    <BRow
      ><BCol>
        <BForm class="floating-label">
          <BInput
            id="floatingEmail"
            type="email"
            class="form-control"
            placeholder="Email address"
            label="Email address"
          />
          <BInput
            id="floatingPassword"
            type="password"
            placeholder="Password"
            label="Password"
          />
        </BForm> </BCol
    ></BRow>
    <BRow
      ><BCol>
        <BForm>
          <BFormFloatingLabel
            label="Email address"
            label-for="floatingEmail"
            class="my-2"
            text="Testing floating label text"
          >
          </BFormFloatingLabel>
        </BForm> </BCol
    ></BRow>
  </Container>
</template>
```
## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
