### PR TITLE
docs: kebab-case properties

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -154,7 +154,7 @@
                           v-for="scope in d.item.scope as SlotScopeReference[]"
                           :key="scope.prop"
                         >
-                          <code>{{ scope.prop }}</code>
+                          <code>{{ kebabCase(scope.prop) }}</code>
                           <code>: {{ scope.type }}</code>
                           <span v-if="!!scope.description"> - {{ scope.description }}</span>
                         </div>
@@ -162,7 +162,7 @@
                       <template #cell(args)="d">
                         <!-- eslint-disable-next-line prettier/prettier -->
                         <div v-for="arg in d.item.args as EmitArgReference[]" :key="arg.arg">
-                          <code>{{ arg.arg }}</code>
+                          <code>{{ kebabCase(arg.arg) }}</code>
                           <code>: {{ arg.type }}</code>
                           <span v-if="!!arg.description"> - {{ arg.description }}</span>
                         </div>
@@ -205,6 +205,7 @@ import type {
   MappedComponentReference,
   SlotScopeReference,
 } from '../types'
+import {kebabCase} from '../utils'
 
 const props = defineProps<{data: ComponentReference[]}>()
 
@@ -218,7 +219,7 @@ const sortData = computed(() =>
       props: Object.entries(el.props).map((el) => [
         el[0],
         Object.entries(el[1])
-          .map(([key, value]) => ({prop: key, ...value}))
+          .map(([key, value]) => ({prop: kebabCase(key), ...value}))
           .sort((a, b) => a.prop.localeCompare(b.prop)),
       ]),
       emits: el.emits.sort((a, b) => a.event.localeCompare(b.event)),

--- a/apps/docs/src/utils/index.ts
+++ b/apps/docs/src/utils/index.ts
@@ -45,3 +45,6 @@ export const omit = <
   Object.keys(objToPluck)
     .filter((key) => !keysToPluck.map((el) => el.toString()).includes(key))
     .reduce((result, key) => ({...result, [key]: objToPluck[key]}), {} as Omit<A, B[number]>)
+
+// Converts PascalCase or camelCase to kebab-case
+export const kebabCase = (str: string) => str.replace(/\B([A-Z])/g, '-$1').toLowerCase()


### PR DESCRIPTION
# Describe the PR

While the [official recommendation](https://vuejs.org/style-guide/rules-strongly-recommended.html#prop-name-casing) for use of properties in SFCs is just that it be consistent, we're using kebab-case and BSV used kebab case, so this seems more readable and more likely what folks are searching for - especially since that's how we're using properties in the examples.

I did not touch slot names or event names since they are strings and could be addressed by being consistent in the data.

I would be interested in changing `update:modelValue` to `update:model-value` globally if you're all right with that @VividLemon 

## Small replication

See the component reference in docs

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
