### PR TITLE
docs(useModalController): Add migration info for msgBoxOk & Commit

### DIFF
--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -216,6 +216,11 @@ To programmatically control your modals with global state, refer to our document
 
 To programmatically create modals, refer to the documentation at [useModalController](/docs/composables/useModalController)
 
+### Modal message boxes
+
+If you're looking for replacements for `$bvModal.msgBoxOk` and `$bvModal.msgBoxConfirm` please see the
+[migration guide](/docs/migration-guide#replacement-for-modal-message-boxes)
+
 <ComponentReference :data="data" />
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/composables/useModalController.md
+++ b/apps/docs/src/docs/composables/useModalController.md
@@ -52,12 +52,12 @@ Showing a modal is done through the `show` or `confirm` method
 
 <script setup lang="ts">
 const {confirm} = useModalController()
-const toast = useToast()
+const modal = useModal()
 
 const showExample = async () => {
   const value = await confirm?.({props: {title: 'Hello World!'}})
 
-  toast.show?.({props: {title: `Promise resolved to ${value}`, variant: 'info'}})
+  modal.show?.({props: {title: `Promise resolved to ${value}`, variant: 'info'}})
 }
 </script>
 ```
@@ -223,7 +223,7 @@ const {hide, hideAll} = useModalController()
 </HighlightCard>
 
 <script setup lang="ts">
-import {BButton, BModal, useModalController, BButtonGroup, useToast} from 'bootstrap-vue-next'
+import {BButton, BModal, useModalController, BButtonGroup, useModal} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
 import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
@@ -234,7 +234,7 @@ const nestedModal2 = ref(false)
 const nestedModal3 = ref(false)
 
 const {hide, hideAll, show, confirm, modals} = useModalController()
-const toast = useToast()
+const modal = useModal()
 
 const title = ref('Hello')
 
@@ -247,7 +247,7 @@ onMounted(() => {
 const showExample = async () => {
   const value = await confirm?.({ props: { title: 'Hello World!' } })
 
-  toast.show?.({ props: { title: `Promise resolved to ${value}`, variant: 'info' } })
+  modal.show?.({ props: { title: `Promise resolved to ${value}`, variant: 'info' } })
 }
 
 const showReactiveExample = () => {

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -101,10 +101,122 @@ Datalist and disabling mousewheel events are not yet implemented.
 The locale property in BSVN only allows a for a single locale, while BSV allows for an array of locales. If this is
 a limitation that affect your scenario, please [file an issue](https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues) with an explanation of the expected behavior.
 
+## BModal
+
+### Replacement for Modal Message boxes
+
+[BootstrapVue](https://bootstrap-vue.org/docs/components/modal#modal-message-boxes) provided two methods on the `this.$bvModal` object called `msgBoxOk` and `msgBoxConfirm`.
+In holding with the Vue3 first philosophy, BootstrapVueNext provides a composible called [`useModalController`](/docs/composables/useModalController) that
+fills the same needs (and more).
+
+Please read the [`useModalController`](/docs/composables/useModalController) documentation and then come back here for examples of replacements
+for `msgBoxOk` and `msgBoxConfirm`.
+
+Example using `useModalController.show` to replace `msgBoxOk` (Remember to include `<BModalOrchestrator />` in your App Root):
+
+<HighlightCard>
+  <div>
+    <BButton @click="okBox">Show Message</BButton>
+    <div>Result: {{ okResult }}</div>
+  </div>
+
+<template #html>
+
+```vue
+<template>
+  <div>
+    <BButton @click="okBox">Show Message</BButton>
+    <div>Result: {{ okResult }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {BButton} from './components'
+import {useModalController} from './composables'
+import {ref} from 'vue'
+
+const {confirm, show} = useModalController()
+
+const confirmResult = ref<boolean | null | undefined>(null)
+
+const confirmBox = async () => {
+  confirmResult.value = await confirm?.({
+    props: {
+      body: 'Are you sure you want to do this?',
+      title: 'Confirm',
+      okTitle: 'Yes',
+      cancelTitle: 'No',
+    },
+  })
+}
+
+const okResult = ref<boolean | null | undefined>(undefined)
+
+const okBox = async () => {
+  okResult.value = await show?.({
+    props: {
+      body: 'This is an informational message',
+      title: 'Message',
+      okOnly: true,
+    },
+  })
+}
+</script>
+```
+
+  </template>
+</HighlightCard>
+
+Example using `useModalController.confirm` to replace `msgBoxConfirm` (Remember to include `<BModalOrchestrator />` in your App Root):
+
+<HighlightCard>
+  <div>
+    <BButton @click="confirmBox">Show Confirm</BButton>
+    <div>Result: {{ confirmResult ?? 'null' }}</div>
+  </div>
+
+<template #html>
+
+```vue
+<template>
+  <div>
+    <BButton @click="confirmBox">Show Confirm</BButton>
+    <div>Result: {{ confirmResult ?? 'null' }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {BButton} from './components'
+import {useModalController} from './composables'
+import {ref} from 'vue'
+
+const {confirm} = useModalController()
+const confirmResult = ref<boolean | null | undefined>(null)
+
+const confirmBox = async () => {
+  confirmResult.value = await confirm?.({
+    props: {
+      body: 'Are you sure you want to do this?',
+      title: 'Confirm',
+      okTitle: 'Yes',
+      cancelTitle: 'No',
+    },
+  })
+}
+</script>
+```
+
+  </template>
+</HighlightCard>
+
+The `show` and `confirm` `props` object accespts all of the properties that are defined on
+[BModal](/docs/components/modal#component-reference) excpet for `modelValue`.
+
 <MigrationWrapper v-for="(item, i) in changes" :key="i" v-bind="item" />
 
 <script setup lang="ts">
-import {computed} from 'vue'
+import {computed, ref} from 'vue'
+import {BButton, BModalOrchestrator, useModalController} from 'bootstrap-vue-next'
 import MigrationWrapper from '../components/MigrationWrapper.vue'
 import HighlightCard from '../components/HighlightCard.vue'
 
@@ -129,4 +241,31 @@ const changes = computed<{
     component: 'BCard',
   },
 ].sort((a, b) => a.component.localeCompare(b.component)))
+
+const {confirm, show} = useModalController()
+
+const okResult = ref<boolean | null | undefined>(undefined)
+
+const okBox = async () => {
+  okResult.value = await show?.({
+    props: {
+      body: 'This is an informational message',
+      title: 'Message',
+      okOnly: true,
+    },
+  })
+}
+
+const confirmResult = ref<boolean | null | undefined>(null)
+
+const confirmBox = async () => {
+  confirmResult.value = await confirm?.({
+    props: {
+      body: 'Are you sure you want to do this?',
+      title: 'Confirm',
+      okTitle: 'Yes',
+      cancelTitle: 'No',
+    },
+  })
+}
 </script>


### PR DESCRIPTION
# Describe the PR

`useModalController` is a reasonable replacement for `$bvModal.msgBoxOk` and `$bvModal.msgBoxConfirm`, but it took me a little while to figure out the mapping, so I thought that learning would be a decent addition to the migration guide.

This more fully documents the solution to #1279 and the message box part of #1068

Also fixed a small bug in the `useModalController` docs that contributed to my confusion.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
