### PR TITLE
ci: Increase pnpm/action-setup@v2 to @v4 to prevent ci failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20.x.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory
@@ -62,7 +62,7 @@ jobs:
           node-version: 20.x.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory
@@ -98,7 +98,7 @@ jobs:
           node-version: 20.x.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           node-version: 20.x.x
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory

--- a/.github/workflows/npm-publish-main.yaml
+++ b/.github/workflows/npm-publish-main.yaml
@@ -28,7 +28,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory

--- a/.github/workflows/npm-publish-nuxt.yaml
+++ b/.github/workflows/npm-publish-nuxt.yaml
@@ -28,7 +28,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
 
       - name: Get PNPM Store Directory

--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         if: ${{ steps.release.outputs.releases_created }}
 


### PR DESCRIPTION
# Describe the PR

We are encountering issues like this in CI:
https://github.com/bootstrap-vue-next/bootstrap-vue-next/actions/runs/9799205309/job/27060648641

The way to resolve this issue can be found here:
https://github.com/pnpm/action-setup/issues/135


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
