### PR TITLE
doc(BFormTextArea,BFormInput): Parity pass + document deprecation of lazy, number and trim

### DIFF
--- a/apps/docs/src/data/components/formInput.data.ts
+++ b/apps/docs/src/data/components/formInput.data.ts
@@ -7,12 +7,6 @@ export default {
       component: 'BFormInput',
       props: {
         '': {
-          list: {
-            type: 'string',
-            default: 'undefined',
-            description:
-              'The ID of the associated datalist element or component (Not Yet Implemented)',
-          },
           max: {
             type: 'Numberish',
             default: 'undefined',
@@ -36,12 +30,6 @@ export default {
             description:
               "Value to set in the 'step' attribute on the input. Used by number-like inputs",
           },
-          trim: {
-            type: 'boolean',
-            default: 'false',
-            description:
-              "When set, trims any leading and trailing white space from the input value. Emulates the Vue '.trim' v-model modifier",
-          },
           type: {
             type: 'InputType',
             default: 'text',
@@ -57,10 +45,9 @@ export default {
             'form',
             'formatter',
             'id',
-            'lazy',
             'lazyFormatter',
+            'list',
             'name',
-            'number',
             'placeholder',
             'plaintext',
             'readonly',

--- a/apps/docs/src/data/components/formInput.data.ts
+++ b/apps/docs/src/data/components/formInput.data.ts
@@ -7,40 +7,6 @@ export default {
       component: 'BFormInput',
       props: {
         '': {
-          autocomplete: {
-            type: 'string',
-            default: 'false',
-            description: "Sets the 'autocomplete' attribute value on the form control",
-          },
-          debounce: {
-            type: 'Numberish',
-            default: '0',
-            description:
-              "When set to a number of milliseconds greater than zero, will debounce the user input. Has no effect if prop 'lazy' is set",
-          },
-          debounceMaxWait: {
-            type: 'Numberish',
-            default: 'NaN',
-            description:
-              "The maximum time in milliseconds allowed to be delayed before it''s invoked",
-          },
-          formatter: {
-            type: '(val: string, evt: Event) => string',
-            default: 'undefined',
-            description: 'Reference to a function for formatting the input',
-          },
-          lazy: {
-            type: 'boolean',
-            default: 'false',
-            description:
-              "When set, updates the v-model on 'change'/'blur' events instead of 'input'. Emulates the Vue '.lazy' v-model modifier",
-          },
-          lazyFormatter: {
-            type: 'boolean',
-            default: 'false',
-            description:
-              'When set, the input is formatted on blur instead of each keystroke (if there is a formatter specified)',
-          },
           list: {
             type: 'string',
             default: 'undefined',
@@ -64,12 +30,6 @@ export default {
             default: "''",
             description: 'The current value of the input',
           },
-          number: {
-            type: 'boolean',
-            default: 'false',
-            description:
-              "When set attempts to convert the input value to a native number. Emulates the Vue '.number' v-model modifier",
-          },
           step: {
             type: 'Numberish',
             default: 'undefined',
@@ -89,11 +49,18 @@ export default {
           },
           ...pick(buildCommonProps(buildCommonProps()), [
             'ariaInvalid',
+            'autocomplete',
             'autofocus',
+            'debounce',
+            'debounceMaxWait',
             'disabled',
             'form',
+            'formatter',
             'id',
+            'lazy',
+            'lazyFormatter',
             'name',
+            'number',
             'placeholder',
             'plaintext',
             'readonly',

--- a/apps/docs/src/data/components/formTextarea.data.ts
+++ b/apps/docs/src/data/components/formTextarea.data.ts
@@ -38,10 +38,10 @@ export default {
             'disabled',
             'form',
             'formatter',
-            'lazyFormatter',
             'id',
+            'lazyFormatter',
+            'list',
             'name',
-            'number',
             'placeholder',
             'plaintext',
             'readonly',
@@ -54,39 +54,14 @@ export default {
       emits: [
         {
           event: 'update:modelValue',
-          args: [],
-          description: '',
-        },
-        {
-          event: 'change',
+          description:
+            'Emitted when the selected value(s) are changed. Looking for the `input` or `change` event - use `update:modelValue` instead.',
           args: [
             {
-              arg: 'change',
-              description: '',
-              type: 'Event',
-            },
-          ],
-          description: '',
-        },
-        {
-          event: 'blur',
-          args: [
-            {
-              arg: 'blur',
-              description: '',
-              type: 'FocusEvent',
-            },
-          ],
-          description: '',
-        },
-        {
-          event: 'input',
-          description: '',
-          args: [
-            {
-              arg: 'input',
-              description: '',
-              type: 'Event',
+              arg: 'value',
+              type: 'string',
+              description:
+                'Value of textarea, after any formatting. Not emitted if the value does not change',
             },
           ],
         },

--- a/apps/docs/src/data/components/formTextarea.data.ts
+++ b/apps/docs/src/data/components/formTextarea.data.ts
@@ -7,53 +7,41 @@ export default {
       component: 'BFormTextarea',
       props: {
         '': {
-          autoComplete: {
-            type: 'string',
-            default: undefined,
-          },
-          debounce: {
-            type: 'Numberish',
-            default: 0,
-          },
-          debounceMaxWait: {
-            type: 'Numberish',
-            default: 'NaN',
-          },
-          formatter: {
-            type: '(val: string, evt: Event) => string',
-            default: undefined,
-          },
-          lazyFormatter: {
-            type: 'boolean',
-            default: false,
-          },
-          list: {
-            type: 'string',
-            default: undefined,
-          },
           modelValue: {
             type: 'Numberish | null',
             default: '""',
+            description: 'The current value of the textarea',
           },
           noResize: {
             type: 'boolean',
             default: false,
+            description:
+              "When set, disabled the browser's resize handle which prevents the user from changing the height of the textarea. Automatically set when in auto height mode",
           },
           rows: {
             type: 'Numberish',
             default: 2,
+            description: 'The minimum number of rows to display. Must be a value greater than 1',
           },
           wrap: {
             type: 'string',
             default: 'soft',
+            description:
+              "The value to place on the textarea's 'wrap' attribute. Controls how line break are returned",
           },
           ...pick(buildCommonProps(), [
             'ariaInvalid',
+            'autocomplete',
             'autofocus',
+            'debounce',
+            'debounceMaxWait',
             'disabled',
             'form',
+            'formatter',
+            'lazyFormatter',
             'id',
             'name',
+            'number',
             'placeholder',
             'plaintext',
             'readonly',

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -508,7 +508,7 @@ The `plaintext` option is not supported by input types `color` or `range`.
 ## `v-model` modifiers
 
 We support the native modifiers [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
-They workas documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
+They work as documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
 
 ## Debounce support
 

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -507,7 +507,8 @@ The `plaintext` option is not supported by input types `color` or `range`.
 
 ## `v-model` modifiers
 
-We support the native modifiers `trim`, `lazy`, and `number`. They should all work out of the box
+We support the native modifiers [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
+They workas documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
 
 ## Debounce support
 

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -1050,7 +1050,7 @@ Note `<BFormTag>` requires BootstrapVueNext's custom CSS/SCSS for proper styling
 <script setup lang="ts">
   import {data} from '../../data/components/formTags.data'
   import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
+  import ComponentSidebar from '../../components/ComponentSidebar.vue'
   import HighlightCard from '../../components/HighlightCard.vue'
   import {BFormTags, BFormText, BFormGroup, BInputGroupText, BButton, BCard, BInputGroup, BFormTag, BFormInput, BFormSelect, BFormCheckbox, BFormInvalidFeedback, BDropdownForm, BDropdownDivider, BDropdownItemButton, BDropdownText, BDropdown} from 'bootstrap-vue-next'
   import {ref, computed, watch} from 'vue'

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -18,20 +18,13 @@ Create multi-line text inputs with support for auto height sizing, minimum and m
     v-model="textEx1"
     placeholder="Enter something..."
     rows="3"
-    max-rows="6"
   />
   <pre class="mt-3 mb-0">{{ textEx1 }}</pre>
   <template #html>
 
 ```vue
 <template>
-  <BFormTextarea
-    id="textarea"
-    v-model="textEx1"
-    placeholder="Enter something..."
-    rows="3"
-    max-rows="6"
-  />
+  <BFormTextarea id="textarea" v-model="textEx1" placeholder="Enter something..." rows="3" />
 
   <pre class="mt-3 mb-0">{{ textEx1 }}</pre>
 </template>
@@ -149,7 +142,7 @@ feature, set the `no-resize` prop to `true`.
 
 ### Auto height
 
-Not yet implemented
+<NotYetImplemented />
 
 ## Contextual states
 
@@ -217,10 +210,6 @@ to set the prop `aria-invalid` to `true`, or one of the supported values:
 
 If the `state` prop is set to `false`, and the `aria-invalid` prop is not explicitly set,
 `BFormTextarea` will automatically set the `aria-invalid` attribute to `'true'`.
-
-## Debounce support
-
-Not yet implemented
 
 ## Formatter support
 
@@ -344,6 +333,48 @@ const textReadOnly = 'This is some text.\nIt is read only and does not look like
   </template>
 </HighlightCard>
 
+## Floating labels
+
+When using [floating labels](/docs/components/form#floating-labels) in `BFormTextsArea` controls, don't use the `rows` property to set a custom
+height. Instead set an explicit `height` (either inline or via custom CSS) as per the
+[Bootstrap 5 documentation](https://getbootstrap.com/docs/5.3/forms/floating-labels/#textareas).
+
+<HighlightCard>
+  <BFormFloatingLabel label="type something" label-for="textarea-floatinglabel">
+    <BFormTextarea
+      id="textarea-floatinglabel"
+      v-model="textFloatingLabel"
+      placeholder="Enter something..."
+      style="height: 6rem"
+    />
+  </BFormFloatingLabel>
+
+  <pre class="mt-3 mb-0">{{ textFloatingLabel }}</pre>
+
+<template #html>
+
+```vue
+<template>
+  <BFormFloatingLabel label="type something" label-for="textarea-floatinglabel">
+    <BFormTextarea
+      id="textarea-floatinglabel"
+      v-model="textFloatingLabel"
+      placeholder="Enter something..."
+      style="height: 6rem"
+    />
+  </BFormFloatingLabel>
+
+  <pre class="mt-3 mb-0">{{ textFloatingLabel }}</pre>
+</template>
+
+<script setup lang="ts">
+const textFloatingLabel = ref()
+</script>
+```
+
+  </template>
+</HighlightCard>
+
 ## `v-model` modifiers
 
 Vue does not officially support `.lazy`, `.trim`, and `.number` modifiers on the `v-model` of custom
@@ -365,6 +396,42 @@ emulate the native Vue `v-model` modifiers `.trim` and `.number` and `.lazy` res
   optional formatting (which may not match the value returned via the `v-model` `update` event,
   which handles the modifiers)
 
+## Debounce support
+
+As an alternative to the `lazy` modifier prop, `<b-form-textarea>` optionally supports debouncing
+user input, updating the `v-model` after a period of idle time from when the last character was
+entered by the user (or a `change` event occurs). If the user enters a new character (or deletes
+characters) before the idle timeout expires, the timeout is re-started.
+
+To enable debouncing, set the prop `debounce` to any integer greater than zero. The value is
+specified in milliseconds. Setting `debounce` to `0` will disable debouncing.
+
+Note: debouncing will _not_ occur if the `lazy` prop is set.
+
+<HighlightCard>
+  <BFormTextarea id="textarea-debounce" v-model="textDebounce" rows="3" debounce="500" />
+
+  <pre class="mt-3 mb-0">{{ textDebounce }}</pre>
+
+<template #html>
+
+```vue
+<template>
+  <BFormTextarea id="textarea-debounce" v-model="textDebounce" rows="3" debounce="500" />
+
+  <pre class="mt-3 mb-0">{{ textDebounce }}</pre>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+import {BFormTextarea} from './components'
+const textDebounce = ref()
+</script>
+```
+
+  </template>
+</HighlightCard>
+
 ## Autofocus
 
 When the `autofocus` prop is set on `BFormTextarea`, the textarea will be auto-focused when it
@@ -374,24 +441,18 @@ it tell when the textarea becomes visible.
 
 ## Native and custom events
 
-All native events (other than the custom `input` and `change` events) are supported, without the
-need for the `.native` modifier.
+All native events are supported, without the need for the `.native` modifier.
 
-The custom `input` and `change` events receive a single argument of the current `value` (after any
-formatting has been applied), and are triggered by user interaction.
-
-The custom `update` event is passed the input value, and is emitted whenever the `v-model` needs
-updating (it is emitted before `input`, `change`. and `blur` as needed).
-
-You can always access the native `input` and `change` events by using the `.native` modifier.
+See the [migration guide](/docs/migration-guide#bform-components) for changes handling of the `change` and `input` events from bootstrap-vue.
 
 ## Exposed input properties and methods
 
-`BFormTextarea` exposes several of the native input element's properties and methods on the
-component reference (i.e. assign a `ref` to your `<BFormTextarea ref="foo" ...>`, capture the ref in a variable and use
-`input.propertyName` or `input.methodName(...)`).
+`BFormInput` exposes the native input element
+(of type [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement))
+on the component as a reference with name `element`. You can use that reference to access the native properties and methods.
 
-### example
+e.g. `<BFormInput ref="foo" ... />`, `const foo = ref<InstanceType<typeof BFormInput> | null>(null)`, and then
+`foo?.value?.element?.methodName` or `foo?.value?.element?.propertyName`
 
 <HighlightCard>
   <BFormTextarea
@@ -400,10 +461,10 @@ component reference (i.e. assign a `ref` to your `<BFormTextarea ref="foo" ...>`
     v-model="textSelectEx"
     placeholder="Enter something..."
     rows="3"
-    max-rows="6"
   />
-  <button class="btn btn-primary mt-1" @click="selectText">Select text</button>
-  <template #html>
+
+<button class="btn btn-primary mt-1" @click="selectText">Select text</button>
+<template #html>
 
 ```vue
 <template>
@@ -413,7 +474,6 @@ component reference (i.e. assign a `ref` to your `<BFormTextarea ref="foo" ...>`
     v-model="textSelectEx"
     placeholder="Enter something..."
     rows="3"
-    max-rows="6"
   />
 
   <button class="btn btn-primary mt-1" @click="selectText">Select text</button>
@@ -421,10 +481,10 @@ component reference (i.e. assign a `ref` to your `<BFormTextarea ref="foo" ...>`
 
 <script setup lang="ts">
 const textSelectEx = ref('')
-const textArea = ref<HTMLElement | null>(null)
+const textArea = ref<InstanceType<typeof BFormTextarea> | null>(null)
 
 const selectText = () => {
-  textArea.value.input.select()
+  textArea?.value?.element?.select()
 }
 </script>
 ```
@@ -467,7 +527,8 @@ import {ref, computed} from 'vue'
 import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
-import {BFormGroup, BRow, BCol, BFormTextarea, BCard, BCardBody} from 'bootstrap-vue-next'
+import NotYetImplemented from '../../components/NotYetImplemented.vue'
+import {BFormFloatingLabel, BFormGroup, BRow, BCol, BFormTextarea, BCard, BCardBody} from 'bootstrap-vue-next'
 
 const textEx1 = ref()
 const textStates = ref('')
@@ -479,9 +540,11 @@ const formatter = (value) => value.toLowerCase()
 
 const textReadOnly = "This is some text.\nIt is read only and does not look like an input."
 
+const textFloatingLabel = ref()
+const textDebounce = ref()
 const textSelectEx = ref('')
-const textArea = ref<HTMLElement | null>(null)
+const textArea = ref<InstanceType<typeof BFormTextarea> | null>(null)
 const selectText = () => {
-  textArea.value.input.select()
+  textArea?.value?.element?.select()
 }
 </script>

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -378,7 +378,7 @@ const textFloatingLabel = ref()
 ## `v-model` modifiers
 
 We support the native modifiers [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
-They workas documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
+They work as documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
 
 ## Debounce support
 

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -377,24 +377,8 @@ const textFloatingLabel = ref()
 
 ## `v-model` modifiers
 
-Vue does not officially support `.lazy`, `.trim`, and `.number` modifiers on the `v-model` of custom
-component based inputs, and may generate a bad user experience. Avoid using Vue's native modifiers.
-
-To get around this, `BFormTextarea` has three boolean props `trim`, `number`, and `lazy` which
-emulate the native Vue `v-model` modifiers `.trim` and `.number` and `.lazy` respectively. The
-`lazy` prop will update the v-model on `change`/`blur`events.
-
-**Notes:**
-
-- The `number` prop takes precedence over the `trim` prop (i.e. `trim` will have no effect when
-  `number` is set)
-- When using the `number` prop, and if the value can be parsed as a number (via `parseFloat`) it
-  will return a value of type `Number` to the `v-model`, otherwise the original input value is
-  returned as type `String`. This is the same behaviour as the native `.number` modifier
-- The `trim` and `number` modifier props do not affect the value returned by the `input` or `change`
-  events. These events will always return the string value of the content of `<textarea>` after
-  optional formatting (which may not match the value returned via the `v-model` `update` event,
-  which handles the modifiers)
+We support the native modifiers [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
+They workas documented in vue.js, so there is no longer a need for `trim`, `lazy`, or `number` properties as in BSV.
 
 ## Debounce support
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -92,6 +92,10 @@ handles references. See the [BFormInput documentation](/docs/components/form-inp
 
 Datalist and disabling mousewheel events are not yet implemented.
 
+`trim`, `lazy`, or `number` properties have been deprecated. We support the native modifiers
+[`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
+They work as documented in vue.js, so there is no longer a need for the properties.
+
 ## BFormSelect
 
 [Options as an object](https://bootstrap-vue.org/docs/components/form-select#options-as-an-object) was deprecated in BootstrapVue and never implemented in BootstrapVueNext
@@ -100,6 +104,12 @@ Datalist and disabling mousewheel events are not yet implemented.
 
 The locale property in BSVN only allows a for a single locale, while BSV allows for an array of locales. If this is
 a limitation that affect your scenario, please [file an issue](https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues) with an explanation of the expected behavior.
+
+## BFormTextbox
+
+`trim`, `lazy`, or `number` properties have been deprecated. We support the native modifiers
+[`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
+They work as documented in vue.js, so there is no longer a need for the properties.
 
 ## BModal
 

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -14,6 +14,11 @@ export const commonProps = () =>
       description:
         'Sets the `aria-invalid` attribute value on the wrapper element. When not provided, the `state` prop will control the attribute',
     },
+    autocomplete: {
+      type: 'string',
+      default: 'false',
+      description: "Sets the 'autocomplete' attribute value on the form control",
+    },
     ariaLabel: {
       type: 'string',
       default: undefined,
@@ -36,6 +41,17 @@ export const commonProps = () =>
       description:
         'When set to `true`, attempts to auto-focus the control when it is mounted, or re-activated when in a keep-alive. Does not set the `autofocus` attribute on the control',
     },
+    debounce: {
+      type: 'Numberish',
+      default: '0',
+      description:
+        "When set to a number of milliseconds greater than zero, will debounce the user input. Has no effect if prop 'lazy' is set",
+    },
+    debounceMaxWait: {
+      type: 'Numberish',
+      default: 'NaN',
+      description: "The maximum time in milliseconds allowed to be delayed before it''s invoked",
+    },
     disabled: {
       type: 'boolean',
       default: false,
@@ -53,6 +69,11 @@ export const commonProps = () =>
       description:
         'ID of the form that the form control belongs to. Sets the `form` attribute on the control',
     },
+    formatter: {
+      type: '(val: string, evt: Event) => string',
+      default: 'undefined',
+      description: 'Reference to a function for formatting the input',
+    },
     htmlField: {
       type: 'string',
       default: 'html',
@@ -65,10 +86,28 @@ export const commonProps = () =>
       description:
         'Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed',
     },
+    lazy: {
+      type: 'boolean',
+      default: 'false',
+      description:
+        "When set, updates the v-model on 'change'/'blur' events instead of 'input'. Emulates the Vue '.lazy' v-model modifier",
+    },
+    lazyFormatter: {
+      type: 'boolean',
+      default: 'false',
+      description:
+        'When set, the input is formatted on blur instead of each keystroke (if there is a formatter specified)',
+    },
     name: {
       type: 'string',
       default: undefined,
       description: 'Sets the value of the `name` attribute on the form control',
+    },
+    number: {
+      type: 'boolean',
+      default: 'false',
+      description:
+        "When set attempts to convert the input value to a native number. Emulates the Vue '.number' v-model modifier",
     },
     options: {
       type: 'readonly CheckboxOptionRaw[]',

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -86,28 +86,22 @@ export const commonProps = () =>
       description:
         'Used to set the `id` attribute on the rendered content, and used as the base to generate any additional element IDs as needed',
     },
-    lazy: {
-      type: 'boolean',
-      default: 'false',
-      description:
-        "When set, updates the v-model on 'change'/'blur' events instead of 'input'. Emulates the Vue '.lazy' v-model modifier",
-    },
     lazyFormatter: {
       type: 'boolean',
       default: 'false',
       description:
         'When set, the input is formatted on blur instead of each keystroke (if there is a formatter specified)',
     },
+    list: {
+      type: 'string',
+      default: 'undefined',
+      description:
+        'The ID of the associated datalist element or component (Datalist is Not Yet Implemented)',
+    },
     name: {
       type: 'string',
       default: undefined,
       description: 'Sets the value of the `name` attribute on the form control',
-    },
-    number: {
-      type: 'boolean',
-      default: 'false',
-      description:
-        "When set attempts to convert the input value to a native number. Emulates the Vue '.number' v-model modifier",
     },
     options: {
       type: 'readonly CheckboxOptionRaw[]',


### PR DESCRIPTION
# Describe the PR

Parity pass on `BFormTextArea`
Document the deprecation of the `lazy`, `number`, and `trim` properties on `BFormInput` and `BFormTextArea` and the replacement by `v-model` modifiers.
Also updated the parity spreadsheet.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
