### PR TITLE
feat(BPopover): Add close-on-hide prop to close the popover when it hides by clipping out of view

### DIFF
--- a/apps/docs/src/docs/components/popover.md
+++ b/apps/docs/src/docs/components/popover.md
@@ -8,10 +8,85 @@
 
 ## Docs to be written
 
+## Auto close popover when hidden by `hide` middleware
+
+The `close-on-hide` prop can be used to have the popover automatically close
+when the target is scrolled out of view. The `boundary` and `boundary-padding`
+props can be used to control what's considered clipping.
+
+<HighlightCard>
+  <BRow>
+    <BCol cols="auto" class="mx-auto">
+      <BPopover :click="true" :close-on-hide="true" :delay="{show: 0, hide: 0}">
+        <template #title>Scroll me out of view</template>
+        <template #target>
+          <BButton>Click me. Popover closes when clipped</BButton>
+        </template>
+      </BPopover>
+    </BCol>
+    <BCol cols="auto" class="mx-auto">
+      <BPopover :click="true" :close-on-hide="true" :delay="{show: 0, hide: 0}" :boundary-padding="{ top: navHeight }">
+        <template #title>Scroll me out of view</template>
+        <template #target>
+          <BButton>This popover gets hidden by the top nav</BButton>
+        </template>
+      </BPopover>
+    </BCol>
+  </BRow>
+  <template #html>
+
+```vue
+<template>
+  <BPopover :click="true" :close-on-hide="true" :delay="{show: 0, hide: 0}">
+    <template #target>
+      <BButton>Click me. Popover closes when clipped</BButton>
+    </template>
+    Scroll me out of view
+  </BPopover>
+  <BPopover
+    :click="true"
+    :close-on-hide="true"
+    :delay="{show: 0, hide: 0}"
+    :boundary-padding="{top: navHeight}"
+  >
+    <template #title>Scroll me out of view</template>
+    <template #target>
+      <BButton>This popover gets hidden by the top nav</BButton>
+    </template>
+  </BPopover>
+</template>
+
+<script setup lang="ts">
+const navRef = ref(null)
+onMounted(() => {
+  navRef.value = document.body.querySelector('#app > nav')
+})
+const navHeight = computed(() => navRef.value?.clientHeight)
+</script>
+```
+
+  </template>
+</HighlightCard>
+
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
+import { computed, ref, onMounted } from 'vue';
+
 import {data} from '../../data/components/popover.data'
+import HighlightCard from '../../components/HighlightCard.vue'
 import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
+
+import {
+  BCol,
+  BContainer,
+  BButton,
+  BPopover,
+  BRow,
+} from 'bootstrap-vue-next'
+
+const navRef = ref(null)
+onMounted(() => { navRef.value = document.body.querySelector('#app > nav') })
+const navHeight = computed(() => navRef.value?.clientHeight)
 </script>

--- a/apps/playground/src/components/Comps/TPopover.vue
+++ b/apps/playground/src/components/Comps/TPopover.vue
@@ -149,6 +149,14 @@
       </BCol>
     </BRow>
     <BRow class="my-5 position-relative">
+      <BPopover :click="true" :close-on-hide="true" :delay="{show: 0, hide: 0}">
+        <template #title>Scroll me out of view</template>
+        <template #target>
+          <BButton>Click me. Popover closes when clipped</BButton>
+        </template>
+      </BPopover>
+    </BRow>
+    <BRow class="my-5 position-relative">
       <BCol>
         <BPopover v-model="value" strategy="absolute" no-fade no-auto-close manual>
           <template #title>

--- a/packages/bootstrap-vue-next/src/components/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover.vue
@@ -101,6 +101,7 @@ const _props = withDefaults(defineProps<BPopoverProps>(), {
   boundary: 'clippingAncestors',
   boundaryPadding: undefined,
   click: false,
+  closeOnHide: false,
   teleportTo: undefined,
   teleportDisabled: false,
   content: undefined,
@@ -280,16 +281,15 @@ const {floatingStyles, middlewareData, placement, update} = useFloating(targetTr
 
 const arrowStyle = ref<CSSProperties>({position: 'absolute'})
 
-watch(middlewareData, () => {
+watch(middlewareData, (newValue) => {
   if (props.noHide === false) {
-    if (middlewareData.value.hide?.referenceHidden) {
-      hidden.value = true
-    } else {
-      hidden.value = false
+    hidden.value = !!newValue.hide?.referenceHidden
+    if (props.closeOnHide && hidden.value && !props.noAutoClose && !props.manual) {
+      hide(new Event('closeOnHide'))
     }
   }
-  if (middlewareData.value.arrow) {
-    const {x, y} = middlewareData.value.arrow
+  if (newValue.arrow) {
+    const {x, y} = newValue.arrow
     arrowStyle.value = {
       position: 'absolute',
       top: y ? `${y}px` : '',
@@ -376,6 +376,7 @@ const hide = (e: Readonly<Event>) => {
     if (
       e?.type === 'click' ||
       e?.type === 'forceHide' ||
+      e?.type === 'closeOnHide' ||
       (e?.type === 'update:modelValue' && props.manual) ||
       (!props.noninteractive &&
         isOutside.value &&

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1186,6 +1186,7 @@ export interface BPopoverProps extends TeleporterProps {
   boundary?: Boundary | RootBoundary
   boundaryPadding?: Padding
   click?: boolean
+  closeOnHide?: boolean
   content?: string
   customClass?: ClassValue
   delay?:


### PR DESCRIPTION
# Describe the PR

Add `close-on-hide` prop to `BPopover` to have the popover close when it's hidden by the `hide` middleware

## Small replication

https://github.com/user-attachments/assets/87f3e709-7d76-49a0-82ca-693ab1e61498

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**

I'll note that I'm not sure if the format of the docs is quite correct, especially the `boundary-padding`, it feels a bit hacky, but I'm not familiar with a better way.