### PR TITLE
docs(types.md): move types under correct headings

### DIFF
--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -16,7 +16,12 @@
 <BCard class="bg-body-tertiary">
 
 ```ts
-type AriaInvalid = boolean | 'grammar' | 'spelling'
+type CommonAlignment = 'start' | 'end' | 'center' | 'fill'
+type Vertical = CommonAlignment | 'baseline' | 'stretch'
+type Horizontal = CommonAlignment | 'between' | 'around'
+type Content = CommonAlignment | 'between' | 'around' | 'stretch'
+type JustifyContent = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'
+type TextHorizontal = 'start' | 'end' | 'center'
 ```
 
 </BCard>
@@ -26,12 +31,7 @@ type AriaInvalid = boolean | 'grammar' | 'spelling'
 <BCard class="bg-body-tertiary">
 
 ```ts
-type CommonAlignment = 'start' | 'end' | 'center' | 'fill'
-type Vertical = CommonAlignment | 'baseline' | 'stretch'
-type Horizontal = CommonAlignment | 'between' | 'around'
-type Content = CommonAlignment | 'between' | 'around' | 'stretch'
-type JustifyContent = 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly'
-type TextHorizontal = 'start' | 'end' | 'center'
+type AriaInvalid = boolean | 'grammar' | 'spelling'
 ```
 
 </BCard>


### PR DESCRIPTION
# Describe the PR

The Types page appeared to have the AriaInvalid and Alignment types under the wrong headings. This should move them to the correct positions.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
