### PR TITLE
Demo file plugin

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -2,6 +2,8 @@ import {defineConfig} from 'vitepress'
 import Icons from 'unplugin-icons/vite'
 import markdownItClass from '@toycode/markdown-it-class'
 import {demoContainer} from './plugins/demo-container'
+import Components from 'unplugin-vue-components/vite'
+import {BootstrapVueNextResolver} from 'bootstrap-vue-next'
 
 const title = 'BootstrapVueNext'
 const description = 'Quickly and Easily Integrate Bootstrap V5 Components With Vue 3'
@@ -24,7 +26,16 @@ export default defineConfig({
     ['meta', {property: 'twitter:description', name: 'twitter:description', content: description}],
   ],
   vite: {
-    plugins: [Icons()],
+    plugins: [
+      Icons(),
+      Components({
+        dirs: ['components', 'docs/components/demo'],
+        extensions: ['vue'],
+        dts: true,
+        include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
+        resolvers: [BootstrapVueNextResolver()],
+      }),
+    ],
   },
   locales: {
     root: {

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,6 +1,6 @@
 import {defineConfig} from 'vitepress'
 import Icons from 'unplugin-icons/vite'
-import markdonnwItClass from '@toycode/markdown-it-class'
+import markdownItClass from '@toycode/markdown-it-class'
 
 const title = 'BootstrapVueNext'
 const description = 'Quickly and Easily Integrate Bootstrap V5 Components With Vue 3'
@@ -42,7 +42,7 @@ export default defineConfig({
   },
   markdown: {
     config: (md) => {
-      md.use(markdonnwItClass, {table: ['table', 'table-striped']})
+      md.use(markdownItClass, {table: ['table', 'table-striped']})
     },
   },
 })

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'vitepress'
 import Icons from 'unplugin-icons/vite'
 import markdownItClass from '@toycode/markdown-it-class'
+import {demoContainer} from './plugins/demo-container'
 
 const title = 'BootstrapVueNext'
 const description = 'Quickly and Easily Integrate Bootstrap V5 Components With Vue 3'
@@ -43,6 +44,7 @@ export default defineConfig({
   markdown: {
     config: (md) => {
       md.use(markdownItClass, {table: ['table', 'table-striped']})
+      md.use(demoContainer, 'src')
     },
   },
 })

--- a/apps/docs/.vitepress/markdown-it-class.d.ts
+++ b/apps/docs/.vitepress/markdown-it-class.d.ts
@@ -1,0 +1,5 @@
+declare module '@toycode/markdown-it-class' {
+  import {PluginSimple} from 'markdown-it'
+  const markdownItClass: PluginSimple
+  export default markdownItClass
+}

--- a/apps/docs/.vitepress/plugins/demo-container.ts
+++ b/apps/docs/.vitepress/plugins/demo-container.ts
@@ -31,8 +31,6 @@ export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
     const start = pos + sentinal.length
     const end = state.skipSpacesBack(max, pos)
 
-    console.log('demo tag found:', state.line, state.src.substring(start, end))
-
     const rawPath = state.src.slice(start, end).trim().replace(/^@/, srcDir).trim()
 
     const {filepath, extension, region, lines, lang, title} = rawPathToToken(rawPath)

--- a/apps/docs/.vitepress/plugins/demo-container.ts
+++ b/apps/docs/.vitepress/plugins/demo-container.ts
@@ -1,0 +1,88 @@
+import type {MarkdownEnv, MarkdownRenderer} from 'vitepress'
+import type {RuleBlock} from 'markdown-it/lib/parser_block.mjs'
+import path from 'path'
+
+// This plugin is inspired by vitepress' snippet plugin and must run before it to work
+//  It accepts all of the same syntax as the snippet plugin, but will render the demo
+//  _and_ display the example code inside of a HighlightCard component
+//
+// TODO: This currently requires an extra step of manually importing the demo component
+//  in the <script setup> block of the markdown file. Next step is to automate this process
+
+export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
+  const blockParser: RuleBlock = (state, startLine, endLine, silent) => {
+    const sentinal = '<<< DEMO '
+    const pos = state.bMarks[startLine] + state.tShift[startLine]
+    const max = state.eMarks[startLine]
+
+    // if it's indented more than 3 spaces, it should be a code block
+    if (state.sCount[startLine] - state.blkIndent >= 4) {
+      return false
+    }
+
+    if (state.src.slice(pos, pos + sentinal.length) !== sentinal) {
+      return false
+    }
+
+    if (silent) {
+      return true
+    }
+
+    const start = pos + sentinal.length
+    const end = state.skipSpacesBack(max, pos)
+
+    console.log('demo tag found:', state.line, state.src.substring(start, end))
+
+    const rawPath = state.src.slice(start, end).trim().replace(/^@/, srcDir).trim()
+
+    const {filepath, extension, region, lines, lang, title} = rawPathToToken(rawPath)
+    const component = title.substring(0, title.indexOf('.'))
+
+    state.line += 1
+
+    const prefixToken = state.push('html_block', '', 0)
+    prefixToken.content = `<HighlightCard><${component}/><template #html>`
+
+    const codeToken = state.push('fence', 'code', 0)
+    codeToken.info = `${lang || extension}${lines ? `{${lines}}` : ''}${title ? `[${title}]` : ''}`
+
+    const {realPath, path: _path} = state.env as MarkdownEnv
+    const resolvedPath = path.resolve(path.dirname(realPath ?? _path), filepath)
+
+    // @ts-ignore
+    codeToken.src = [resolvedPath, region.slice(1)]
+    codeToken.markup = '```'
+    codeToken.map = [startLine, startLine + 1]
+
+    const postfixToken = state.push('html_block', '', 0)
+    postfixToken.content = `</template></HighlightCard>`
+
+    return true
+  }
+
+  md.block.ruler.before('snippet', 'demo', blockParser)
+}
+
+/**
+ * raw path format: "/path/to/file.extension#region {meta} [title]"
+ *    where #region, {meta} and [title] are optional
+ *    meta can be like '1,2,4-6 lang', 'lang' or '1,2,4-6'
+ *    lang can contain special characters like C++, C#, F#, etc.
+ *    path can be relative to the current file or absolute
+ *    file extension is optional
+ *    path can contain spaces and dots
+ *
+ * captures: ['/path/to/file.extension', 'extension', '#region', '{meta}', '[title]']
+ */
+const rawPathRegexp =
+  /^(.+?(?:(?:\.([a-z0-9]+))?))(?:(#[\w-]+))?(?: ?(?:{(\d+(?:[,-]\d+)*)? ?(\S+)?}))? ?(?:\[(.+)\])?$/
+
+function rawPathToToken(rawPath: string) {
+  const [filepath = '', extension = '', region = '', lines = '', lang = '', rawTitle = ''] = (
+    rawPathRegexp.exec(rawPath) || []
+  ).slice(1)
+
+  const title = rawTitle || filepath.split('/').pop() || ''
+
+  return {filepath, extension, region, lines, lang, title}
+}

--- a/apps/docs/.vitepress/plugins/demo-container.ts
+++ b/apps/docs/.vitepress/plugins/demo-container.ts
@@ -5,9 +5,6 @@ import path from 'path'
 // This plugin is inspired by vitepress' snippet plugin and must run before it to work
 //  It accepts all of the same syntax as the snippet plugin, but will render the demo
 //  _and_ display the example code inside of a HighlightCard component
-//
-// TODO: This currently requires an extra step of manually importing the demo component
-//  in the <script setup> block of the markdown file. Next step is to automate this process
 
 export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
   const blockParser: RuleBlock = (state, startLine, endLine, silent) => {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,6 +31,7 @@
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "unplugin-icons": "^0.19.0",
+    "unplugin-vue-components": "^0.27.0",
     "vitepress": "1.1.4",
     "vue": "^3.4.27"
   },

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -15,22 +15,10 @@ Indicate the current page’s location within a navigational hierarchy that auto
 ## Overview
 
 <HighlightCard>
-  <BBreadcrumb :items="breadcrumbItems" />
+  <BreadcrumbOverview />
   <template #html>
 
-```vue
-<BBreadcrumb :items="breadcrumbItems" />
-
-<script setup lang="ts">
-import type {BreadcrumbItem} from 'bootstrap-vue-next'
-
-const breadcrumbItems = ref<BreadcrumbItem[]>([
-  {text: 'Admin', href: 'https://getbootstrap.com/'},
-  {text: 'Manage', href: '#'},
-  {text: 'Library'},
-])
-</script>
-```
+<<< ./demo/BreadcrumbOverview.vue#snippet
 
   </template>
 </HighlightCard>
@@ -139,6 +127,7 @@ import {BBreadcrumbItem, BBreadcrumb} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
+import BreadcrumbOverview from "./demo/BreadcrumbOverview.vue"
 
 const breadcrumbItems = ref<BreadcrumbItem[]>([
   { text: 'Admin', href:'https://getbootstrap.com/'},

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -14,14 +14,7 @@ Indicate the current page’s location within a navigational hierarchy that auto
 
 ## Overview
 
-<HighlightCard>
-  <BreadcrumbOverview />
-  <template #html>
-
-<<< ./demo/BreadcrumbOverview.vue
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/BreadcrumbOverview.vue
 
 ## Breadcrumb items
 
@@ -39,34 +32,7 @@ You may also manually place individual `BBreadcrumbItem` child components in the
 the `BBreadcrumb` component, as an alternative to using the `items` prop, for greater control
 over the content of each item:
 
-<HighlightCard>
-  <BBreadcrumb>
-    <BBreadcrumbItem href="#home">
-      Home
-    </BBreadcrumbItem>
-    <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
-    <BBreadcrumbItem href="#bar" @click="alertEvent">Bar</BBreadcrumbItem>
-    <BBreadcrumbItem active>Baz</BBreadcrumbItem>
-  </BBreadcrumb>
-  <template #html>
-
-```vue
-<BBreadcrumb>
-  <BBreadcrumbItem href="#home"> Home </BBreadcrumbItem>
-  <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
-  <BBreadcrumbItem href="#bar" @click="alertEvent">Bar</BBreadcrumbItem>
-  <BBreadcrumbItem active>Baz</BBreadcrumbItem>
-</BBreadcrumb>
-
-<script setup lang="ts">
-const alertEvent = (event: PointerEvent) => {
-  alert(`Event ${event.target}`)
-}
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/BreadcrumbManual.vue
 
 Remember to set the `active` prop on the last item.
 
@@ -78,54 +44,10 @@ Remember to set the `active` prop on the last item.
 Two slots are provided to put additional content before and after the breadcrumb.
 Use slot `prepend` to put content before the breadcrumb. Use slot `append` to put content after the breadcrumb.
 
-<HighlightCard>
-  <BBreadcrumb>
-    <BBreadcrumbItem href="#home">
-      Home
-    </BBreadcrumbItem>
-    <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
-    <BBreadcrumbItem href="#bar">Bar</BBreadcrumbItem>
-    <BBreadcrumbItem active>Baz</BBreadcrumbItem>
-    <template v-slot:prepend><span class="mx-2">prepend text</span></template>
-    <template v-slot:append><span class="mx-2">append text</span></template>
-  </BBreadcrumb>
-  <template #html>
-
-```vue-html
-<BBreadcrumb>
-  <BBreadcrumbItem href="#home"> Home </BBreadcrumbItem>
-  <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
-  <BBreadcrumbItem href="#bar">Bar</BBreadcrumbItem>
-  <BBreadcrumbItem active>Baz</BBreadcrumbItem>
-  <template v-slot:prepend><span class="mx-2">prepend text</span></template>
-  <template v-slot:append><span class="mx-2">append text</span></template>
-</BBreadcrumb>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/BreadcrumbSlots.vue#template{vue-html}
 
 <ComponentReference :data="data" />
 
 <script setup lang="ts">
 import {data} from '../../data/components/breadcrumb.data'
-import {ref} from 'vue';
-import {BBreadcrumbItem, BBreadcrumb} from 'bootstrap-vue-next'
-import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
-import HighlightCard from '../../components/HighlightCard.vue'
-import BreadcrumbOverview from "./demo/BreadcrumbOverview.vue"
-import BreadcrumbAsArray from "./demo/BreadcrumbAsArray.vue"
-
-const breadcrumbItems = ref<BreadcrumbItem[]>([
-  { text: 'Admin', href:'https://getbootstrap.com/'},
-  { text: 'Manage', href:'#'},
-  { text: 'Library'},
-]);
-
-const breadcrumbStringArray = ['Admin', 'Manage', 'Library'];
-
-const alertEvent = (event: PointerEvent) => {
-  alert(`Event ${event.target}`);
-}
 </script>

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -18,7 +18,7 @@ Indicate the current page’s location within a navigational hierarchy that auto
   <BreadcrumbOverview />
   <template #html>
 
-<<< ./demo/BreadcrumbOverview.vue#snippet
+<<< ./demo/BreadcrumbOverview.vue
 
   </template>
 </HighlightCard>
@@ -31,20 +31,7 @@ The active state of last element is automatically set if it is `undefined`.
 
 ### Breadcrumb items as array of strings
 
-<HighlightCard>
-  <BBreadcrumb :items="breadcrumbStringArray" />
-  <template #html>
-
-```vue
-<BBreadcrumb :items="breadcrumbStringArray" />
-
-<script setup lang="ts">
-const breadcrumbStringArray = ['Admin', 'Manage', 'Library']
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/BreadcrumbAsArray.vue
 
 ## Manually placed items
 
@@ -128,6 +115,7 @@ import ComponentReference from '../../components/ComponentReference.vue'
 import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import BreadcrumbOverview from "./demo/BreadcrumbOverview.vue"
+import BreadcrumbAsArray from "./demo/BreadcrumbAsArray.vue"
 
 const breadcrumbItems = ref<BreadcrumbItem[]>([
   { text: 'Admin', href:'https://getbootstrap.com/'},

--- a/apps/docs/src/docs/components/demo/BreadcrumbAsArray.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbAsArray.vue
@@ -3,7 +3,5 @@
 </template>
 
 <script setup lang="ts">
-import {BBreadcrumb} from 'bootstrap-vue-next'
-
 const breadcrumbStringArray = ['Admin', 'Manage', 'Library']
 </script>

--- a/apps/docs/src/docs/components/demo/BreadcrumbAsArray.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbAsArray.vue
@@ -1,0 +1,9 @@
+<template>
+  <BBreadcrumb :items="breadcrumbStringArray" />
+</template>
+
+<script setup lang="ts">
+import {BBreadcrumb} from 'bootstrap-vue-next'
+
+const breadcrumbStringArray = ['Admin', 'Manage', 'Library']
+</script>

--- a/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
@@ -1,0 +1,15 @@
+<template>
+  <BBreadcrumb>
+    <BBreadcrumbItem href="#home"> Home </BBreadcrumbItem>
+    <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
+    <BBreadcrumbItem href="#bar" @click="alertEvent">Bar</BBreadcrumbItem>
+    <BBreadcrumbItem active>Baz</BBreadcrumbItem>
+  </BBreadcrumb>
+</template>
+
+<script setup lang="ts">
+const alertEvent = (event: PointerEvent) => {
+  // eslint-disable-next-line no-alert
+  alert(`Event ${event.target}`)
+}
+</script>

--- a/apps/docs/src/docs/components/demo/BreadcrumbOverview.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbOverview.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import {BBreadcrumb, type BreadcrumbItem} from 'bootstrap-vue-next'
+import {type BreadcrumbItem} from 'bootstrap-vue-next'
 import {ref} from 'vue'
 
 const breadcrumbItems = ref<BreadcrumbItem[]>([

--- a/apps/docs/src/docs/components/demo/BreadcrumbOverview.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbOverview.vue
@@ -1,0 +1,14 @@
+<template>
+  <BBreadcrumb :items="breadcrumbItems" />
+</template>
+
+<script setup lang="ts">
+import {BBreadcrumb, type BreadcrumbItem} from 'bootstrap-vue-next'
+import {ref} from 'vue'
+
+const breadcrumbItems = ref<BreadcrumbItem[]>([
+  {text: 'Admin', href: 'https://getbootstrap.com/'},
+  {text: 'Manage', href: '#'},
+  {text: 'Library'},
+])
+</script>

--- a/apps/docs/src/docs/components/demo/BreadcrumbSlots.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbSlots.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- #region template -->
+  <BBreadcrumb>
+    <BBreadcrumbItem href="#home"> Home </BBreadcrumbItem>
+    <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
+    <BBreadcrumbItem href="#bar">Bar</BBreadcrumbItem>
+    <BBreadcrumbItem active>Baz</BBreadcrumbItem>
+    <template #prepend><span class="mx-2">prepend text</span></template>
+    <template #append><span class="mx-2">append text</span></template>
+  </BBreadcrumb>
+  <!-- #endregion template -->
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 15.2.2
       turbo:
         specifier: latest
-        version: 2.0.11
+        version: 2.0.14
 
   apps/docs:
     devDependencies:
@@ -77,6 +77,9 @@ importers:
       unplugin-icons:
         specifier: ^0.19.0
         version: 0.19.0(@vue/compiler-sfc@3.4.31)(vue-template-compiler@2.7.16)
+      unplugin-vue-components:
+        specifier: ^0.27.0
+        version: 0.27.0(@babel/parser@7.24.7)(@nuxt/kit@3.12.3(rollup@4.18.1))(rollup@4.18.1)(vue@3.4.27(typescript@5.4.5))
       vitepress:
         specifier: 1.1.4
         version: 1.1.4(@algolia/client-search@4.23.3)(@types/node@20.12.12)(postcss@8.4.39)(sass@1.77.2)(search-insights@2.13.0)(terser@5.30.4)(typescript@5.4.5)
@@ -5741,38 +5744,38 @@ packages:
     resolution: {integrity: sha512-ZSDngmP1z6zw+FIkIBjvOp/II/mIub/O7Pp12j1WNsiCpg5R5wAc//i555bBQsE44O94btLt0xM/Zr2LQjwdCg==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  turbo-darwin-64@2.0.11:
-    resolution: {integrity: sha512-YlHEEhcm+jI1BSZoLugGHUWDfRXaNaQIv7tGQBfadYjo9kixBnqoTOU6s1ubOrQMID+lizZZQs79GXwqM6vohg==}
+  turbo-darwin-64@2.0.14:
+    resolution: {integrity: sha512-kwfDmjNwlNfvtrvT29+ZBg5n1Wvxl891bFHchMJyzMoR0HOE9N1NSNdSZb9wG3e7sYNIu4uDkNk+VBEqJW0HzQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.0.11:
-    resolution: {integrity: sha512-K/YW+hWzRQ/wGmtffxllH4M1tgy8OlwgXODrIiAGzkSpZl9+pIsem/F86UULlhsIeavBYK/LS5+dzV3DPMjJ9w==}
+  turbo-darwin-arm64@2.0.14:
+    resolution: {integrity: sha512-m3LXYEshCx3wc4ZClM6gb01KYpFmtjQ9IBF3A7ofjb6ahux3xlYZJZ3uFCLAGHuvGLuJ3htfiPbwlDPTdknqqw==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.0.11:
-    resolution: {integrity: sha512-mv8CwGP06UPweMh1Vlp6PI6OWnkuibxfIJ4Vlof7xqjohAaZU5FLqeOeHkjQflH/6YrCVuS9wrK0TFOu+meTtA==}
+  turbo-linux-64@2.0.14:
+    resolution: {integrity: sha512-7vBzCPdoTtR92SNn2JMgj1FlMmyonGmpMaQdgAB1OVYtuQ6NVGoh7/lODfaILqXjpvmFSVbpBIDrKOT6EvcprQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.0.11:
-    resolution: {integrity: sha512-wLE5tl4oriTmHbuayc0ki0csaCplmVLj+uCWtecM/mfBuZgNS9ICNM9c4sB+Cfl5tlBBFeepqRNgvRvn8WeVZg==}
+  turbo-linux-arm64@2.0.14:
+    resolution: {integrity: sha512-jwH+c0bfjpBf26K/tdEFatmnYyXwGROjbr6bZmNcL8R+IkGAc/cglL+OToqJnQZTgZvH7uDGbeSyUo7IsHyjuA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.0.11:
-    resolution: {integrity: sha512-tja3zvVCSWu3HizOoeQv0qDJ+GeWGWRFOOM6a8i3BYnXLgGKAaDZFcjwzgC50tWiAw4aowIVR4OouwIyRhLBaQ==}
+  turbo-windows-64@2.0.14:
+    resolution: {integrity: sha512-w9/XwkHSzvLjmioo6cl3S1yRfI6swxsV1j1eJwtl66JM4/pn0H2rBa855R0n7hZnmI6H5ywLt/nLt6Ae8RTDmw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.0.11:
-    resolution: {integrity: sha512-sYjXP6k94Bqh99R+y3M1Ks6LRIEZybMz+7enA8GKl6JJ2ZFaXxTnS6q+/2+ii1+rRwxohj5OBb4gxODcF8Jd4w==}
+  turbo-windows-arm64@2.0.14:
+    resolution: {integrity: sha512-XaQlyYk+Rf4xS5XWCo8XCMIpssgGGy8blzLfolN6YBp4baElIWMlkLZHDbGyiFmCbNf9I9gJI64XGRG+LVyyjA==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.0.11:
-    resolution: {integrity: sha512-imDlFFAvitbCm1JtDFJ6eG882qwxHUmVT2noPb3p2jq5o5DuXOchMbkVS9kUeC3/4WpY5N0GBZ3RvqNyjHZw1Q==}
+  turbo@2.0.14:
+    resolution: {integrity: sha512-00JjdCMD/cpsjP0Izkjcm8Oaor5yUCfDwODtaLb+WyblyadkaDEisGhy3Dbd5az9n+5iLSPiUgf+WjPbns6MRg==}
     hasBin: true
 
   type-check@0.4.0:
@@ -12879,32 +12882,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  turbo-darwin-64@2.0.11:
+  turbo-darwin-64@2.0.14:
     optional: true
 
-  turbo-darwin-arm64@2.0.11:
+  turbo-darwin-arm64@2.0.14:
     optional: true
 
-  turbo-linux-64@2.0.11:
+  turbo-linux-64@2.0.14:
     optional: true
 
-  turbo-linux-arm64@2.0.11:
+  turbo-linux-arm64@2.0.14:
     optional: true
 
-  turbo-windows-64@2.0.11:
+  turbo-windows-64@2.0.14:
     optional: true
 
-  turbo-windows-arm64@2.0.11:
+  turbo-windows-arm64@2.0.14:
     optional: true
 
-  turbo@2.0.11:
+  turbo@2.0.14:
     optionalDependencies:
-      turbo-darwin-64: 2.0.11
-      turbo-darwin-arm64: 2.0.11
-      turbo-linux-64: 2.0.11
-      turbo-linux-arm64: 2.0.11
-      turbo-windows-64: 2.0.11
-      turbo-windows-arm64: 2.0.11
+      turbo-darwin-64: 2.0.14
+      turbo-darwin-arm64: 2.0.14
+      turbo-linux-64: 2.0.14
+      turbo-linux-arm64: 2.0.14
+      turbo-windows-64: 2.0.14
+      turbo-windows-arm64: 2.0.14
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
# Describe the PR

This PR sets up a system to clean up how we implement demos/examples in our docs.

- I wrote a markdown-it plugin to override the snippet plugin syntax (<<< to take a DEMO marker, which will generate our entire <HighlightCard> demo section including the running demo and the syntax highlighted code with the single line + an external file.
- I added and configured `unplugin-vue-components` to clean up the import statements in both the demos and the *.md files.
- In addition, I used `unplugin-vue-components` to auto-register the demo components in markdown files, which removes the need to do any fancy footwork with adding import statements to the *.md files for those components.

Take a look at `breadcrumb.md` for an example of how this has cleaned up the markdown.

At this point, I believe the system is unambiguously better than it is currently. It's still set up so that we can incrementally move over to the new system and still use the old system if there are snippets that are small enough that we don't think it's necessary to have an external demo file.

I'm open to feedback on naming conventions/file structure for the demo files, but aside from that I believe this is ready to commit.


## Background Info

I'm pretty frustrated with how the demos/examples in our docs work. There are two full copies of the code, one of which is split between the place where the demo is and the main `script` block and neither gets autoformatted correctly. I've looked at a number of `markdown-it` plugins but none seem to be well used or supported and I couldn't get any to work.  The closest one I found was https://github.com/hairyf/markdown-it-vitepress-demo - I think it would do what I want if it worked, but it doesn't.

That sent me down the path of looking at what vitepress supports. [They do support pulling a code snippet from a SFC file](https://vitepress.dev/guide/markdown#import-code-snippets).

```vue
<template>
  <HighlightCard>
    <BreadcrumbOverview />
    <template #html>
  
  <<< ./demo/BreadcrumbOverview.vue
  
    </template>
  </HighlightCard>
</template>

<script setup lang="ts">
import BreadcrumbOverview from "./demo/BreadcrumbOverview.vue"
</script>
```

That solves the duplicate code + code formatting issue nicely.  It does have the downside of having a bunch of little demo files floating around, but all of the solutions I've found do that.

It's also more verbose than I'd like.

I dug into vitepress' snippet plugin and found it pretty readable. I pulled that apart and rewrote their rule to let me do something like this:

```vue
<template>
<<< DEMO ./demo/BreadcrumbAsArray.vue
</template?

<script setup lang="ts">
import BreadcrumbOverview from "./demo/BreadcrumbOverview.vue"
</script>
```

It also still supports all of the line hightling, etc. that the [vitepress snippet plugin](https://vitepress.dev/guide/markdown#import-code-snippets) does and doesn't interfere with the original plugin (it just has to run first, which it does).

I'm pretty happy with this solution. I'd like to take the time to see if I can get rid of the explicit import of the component and then I'd like to move forward with it. It has the advantage that it peacefully coexists with the existing system so I can convert over docs as I go through them for the parity pass.

Questions for @VividLemon:
1. Does this logic make sense to you? Or is there something that's sending up a red flag?
2. If you're good with this, do you have opinions on the file structure for the demo components?
3. This has the advantage of making the code we display identical to the code that's running, but it doesn't expunge the somewhat redundant imports. Also, a bunch of our existing samples don't include the outer <template> tags on the template block, while this always will. I can fix either or both of these by overriding Vitepress's `fence` render rule, but would rather not if you're all right with things as they are. This is also something that we can play with going forward if we go down this path, doesn't have to be solved on the initial round.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
