### PR TITLE
doc(BButton): Fill out component reference and clean up docs

### DIFF
--- a/apps/docs/src/components/NotYetImplemented.vue
+++ b/apps/docs/src/components/NotYetImplemented.vue
@@ -2,6 +2,6 @@
   <a
     href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#developing"
     style="color: red"
-    >Not yet implemented</a
-  >
+    >Not yet implemented <span v-if="$slots.default">: </span><slot
+  /></a>
 </template>

--- a/apps/docs/src/data/components/button.data.ts
+++ b/apps/docs/src/data/components/button.data.ts
@@ -1,5 +1,7 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
 import type {ComponentReference, PropertyReference} from '../../types'
+import {buildCommonProps, pick} from '../../utils'
+import {linkProps, linkTo} from '../../utils/link-props'
 
 export default {
   load: (): ComponentReference[] => [
@@ -7,128 +9,68 @@ export default {
       component: 'BButton',
       props: {
         '': {
-          pill: {
-            type: 'boolean',
-            default: false,
-          },
-          pressed: {
-            type: 'boolean',
-            default: undefined,
-          },
-          size: {
-            type: 'Size',
-            default: 'md',
-          },
-          squared: {
-            type: 'boolean',
-            default: false,
-          },
-          tag: {
-            type: 'string',
-            default: 'button',
-          },
-          type: {
-            type: 'ButtonType',
-            default: 'button',
-          },
-          variant: {
-            type: 'ButtonVariant | null',
-            default: 'secondary',
-          },
           loading: {
             type: 'boolean',
             default: false,
+            description: 'When set to `true`, renders the button in loading state',
           },
           loadingFill: {
             type: 'boolean',
             default: false,
+            description:
+              'When set to `true`, fills the button with the loading spinner and ignores `loading-text`',
           },
-          active: {
-            type: 'boolean',
-            default: undefined,
-          },
-          activeClass: {
+          loadingText: {
             type: 'string',
-            default: undefined,
+            default: 'Loading...',
+            description: 'The text to display when the button is in a loading state',
           },
-          disabled: {
-            type: 'boolean',
-            default: undefined,
-          },
-          exactActiveClass: {
-            type: 'string',
-            default: undefined,
-          },
-          href: {
-            type: 'string',
-            default: undefined,
-          },
-          icon: {
-            type: 'boolean',
-            default: undefined,
-          },
-          opacity: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          opacityHover: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          rel: {
-            type: 'string',
-            default: undefined,
-          },
-          replace: {
-            type: 'boolean',
-            default: undefined,
-          },
-          routerComponentName: {
-            type: 'string',
-            default: undefined,
-          },
-          routerTag: {
-            type: 'string',
-            default: undefined,
-          },
-          stretched: {
+          pill: {
             type: 'boolean',
             default: false,
+            description: "Renders the button with the pill style appearance when set to 'true'",
           },
-          target: {
-            type: 'LinkTarget',
+          pressed: {
+            type: 'boolean',
             default: undefined,
+            description:
+              "When set to 'true', gives the button the appearance of being pressed and adds attribute 'aria-pressed=\"true\"'. When set to `false` adds attribute 'aria-pressed=\"false\"'. Tri-state prop. Syncable with the .sync modifier",
           },
-          to: {
-            type: 'RouteLocationRaw',
-            default: undefined,
+          squared: {
+            type: 'boolean',
+            default: false,
+            description: "Renders the button with non-rounded corners when set to 'true'",
           },
-          underlineOffset: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
+          type: {
+            type: 'ButtonType',
+            default: 'button',
+            description:
+              "The value to set the button's 'type' attribute to. Can be one of 'button', 'submit', or 'reset'",
           },
-          underlineOffsetHover: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
+          ...pick(
+            buildCommonProps({
+              variant: {
+                default: 'secondary',
+              },
+            }),
+            ['size', 'tag', 'variant']
+          ),
+        } satisfies Record<
+          Exclude<keyof BvnComponentProps['BButton'], keyof typeof linkProps>,
+          PropertyReference
+        >,
+        'BLink props': {
+          _linkTo: {
+            type: linkTo,
           },
-          underlineOpacity: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineOpacityHover: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineVariant: {
-            type: 'ColorVariant | null',
-            default: undefined,
-          },
-          loadingText: {},
-          noPrefetch: {},
-          noRel: {},
-          prefetch: {},
-          prefetchedClass: {},
-        } satisfies Record<keyof BvnComponentProps['BButton'], PropertyReference>,
+          ...pick(linkProps, [
+            'activeClass',
+            'exactActiveClass',
+            'replace',
+            'routerComponentName',
+            'routerTag',
+          ]),
+        },
       },
       emits: [
         {
@@ -143,32 +85,29 @@ export default {
           event: 'click',
         },
         {
+          event: 'update:pressed',
+          description: 'Emitted when the `pressed` prop is changed',
           args: [
             {
-              arg: 'update:pressed',
-              description: '',
+              arg: 'value',
               type: 'boolean',
+              description: 'The new value of the `pressed` prop',
             },
           ],
-          description: '',
-          event: 'update:pressed',
         },
       ],
       slots: [
         {
           name: 'default',
-          description: '',
-          scope: [],
+          description: 'Content to place in the button',
         },
         {
           name: 'loading',
           description: 'The content to replace the default loader',
-          scope: [],
         },
         {
           name: 'loading-spinner',
           description: 'The content to replace the default loading spinner',
-          scope: [],
         },
       ],
     },
@@ -176,34 +115,33 @@ export default {
       component: 'BCloseButton',
       props: {
         '': {
-          ariaLabel: {
-            description: '',
-            type: 'string',
-            default: 'Close',
-          },
-          disabled: {
-            description: '',
-            type: 'boolean',
-            default: false,
-          },
           type: {
-            default: 'button',
             type: 'ButtonType',
-            description: '',
+            default: 'button',
+            description:
+              "The value to set the button's 'type' attribute to. Can be one of 'button', 'submit', or 'reset'",
           },
+          ...pick(
+            buildCommonProps({
+              ariaLabel: {
+                default: 'Close',
+              },
+            }),
+            ['ariaLabel', 'disabled']
+          ),
         } satisfies Record<keyof BvnComponentProps['BCloseButton'], PropertyReference>,
       },
       emits: [
         {
+          event: 'click',
+          description: 'Emitted when non-disabled button clicked',
           args: [
             {
               arg: 'click',
-              description: '',
               type: 'MouseEvent',
+              description: 'Native click event object',
             },
           ],
-          description: 'On click event',
-          event: 'click',
         },
       ],
       slots: [],

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -68,7 +68,7 @@ Note the `type` prop has no effect when either `href` or `to` props are set.
 Fancy larger or smaller buttons? Specify `lg` or `sm` via the `size` prop.
 
 <HighlightCard>
-  <div class="d-flex gap-2">
+  <div>
     <BButton size="sm" class="mx-1">Small Button</BButton>
     <BButton class="mx-1">Default Button</BButton>
     <BButton size="lg" class="mx-1">Large Button</BButton>
@@ -76,9 +76,9 @@ Fancy larger or smaller buttons? Specify `lg` or `sm` via the `size` prop.
   <template #html>
 
 ```vue-html
-<BButton size="sm">Small Button</BButton>
-<BButton>Default Button</BButton>
-<BButton size="lg">Large Button</BButton>
+<BButton size="sm" class="mx-1">Small Button</BButton>
+<BButton class="mx-1">Default Button</BButton>
+<BButton size="lg" class="mx-1">Large Button</BButton>
 ```
 
   </template>
@@ -90,7 +90,8 @@ Use the `variant` prop to generate the various Bootstrap contextual button varia
 
 By default, `BButton` will render with the `secondary` variant.
 
-The `variant` prop adds the Bootstrap v4.3 class `.btn-<variant>` on the rendered button.
+The `variant` prop adds the Bootstrap class `.btn-<variant>` on the rendered button.
+See the [Color Variants](/docs/reference/color-variants) page for details.
 
 ### Solid color variants
 
@@ -174,29 +175,32 @@ padding and size of a button.
   </template>
 </HighlightCard>
 
-**Tip:** remove the hover underline from a link variant button by adding the Bootstrap v4.3 utility
-class `text-decoration-none` to `BButton`.
+**Tip:** remove the hover underline from a link variant button by setting `underline-opacity="0"`.
 
 ## Block level buttons
 
-Create responsive stacks of full-width, “block buttons” like those in Bootstrap 4 with a mix of our display and gap utilities. By using utilities instead of button specific classes, we have much greater control over spacing, alignment, and responsive behaviors.
+Create responsive stacks of full-width, “block buttons” by wrapping the button(s) in a div and specifying
+`d-grid` and `gap-*`. By using css utilities instead a boolean property on the button, we have much greater
+control over spacing, alignment, and responsive behaviors. See the
+[Bootstrap 5](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons)
+documentation for details
 
 <HighlightCard>
   <div class="d-grid gap-2">
     <BButton block variant="primary">Block Level Button</BButton>
-    <BButton block variant="primary">Block Level Button</BButton>
+    <BButton block variant="primary">Another Block Level Button</BButton>
   </div>
   <template #html>
 
 ```vue-html
-<BButton block variant="primary">Block Level Button</BButton>
-<BButton block variant="primary">Block Level Button</BButton>
+<div class="d-grid gap-2">
+  <BButton block variant="primary">Block Level Button</BButton>
+  <BButton block variant="primary">Another Block Level Button</BButton>
+</div>
 ```
 
   </template>
 </HighlightCard>
-
-**Note:** Bootstrap 5 no long supports the `.btn-block` class, so it is removed. Use bootstrap 5's utility classes to get the same effect. [See](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons).
 
 ## Pill style
 
@@ -356,6 +360,33 @@ If using toggle button style for a radio or checkbox style interface, it is best
 `button` style support of [`BFormRadioGroup`](/docs/components/form-radio) and
 [`BFormCheckboxGroup`](/docs/components/form-checkbox).
 
+## Loading
+
+`BButton` supports several properties to indicate a loading state. When `loading` is true, the
+loading state is active, otherwise the normal button is displayed. When loading is active, `loading-text`
+is show along with a spinner. If `loading-fill` is true, the button shows only the spinner and the
+`loading-text` is ignored. You can also override the spinner with an arbitrary component by
+using the `loading-spinner` slot or the entire content of the button with the `loading` slot.
+
+<HighlightCard>
+  <div class="d-flex gap-2">
+    <BButton :loading="true">Button</BButton>
+    <BButton :loading="true" loading-fill>Button</BButton>
+    <BButton :loading="true" loading-text="Please Wait...">Button</BButton>
+    <BButton :loading="false" loading-text="Please Wait...">Button</BButton>
+  </div>
+  <template #html>
+
+```vue-html
+<BButton :loading="true">Button</BButton>
+<BButton :loading="true" loading-fill>Button</BButton>
+<BButton :loading="true" loading-text="Please Wait...">Button</BButton>
+<BButton :loading="false" loading-text="Please Wait...">Button</BButton>
+```
+
+  </template>
+</HighlightCard>
+
 ## Router link support
 
 Refer to the [`Router support`](/docs/reference/router-links) reference docs for the various
@@ -371,6 +402,8 @@ disabled, the `aria-disabled="true"` attribute will be set on the `<a>` element.
 When the `href` is set to any other value (~~or the `to` prop is used~~), `role="button"` will not be
 added, nor will the keyboard event listeners be enabled.
 
+<NotYetImplemented>The `role="button"` behavior is partially implemented, but the keyboard listen are not</NotYetImplemented>
+
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
@@ -380,6 +413,7 @@ import {BButtonGroup, BButton} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
+import NotYetImplemented from '../../components/NotYetImplemented.vue'
 
 const buttonToggle = ref(false);
 const buttons = ref([

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -180,7 +180,7 @@ padding and size of a button.
 ## Block level buttons
 
 Create responsive stacks of full-width, “block buttons” by wrapping the button(s) in a div and specifying
-`d-grid` and `gap-*`. By using css utilities instead a boolean property on the button, we have much greater
+`d-grid` and `gap-*`. By using CSS utilities instead a boolean property on the button, we have much greater
 control over spacing, alignment, and responsive behaviors. See the
 [Bootstrap 5](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons)
 documentation for details
@@ -364,7 +364,7 @@ If using toggle button style for a radio or checkbox style interface, it is best
 
 `BButton` supports several properties to indicate a loading state. When `loading` is true, the
 loading state is active, otherwise the normal button is displayed. When loading is active, `loading-text`
-is show along with a spinner. If `loading-fill` is true, the button shows only the spinner and the
+is shown along with a spinner. If `loading-fill` is true, the button shows only the spinner and the
 `loading-text` is ignored. You can also override the spinner with an arbitrary component by
 using the `loading-spinner` slot or the entire content of the button with the `loading` slot.
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -160,6 +160,19 @@ Badges no longer have focus or hover styles for links. See the
 
 The `html` prop on `BBreadcrumbItem` is deprecated. Use the default slot instead.
 
+## BButton
+
+The `block` prop is deprecated. See our [`BButton` documentation](/docs/components/button#block-level-buttons)
+and [Bootstrap's documentation](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons) for
+details.
+
+## BButtonClose
+
+`BButtonClose` has been renamed to `BCloseButton` for consistency with [Bootstrap](https://getbootstrap.com/docs/5.3/components/close-button/)
+
+The `content` and `text-variant` props have been deprecated since Bootstrap 5 moved to using an
+embedded svg for the close icon. See [their migration guide](https://getbootstrap.com/docs/5.3/migration/#close-button-1) for details.
+
 ## BForm
 
 Bootstrap 5 has dropped form-specific layout classes for the grid system. See the


### PR DESCRIPTION
# Describe the PR

Parity pass for BButton and BCloseButton

- updated component reference
- cleaned up docs and added a section for the `loading` props
- filled out the parity spreadsheet 
- added the ability to specify additional details in `NotYetImplemented` component
-
## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
