### PR TITLE
fix(BFormGroup): Add form-group class + styling for compatibility addresses #2039

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormGroup/BFormGroup.vue
@@ -370,6 +370,7 @@ export default defineComponent({
         {
           'was-validated': props.validated,
         },
+        'form-group',
       ],
       'id': useId(() => props.id).value,
       'disabled': isFieldset ? props.disabled : null,
@@ -396,3 +397,9 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+.form-group {
+  margin-bottom: 1rem;
+}
+</style>


### PR DESCRIPTION
# Describe the PR

We were no longer adding the `form-group` class to the main `BFormGroup` element, since BS5 dropped this class `https://getbootstrap.com/docs/5.3/migration/#forms-1`

This PR adds `form-group` back and defines the class with the margin that BS4 used. This address #2039. I'm not 100% convinced that we want to do this in every case that comes up, but it's pretty straightforward in this case. @VividLemon?

## Small replication

Examples in the docs replicate this

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
