### PR TITLE
fix(BOffcanvas): Fix regression in docs caused  by #1992

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -94,11 +94,10 @@
         <BOffcanvas
           id="sidebar-menu"
           v-model="sidebar"
-          :teleport-disabled="true"
-          :backdrop="false"
+          responsive="lg"
           title="Browse docs"
+          header-class="d-flex"
           class="h-100 border-0"
-          :body-scrolling="isLargeScreen"
         >
           <TableOfContentsNav />
         </BOffcanvas>
@@ -128,13 +127,11 @@
               <BOffcanvas
                 id="otp-menu"
                 v-model="onThisPage"
-                :teleport-disabled="true"
-                :backdrop="false"
+                responsive="lg"
                 placement="end"
                 title="On this page"
                 class="h-100 border-0"
-                :body-scrolling="isLargeScreen"
-                header-class="pb-0"
+                header-class="pb-0 d-flex"
                 body-class="py-2"
               >
                 <div class="bd-toc" />
@@ -195,8 +192,8 @@ const globalData = inject(appInfoKey, {
 })
 
 const isLargeScreen = useMediaQuery('(min-width: 992px)')
-const sidebar = ref(isLargeScreen.value)
-const onThisPage = ref(isLargeScreen.value)
+const sidebar = ref(false)
+const onThisPage = ref(false)
 
 const headerLinks = [
   {
@@ -270,16 +267,6 @@ const currentIcon = computed(() => map[colorMode.value])
 const set = (newValue: keyof typeof map) => {
   colorMode.value = newValue
 }
-
-watch(isLargeScreen, (newValue) => {
-  if (newValue === true) {
-    sidebar.value = true
-    onThisPage.value = true
-    return
-  }
-  sidebar.value = false
-  onThisPage.value = false
-})
 
 watch(
   () => route.path,
@@ -763,6 +750,12 @@ watch(
 [data-bs-theme='light'] {
   .vp-code-dark {
     display: none;
+  }
+}
+
+@media (min-width: 992px) {
+  .offcanvas-header button {
+    display: none !important;
   }
 }
 </style>

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -674,7 +674,9 @@ watch(
   }
 
   .offcanvas.offcanvas-start,
-  .offcanvas.offcanvas-end {
+  .offcanvas-lg.offcanvas-start,
+  .offcanvas.offcanvas-end,
+  .offcanvas-lg.offcanvas-end {
     @media (min-width: 992px) {
       width: 12.5rem !important;
     }

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -51,7 +51,7 @@
       </div>
     </Transition>
     <slot v-if="showBackdrop" name="backdrop">
-      <BOverlay fixed no-wrap no-spinner @click="hide('backdrop')" />
+      <div class="offcanvas-backdrop fade show" @click="hide('backdrop')" />
     </slot>
   </Teleport>
 </template>
@@ -70,7 +70,6 @@ import type {BOffcanvasProps} from '../../types'
 import {BvTriggerableEvent, isEmptySlot} from '../../utils'
 import BButton from '../BButton/BButton.vue'
 import BCloseButton from '../BButton/BCloseButton.vue'
-import BOverlay from '../BOverlay/BOverlay.vue'
 
 // TODO once the responsive stuff may be implemented correctly,
 // What needs to occur is a fixing of the "body scrolling".

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -51,7 +51,7 @@
       </div>
     </Transition>
     <slot v-if="showBackdrop" name="backdrop">
-      <div class="offcanvas-backdrop fade show" @click="hide('backdrop')" />
+      <BOverlay fixed no-wrap no-spinner @click="hide('backdrop')" />
     </slot>
   </Teleport>
 </template>
@@ -70,6 +70,7 @@ import type {BOffcanvasProps} from '../../types'
 import {BvTriggerableEvent, isEmptySlot} from '../../utils'
 import BButton from '../BButton/BButton.vue'
 import BCloseButton from '../BButton/BCloseButton.vue'
+import BOverlay from '../BOverlay/BOverlay.vue'
 
 // TODO once the responsive stuff may be implemented correctly,
 // What needs to occur is a fixing of the "body scrolling".


### PR DESCRIPTION
# Describe the PR

This fixes an issue caused by #1992 where the overlay in `BOffCanvas` was not behaving as expected (see repro).

Revert to using `BOverlay` rather than manually setting up an overlay in `BOffcanvas`

I didn't dig further to see how hard it would be to get this working with out using the `BOverlay` component, I'm not sure that would be useful (possibly slightly better performance?)

## Small replication

See the docs site against main:
![image](https://github.com/bootstrap-vue-next/bootstrap-vue-next/assets/5083020/6e3dd733-4c23-46a7-ba72-36d585cd4175)



A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
