### PR TITLE
fix: pass attributes through in BDropdownItemButton

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -29,6 +29,7 @@ const _props = withDefaults(defineProps<BDropdownItemButtonProps>(), {
   buttonClass: undefined,
   disabled: false,
   variant: null,
+  wrapperAttrs: undefined,
 })
 const props = useDefaults(_props, 'BDropdownItemButton')
 

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -1,11 +1,12 @@
 <template>
-  <li role="presentation">
+  <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
     <button
       role="menu"
       type="button"
       class="dropdown-item"
       :class="computedClasses"
       :disabled="props.disabled"
+      v-bind="attrs"
       @click="clicked"
     >
       <slot />
@@ -16,7 +17,11 @@
 <script setup lang="ts">
 import {useDefaults} from '../../composables'
 import type {BDropdownItemButtonProps} from '../../types'
-import {computed} from 'vue'
+import {computed, useAttrs} from 'vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
 
 const _props = withDefaults(defineProps<BDropdownItemButtonProps>(), {
   active: false,
@@ -30,6 +35,8 @@ const props = useDefaults(_props, 'BDropdownItemButton')
 const emit = defineEmits<{
   click: [value: MouseEvent]
 }>()
+
+const {class: wrapperClass, ...attrs} = useAttrs()
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -18,10 +18,6 @@ import {useDefaults} from '../../composables'
 import type {BDropdownItemButtonProps} from '../../types'
 import {computed} from 'vue'
 
-defineOptions({
-  inheritAttrs: false,
-})
-
 const _props = withDefaults(defineProps<BDropdownItemButtonProps>(), {
   active: false,
   activeClass: 'active',

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -121,6 +121,7 @@ export interface BDropdownItemButtonProps {
   active?: boolean
   activeClass?: ClassValue
   buttonClass?: ClassValue
+  wrapperAttrs?: Readonly<AttrsValue>
   disabled?: boolean
   variant?: ColorVariant | null
 }


### PR DESCRIPTION
# Describe the PR

Currently, attributes passed to BDropdownItemButton are swallowed. But we want to add them to the list element like it was in BootstrapVue.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
