### PR TITLE
fix(BAvatar): Several fixes from parity pass

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
@@ -101,7 +101,7 @@ const props = withDefaults(defineProps<BAvatarProps>(), {
   textVariant: null,
   // End ColorExtendables props
   // RadiusElementExtendables props
-  rounded: undefined,
+  rounded: 'circle',
   roundedBottom: undefined,
   roundedEnd: undefined,
   roundedStart: undefined,
@@ -140,21 +140,11 @@ const computedParentSize = useNumberishToStyle(() => parentData?.size.value)
 const computedSize = computed(() => computedParentSize.value ?? computedPropSize.value)
 
 const computedVariant = toRef(() => parentData?.variant.value ?? props.variant)
+const computedRounded = toRef(() => parentData?.rounded.value ?? props.rounded)
 const computedRoundedTop = toRef(() => parentData?.roundedTop.value ?? props.roundedTop)
 const computedRoundedBottom = toRef(() => parentData?.roundedBottom.value ?? props.roundedBottom)
 const computedRoundedStart = toRef(() => parentData?.roundedStart.value ?? props.roundedStart)
 const computedRoundedEnd = toRef(() => parentData?.roundedEnd.value ?? props.roundedEnd)
-const computedDefaultRounded = toRef(() =>
-  computedRoundedTop.value ||
-  computedRoundedBottom.value ||
-  computedRoundedStart.value ||
-  computedRoundedEnd.value
-    ? undefined
-    : 'circle'
-)
-const computedRounded = toRef(
-  () => parentData?.rounded.value ?? props.rounded ?? computedDefaultRounded.value
-)
 
 const radiusElementClasses = useRadiusElementClasses(() => ({
   rounded: computedRounded.value,

--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
@@ -18,6 +18,17 @@
     <span v-else-if="!!props.text" class="b-avatar-text" :style="textFontStyle">
       {{ props.text }}
     </span>
+    <span v-else class="b-avatar-img"
+      ><svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="80%"
+        height="80%"
+        fill="currentColor"
+        class="bi bi-person-fill"
+        viewBox="0 0 16 16"
+      >
+        <path d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1zm5-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6" /></svg
+    ></span>
     <BBadge
       v-if="showBadge"
       :pill="props.badgePill"
@@ -54,7 +65,7 @@ const props = withDefaults(defineProps<BAvatarProps>(), {
   badgeBgVariant: null,
   badgeTextVariant: null,
   badgeVariant: 'primary',
-  badgePlacement: 'top-end',
+  badgePlacement: 'bottom-end',
   badgeDotIndicator: false,
   badgePill: false,
   button: false,
@@ -78,7 +89,6 @@ const props = withDefaults(defineProps<BAvatarProps>(), {
   stretched: false,
   routerComponentName: undefined,
   target: undefined,
-  to: undefined,
   underlineOffset: undefined,
   underlineOffsetHover: undefined,
   underlineOpacity: undefined,
@@ -91,7 +101,7 @@ const props = withDefaults(defineProps<BAvatarProps>(), {
   textVariant: null,
   // End ColorExtendables props
   // RadiusElementExtendables props
-  rounded: false,
+  rounded: undefined,
   roundedBottom: undefined,
   roundedEnd: undefined,
   roundedStart: undefined,
@@ -130,11 +140,21 @@ const computedParentSize = useNumberishToStyle(() => parentData?.size.value)
 const computedSize = computed(() => computedParentSize.value ?? computedPropSize.value)
 
 const computedVariant = toRef(() => parentData?.variant.value ?? props.variant)
-const computedRounded = toRef(() => parentData?.rounded.value ?? props.rounded)
 const computedRoundedTop = toRef(() => parentData?.roundedTop.value ?? props.roundedTop)
 const computedRoundedBottom = toRef(() => parentData?.roundedBottom.value ?? props.roundedBottom)
 const computedRoundedStart = toRef(() => parentData?.roundedStart.value ?? props.roundedStart)
 const computedRoundedEnd = toRef(() => parentData?.roundedEnd.value ?? props.roundedEnd)
+const computedDefaultRounded = toRef(() =>
+  computedRoundedTop.value ||
+  computedRoundedBottom.value ||
+  computedRoundedStart.value ||
+  computedRoundedEnd.value
+    ? undefined
+    : 'circle'
+)
+const computedRounded = toRef(
+  () => parentData?.rounded.value ?? props.rounded ?? computedDefaultRounded.value
+)
 
 const radiusElementClasses = useRadiusElementClasses(() => ({
   rounded: computedRounded.value,

--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatarGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatarGroup.vue
@@ -19,7 +19,7 @@ const _props = withDefaults(defineProps<BAvatarGroupProps>(), {
   square: false,
   tag: 'div',
   // RadiusElementExtendables props
-  rounded: false,
+  rounded: undefined,
   roundedBottom: undefined,
   roundedEnd: undefined,
   roundedStart: undefined,

--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatarGroup.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatarGroup.vue
@@ -19,7 +19,7 @@ const _props = withDefaults(defineProps<BAvatarGroupProps>(), {
   square: false,
   tag: 'div',
   // RadiusElementExtendables props
-  rounded: undefined,
+  rounded: 'circle',
   roundedBottom: undefined,
   roundedEnd: undefined,
   roundedStart: undefined,

--- a/packages/bootstrap-vue-next/src/composables/useRadiusElementClasses.ts
+++ b/packages/bootstrap-vue-next/src/composables/useRadiusElementClasses.ts
@@ -6,12 +6,12 @@ export default (obj: MaybeRefOrGetter<RadiusElementExtendables>) => {
     value: boolean | RadiusElement,
     str: 'top' | 'bottom' | 'start' | 'end' | null
   ): string => {
-    const strValue = str === null ? '' : `${str}-`
+    const strValue = str === null ? '' : `-${str}`
 
     return value === 'circle'
-      ? `${strValue}rounded-circle`
+      ? `rounded${strValue}-circle`
       : value === 'pill'
-        ? `${strValue}rounded-pill`
+        ? `rounded${strValue}-pill`
         : typeof value === 'number' ||
             value === '0' ||
             value === '1' ||
@@ -19,14 +19,14 @@ export default (obj: MaybeRefOrGetter<RadiusElementExtendables>) => {
             value === '3' ||
             value === '4' ||
             value === '5'
-          ? `${strValue}rounded-${value}`
+          ? `rounded${strValue}-${value}`
           : value === 'none'
-            ? `${strValue}rounded-0`
+            ? `rounded${strValue}-0`
             : value === 'sm'
-              ? `${strValue}rounded-1`
+              ? `rounded${strValue}-1`
               : value === 'lg'
-                ? `${strValue}rounded-5`
-                : `${strValue}rounded` // true is last
+                ? `rounded${strValue}-5`
+                : `rounded${strValue}` // true is last
   }
 
   return computed(() => {

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -66,7 +66,7 @@ export const avatarGroupInjectionKey: InjectionKey<{
   overlapScale: Readonly<Ref<number>>
   size: Readonly<Ref<LiteralUnion<Size, Numberish> | undefined>>
   square: Readonly<Ref<boolean>>
-  rounded: Readonly<Ref<RadiusElement | boolean>>
+  rounded: Readonly<Ref<RadiusElement | boolean | undefined>>
   roundedTop: Readonly<Ref<RadiusElement | boolean | undefined>>
   roundedBottom: Readonly<Ref<RadiusElement | boolean | undefined>>
   roundedStart: Readonly<Ref<RadiusElement | boolean | undefined>>

--- a/packages/bootstrap-vue-next/src/utils/keys.ts
+++ b/packages/bootstrap-vue-next/src/utils/keys.ts
@@ -66,7 +66,7 @@ export const avatarGroupInjectionKey: InjectionKey<{
   overlapScale: Readonly<Ref<number>>
   size: Readonly<Ref<LiteralUnion<Size, Numberish> | undefined>>
   square: Readonly<Ref<boolean>>
-  rounded: Readonly<Ref<RadiusElement | boolean | undefined>>
+  rounded: Readonly<Ref<RadiusElement | boolean>>
   roundedTop: Readonly<Ref<RadiusElement | boolean | undefined>>
   roundedBottom: Readonly<Ref<RadiusElement | boolean | undefined>>
   roundedStart: Readonly<Ref<RadiusElement | boolean | undefined>>

--- a/packages/bootstrap-vue-next/tests/composables/useRadiusElementClasses.spec.ts
+++ b/packages/bootstrap-vue-next/tests/composables/useRadiusElementClasses.spec.ts
@@ -201,10 +201,10 @@ describe('useRadiusElementClasses blackbox test', () => {
 
     expect(radiusElementClasses.value).toEqual({
       'rounded': false,
-      'top-rounded-5': true,
-      'bottom-rounded-1': true,
-      'start-rounded-2': true,
-      'end-rounded-4': true,
+      'rounded-top-5': true,
+      'rounded-bottom-1': true,
+      'rounded-start-2': true,
+      'rounded-end-4': true,
     })
   })
 })


### PR DESCRIPTION
# Describe the PR

- Added in an SVG so that the default Avatar shows the person-fill icon as in BSV
- Fixed the edge rounding to be in the correct order
- Make the default rounding if no rounded properties are set 'circle' - this makes it work the same way BSV did.

## Small replication

See examples in the docs. These are all issues that I found from broken examples in the `BAvatar` documenation

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
