### PR TITLE
docs: Style ol/ul appropriately

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -347,6 +347,14 @@ watch(
     hr {
       margin: 3rem 0;
     }
+
+    ol {
+      list-style-type: decimal;
+    }
+
+    ul {
+      list-style-type: disc;
+    }
   }
 
   .alert {


### PR DESCRIPTION
# Describe the PR

It looks like vitepress removes sets the style for `ol` and `ul` to `list-style: none` - I'm guessing this is because it uses lists for table of contents, etc. In any case, this causes uglification of the core documentation, so this PR re-instates the default styles within the context of our document bodies.

## Small replication

ol before

![image](https://github.com/user-attachments/assets/c9020d82-7262-4595-91ca-0b0bfa1eb72a)

ol after

![image](https://github.com/user-attachments/assets/5ce71e3c-f76f-426e-b917-5972aac354a6)

ul before

![image](https://github.com/user-attachments/assets/7ae7535b-d743-4bf2-b25c-8cfe7f7d1fa4)


ul after

![image](https://github.com/user-attachments/assets/1e24949b-131f-4cfd-8658-9a0471bc4bc4)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
