### PR TITLE
docs(BBadge): Parity pass

### DIFF
--- a/apps/docs/src/data/components/avatar.data.ts
+++ b/apps/docs/src/data/components/avatar.data.ts
@@ -40,6 +40,8 @@ export default {
           badgePlacement: {
             type: 'CombinedPlacement',
             default: 'bottom-end',
+            description:
+              'Placement of the badge relative to the avatar. One of the values of `CombinedPlacement`',
           },
           badgePill: {
             type: 'boolean',

--- a/apps/docs/src/data/components/badge.data.ts
+++ b/apps/docs/src/data/components/badge.data.ts
@@ -1,5 +1,7 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
 import type {ComponentReference, PropertyReference} from '../../types'
+import {linkProps, linkTo} from '../../utils/link-props'
+import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
@@ -7,6 +9,11 @@ export default {
       component: 'BBadge',
       props: {
         '': {
+          dotIndicator: {
+            type: 'boolean',
+            default: false,
+            description: 'Indication position and dot styling applied',
+          },
           pill: {
             type: 'boolean',
             default: false,
@@ -17,113 +24,30 @@ export default {
             default: 'span',
             description: 'Specify the HTML tag to render instead of the default tag',
           },
-          textIndicator: {
-            type: 'boolean',
-            default: false,
-            description: 'Indication position applied',
-          },
-          dotIndicator: {
-            type: 'boolean',
-            default: false,
-            description: 'Indication position and dot styling applied',
-          },
           placement: {
             type: 'CombinedPlacement',
             default: undefined,
+            description:
+              'Placement of the badge relative to the its parent. One of the values of `CombinedPlacement`',
           },
-          active: {
-            type: 'boolean',
-            default: undefined,
+          ...pick(
+            buildCommonProps({
+              variant: {
+                default: 'secondary',
+              },
+            }),
+            ['bgVariant', 'variant', 'textVariant']
+          ),
+        } satisfies Record<
+          Exclude<keyof BvnComponentProps['BBadge'], keyof typeof linkProps>,
+          PropertyReference
+        >,
+        'BLink props': {
+          _linkTo: {
+            type: linkTo,
           },
-          activeClass: {
-            type: 'string',
-            default: undefined,
-          },
-          disabled: {
-            type: 'boolean',
-            default: undefined,
-          },
-          exactActiveClass: {
-            type: 'string',
-            default: undefined,
-          },
-          href: {
-            type: 'string',
-            default: undefined,
-          },
-          icon: {
-            type: 'boolean',
-            default: undefined,
-          },
-          opacity: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          opacityHover: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          rel: {
-            type: 'string',
-            default: undefined,
-          },
-          replace: {
-            type: 'boolean',
-            default: undefined,
-          },
-          routerComponentName: {
-            type: 'string',
-            default: undefined,
-          },
-          stretched: {
-            type: 'boolean',
-            default: false,
-          },
-          target: {
-            type: 'LinkTarget',
-            default: undefined,
-          },
-          to: {
-            type: 'RouteLocationRaw',
-            default: undefined,
-          },
-          underlineOffset: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
-          },
-          underlineOffsetHover: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
-          },
-          underlineOpacity: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineOpacityHover: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineVariant: {
-            type: 'ColorVariant | null',
-            default: undefined,
-          },
-          variant: {
-            type: 'ColorVariant | null',
-            default: 'secondary',
-          },
-          bgVariant: {
-            type: 'ColorVariant | null',
-            default: null,
-          },
-          textVariant: {
-            type: 'TextColorVariant | null',
-            default: null,
-          },
-          noPrefetch: {},
-          noRel: {},
-          prefetchedClass: {},
-          prefetch: {},
-        } satisfies Record<keyof BvnComponentProps['BBadge'], PropertyReference>,
+          ...linkProps,
+        },
       },
       emits: [],
       slots: [

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -62,12 +62,14 @@ Unless the context is clear (as with the “Notifications” example, where it i
 
 ### Positioned
 
-Use utilities to modify a `.badge` and position it in the corner of a link or button.
+Use the `placement` property to position it relative to a parent [link](/docs/components/link) or [button](/docs/components/link).
+Note that for links of buttons, you haveto manually apply the `postition-relative` class to the badge's parent,
+unlike with [`Avatars`](<(/docs/components/avatar)>) where that is hanlded automatically.
 
 <HighlightCard>
   <BButton variant="primary" class="position-relative">
     Inbox
-    <BBadge variant="danger" text-indicator>
+    <BBadge variant="danger" placement="top-end">
       99+
       <span class="visually-hidden">unread messages</span>
     </BBadge>
@@ -77,7 +79,7 @@ Use utilities to modify a `.badge` and position it in the corner of a link or bu
 ```vue-html
 <BButton variant="primary" class="position-relative">
   Inbox
-  <BBadge variant="danger" text-indicator>
+  <BBadge variant="danger" placement="top-end">
     99+
     <span class="visually-hidden">unread messages</span>
   </BBadge>
@@ -87,7 +89,9 @@ Use utilities to modify a `.badge` and position it in the corner of a link or bu
   </template>
 </HighlightCard>
 
-You can also replace the `.badge` class with a few more utilities without a count for a more generic indicator.
+The `Badge` component also implements a `dot-indicator` property to transform the badge into
+a more generic indicator. Please note that you have to manually apply the `position-relative`
+class to the parent button.
 
 <HighlightCard>
   <BButton variant="primary" class="position-relative">
@@ -178,7 +182,7 @@ Use the `pill` prop to make badges more rounded with a larger border-radius.
 
 ## Actionable badges
 
-Quickly provide actionable badges with ~~hover~~ and ~~focus~~ states by specifying either the `href` prop (links) or `to` prop (router-links):
+Quickly provide actionable badges by specifying either the `href` prop (links) or `to` prop (router-links):
 
 <HighlightCard>
   <div class="d-flex mb-4" style="column-gap: 1%;">

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -151,6 +151,11 @@ Rounding a specific side of the avatar is now accomplished using the boolean pro
 `rounded-bottom`, `rounded-start`, and `rounded-end` rather than the `top`, `bottom`, `left`, and `right`
 values for the `rounded` prop.
 
+## BBadge
+
+Badges no longer have focus or hover styles for links. See the
+[Bootstrap migration guide](https://getbootstrap.com/docs/5.3/migration/#badges) for more information.
+
 ## BForm
 
 Bootstrap 5 has dropped form-specific layout classes for the grid system. See the

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -764,9 +764,8 @@ export interface BAvatarGroupProps extends ColorExtendables, RadiusElementExtend
 export interface BBadgeProps extends Omit<BLinkProps, 'routerTag'>, ColorExtendables {
   dotIndicator?: boolean
   pill?: boolean
-  tag?: string
-  textIndicator?: boolean
   placement?: CombinedPlacement
+  tag?: string
 }
 
 export interface BBreadcrumbProps {


### PR DESCRIPTION
# Describe the PR

- Updated docs & fixed bugs in docs
- Filled out component reference
- Updated Parity Spreadsheet
- Removed orphaned text-indicator prop (this isn't implemented in BSV, my guess is that it was an artifact of an earlier implementation of BSVN).

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
