### PR TITLE
fix(BFormCheckbox): Handle contextual state === false correctly (Fixes #2017)

### DIFF
--- a/apps/playground/src/components/Comps/TFormCheckbox.vue
+++ b/apps/playground/src/components/Comps/TFormCheckbox.vue
@@ -82,9 +82,7 @@
     </BRow>
     <BRow>
       <BCol>
-        <BFormCheckbox v-model="checkedIndeterminate" indeterminate
-          >Indeterminate</BFormCheckbox
-        >
+        <BFormCheckbox v-model="checkedIndeterminate" indeterminate>Indeterminate</BFormCheckbox>
       </BCol>
       <BCol> Checked: {{ checkedIndeterminate }} </BCol>
     </BRow>
@@ -132,11 +130,33 @@
         </button>
       </BCol>
     </BRow>
+    <BRow>
+      <BCol>
+        <h4 class="m-2">Contextual</h4>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol>
+        <BFormCheckbox :state="false">Checkbox state false</BFormCheckbox>
+        <BFormCheckbox :state="true">Checkbox state true</BFormCheckbox>
+        <BFormCheckbox>Checkbox state null</BFormCheckbox>
+
+        <BFormCheckboxGroup
+          v-model="contextualSelected"
+          :options="contextualStateOptions"
+          :state="contextualState"
+          name="checkbox-validation"
+        />
+
+        <div v-if="!contextualState">Please select two</div>
+        <div v-if="contextualState">Thank you</div>
+      </BCol>
+    </BRow>
   </BContainer>
 </template>
 
 <script setup lang="ts">
-import {reactive, ref} from 'vue'
+import {computed, reactive, ref} from 'vue'
 
 const checkboxes = reactive({
   status: true,
@@ -163,4 +183,14 @@ const checkedAvailableCars = ['BMW', 'Mercedes', 'Toyota']
 const setCheckedSelectedCars = () => {
   checkedSelectedCars.value = ['Mercedes', 'Toyota']
 }
+
+const contextualStateOptions = [
+  {text: 'First Check', value: 'first'},
+  {text: 'Second Check', value: 'second'},
+  {text: 'Third Check', value: 'third'},
+]
+
+const contextualSelected = ref([])
+
+const contextualState = computed(() => contextualSelected.value.length === 2)
 </script>

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -115,7 +115,8 @@ const classesObject = computed(() => ({
   inline: props.inline || (parentData?.inline.value ?? false),
   reverse: props.reverse || (parentData?.reverse.value ?? false),
   switch: props.switch || (parentData?.switch.value ?? false),
-  state: props.state || parentData?.state.value,
+  state:
+    props.state === true || props.state === false ? props.state : parentData?.state.value ?? null,
   size: props.size ?? parentData?.size.value ?? 'md', // This is where the true default is made
   buttonVariant: props.buttonVariant ?? parentData?.buttonVariant.value ?? 'secondary', // This is where the true default is made
   hasDefaultSlot: hasDefaultSlot.value,


### PR DESCRIPTION
# Describe the PR

Checkbox `state === false` was resolving to undefined (which is effectively the null state) if there was no parent. Instead of using the parent value for all `falsey` values, I'm checking that the direct prop is `true` or `false` and only falling back to the parent if it's not.

## Small replication

See #2017 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
