### PR TITLE
fix(BForm): Remove confusing prevent default on form submit - Addresses #2124

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BForm.vue
@@ -1,11 +1,5 @@
 <template>
-  <form
-    :id="props.id"
-    ref="element"
-    :novalidate="props.novalidate"
-    :class="computedClasses"
-    @submit.prevent="submitted"
-  >
+  <form :id="props.id" ref="element" :novalidate="props.novalidate" :class="computedClasses">
     <slot />
   </form>
 </template>
@@ -23,10 +17,6 @@ const _props = withDefaults(defineProps<BFormProps>(), {
 })
 const props = useDefaults(_props, 'BForm')
 
-const emit = defineEmits<{
-  submit: [value: Event]
-}>()
-
 const element = ref<HTMLFormElement | null>(null)
 
 defineSlots<{
@@ -38,10 +28,6 @@ const computedClasses = computed(() => ({
   'form-floating': props.floating,
   'was-validated': props.validated,
 }))
-
-const submitted = (e: Readonly<Event>) => {
-  emit('submit', e)
-}
 
 defineExpose({
   element,


### PR DESCRIPTION
# Describe the PR

I can't find any reason to override the submit event's default behavior on `BForm`. I think the best way to address #2124 is to remove the custom event handler and let the native event propagate. 

I might be missing something about how the event propagation in Vue3 works, but I tested with a simple form and the event is coming through the way I expect.

## Small replication

See issue

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
