### PR TITLE
fix(BFormGroup): change labelSrOnly to labelVisuallyHidden as per BS5

### DIFF
--- a/apps/playground/src/components/Comps/TFormGroup.vue
+++ b/apps/playground/src/components/Comps/TFormGroup.vue
@@ -35,6 +35,18 @@
         <p class="mt-2">Value: {{ value }}</p>
       </BCol>
     </BRow>
+    <BRow>
+      <BCol>
+        <BFormGroup
+          label="Enter your name"
+          label-for="input-1"
+          valid-feedback="Thank you!"
+          label-visually-hidden
+        >
+          <BFormInput id="input-1" v-model="name" :state="state" trim />
+        </BFormGroup>
+      </BCol>
+    </BRow>
   </BContainer>
 </template>
 
@@ -54,4 +66,6 @@ const onTagState = (valid: string[], invalid: string[], duplicate: string[]) => 
     duplicate,
   })
 }
+
+const name = ref('')
 </script>

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -35,14 +35,15 @@ export default defineComponent({
     description: {type: [String], default: undefined},
     disabled: {type: Boolean, default: false},
     feedbackAriaLive: {type: String, default: 'assertive'},
+    floating: {type: Boolean, default: false},
     id: {type: String, default: undefined},
     invalidFeedback: {type: String, default: undefined},
     label: {type: String, default: undefined},
-    labelAlign: {type: [Boolean, String, Number], default: undefined},
-    labelAlignLg: {type: [Boolean, String, Number], default: undefined},
-    labelAlignMd: {type: [Boolean, String, Number], default: undefined},
-    labelAlignSm: {type: [Boolean, String, Number], default: undefined},
-    labelAlignXl: {type: [Boolean, String, Number], default: undefined},
+    labelAlign: {type: [String], default: undefined},
+    labelAlignLg: {type: [String], default: undefined},
+    labelAlignMd: {type: [String], default: undefined},
+    labelAlignSm: {type: [String], default: undefined},
+    labelAlignXl: {type: [String], default: undefined},
     labelClass: {type: [Array, Object, String], default: undefined},
     labelCols: {type: [Boolean, String, Number], default: undefined},
     labelColsLg: {type: [Boolean, String, Number], default: undefined},
@@ -51,12 +52,11 @@ export default defineComponent({
     labelColsXl: {type: [Boolean, String, Number], default: undefined},
     labelFor: {type: String, default: undefined},
     labelSize: {type: String, default: undefined},
-    labelSrOnly: {type: Boolean, default: false},
+    labelVisuallyHidden: {type: Boolean, default: false},
     state: {type: Boolean as PropType<boolean | null>, default: null},
     tooltip: {type: Boolean, default: false},
     validFeedback: {type: String, default: undefined},
     validated: {type: Boolean, default: false},
-    floating: {type: Boolean, default: false},
   },
   setup(props) {
     const ariaDescribedby: string | null = null as string | null
@@ -221,7 +221,7 @@ export default defineComponent({
 
     if (labelContent || this.isHorizontal) {
       const labelTag: 'legend' | 'label' = isFieldset ? 'legend' : 'label'
-      if (props.labelSrOnly) {
+      if (props.labelVisuallyHidden) {
         if (labelContent) {
           $label = h(
             labelTag,

--- a/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/form-group.spec.ts
@@ -31,6 +31,13 @@ describe('form-group', () => {
     expect(wrapper.classes()).toContain('is-invalid')
   })
 
+  it('legend has class visually-hidden when prop label-visually-hidden is true', () => {
+    const wrapper = mount(BFormGroup, {
+      props: {label: 'foo', labelVisuallyHidden: true},
+    })
+    expect(wrapper.get('legend').classes()).toContain('visually-hidden')
+  })
+
   it('does not contain a valid class when prop state is null', () => {
     const wrapper = mount(BFormGroup, {
       props: {state: null},


### PR DESCRIPTION
# Describe the PR

Rename prop labeSrOnly to labelVisuallyHiddes as per the BS5 change
Also fix the types for labelAlign* - the can only be strings not number or boolean

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
