### PR TITLE
fix: add target to BLink RouterLink component

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -10,6 +10,7 @@
     <component
       :is="props.routerTag"
       :href="localHref"
+      :target="target"
       :class="{
         [defaultActiveClass]: props.active,
         [props.activeClass]: isActive,

--- a/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
+++ b/packages/bootstrap-vue-next/src/components/BLink/BLink.vue
@@ -10,7 +10,7 @@
     <component
       :is="props.routerTag"
       :href="localHref"
-      :target="target"
+      :target="props.target"
       :class="{
         [defaultActiveClass]: props.active,
         [props.activeClass]: isActive,


### PR DESCRIPTION
# Describe the PR

The BLink component currently does not pass through the target prop if it is rendered as a RouterLink. Works for normal links with href.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
