### PR TITLE
fix(BPagination): Get rid of bad binding on li

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
+++ b/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
@@ -350,7 +350,7 @@ const pages = computed(
           return {id: ELLIPSIS_BUTTON, ...ellipsisProps.value}
         default:
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          return {id: p, ...getPageButtonProps(p!)}
+          return {id: p, ...getPageButtonProps(p)}
       }
     }) as PageButton[]
 )
@@ -380,7 +380,7 @@ const elements = computed(() => {
       ...Array.from({length: pages}, (_, index) => index + 1),
       NEXT_BUTTON,
       !lastPage && !hideEndButtons ? LAST_BUTTON : null,
-    ].filter((x) => x !== null)
+    ].filter((x) => x !== null) as number[]
   }
 
   // All of the remaining cases result in an array that is exactly limit + 4 - hideEndButtons * 2 in length, so create
@@ -460,7 +460,7 @@ const elements = computed(() => {
   //   }
   // }
 
-  return buttons as number[]
+  return buttons.filter((x) => x !== null) as number[]
 })
 </script>
 

--- a/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
+++ b/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
@@ -6,40 +6,26 @@
     :aria-disabled="props.disabled"
     :aria-label="props.ariaLabel || undefined"
   >
-    <ReusableButton.define v-slot="{button, li, text, clickHandler}">
-      <li v-bind="li">
-        <component v-bind="button" :is="button.is" @click="clickHandler">
-          <slot
-            :name="text.name"
-            :disabled="text.disabled"
-            :page="text.page"
-            :index="text.index"
-            :active="text.active"
-            :content="text.value"
-          >
-            {{ text.value }}
-          </slot>
-        </component>
-      </li>
-    </ReusableButton.define>
-
-    <ReusableEllipsis.define>
-      <li v-bind="ellipsisProps.li">
-        <span v-bind="ellipsisProps.span">
+    <template v-for="page in pages" :key="`page-${page.id}`">
+      <li v-bind="page.li">
+        <span v-if="page.id === ELLIPSIS_BUTTON" v-bind="ellipsisProps.span">
           <slot name="ellipsis-text">
             {{ props.ellipsisText || '...' }}
           </slot>
         </span>
+        <component v-bind="page.button" :is="page.button.is" v-else @click="page.clickHandler">
+          <slot
+            :name="page.text.name"
+            :disabled="page.text.disabled"
+            :page="page.text.page"
+            :index="page.text.index"
+            :active="page.text.active"
+            :content="page.text.value"
+          >
+            {{ page.text.value }}
+          </slot>
+        </component>
       </li>
-    </ReusableEllipsis.define>
-
-    <template v-for="button in buttons" :key="`page-${button}`">
-      <ReusableButton.reuse v-if="button === FIRST_BUTTON" v-bind="firstButtonProps" />
-      <ReusableButton.reuse v-else-if="button === PREV_BUTTON" v-bind="prevButtonProps" />
-      <ReusableButton.reuse v-else-if="button === NEXT_BUTTON" v-bind="nextButtonProps" />
-      <ReusableButton.reuse v-else-if="button === LAST_BUTTON" v-bind="lastButtonProps" />
-      <ReusableEllipsis.reuse v-else-if="button === ELLIPSIS_BUTTON" />
-      <ReusableButton.reuse v-else-if="button !== null" v-bind="getPageButtonProps(button)" />
     </template>
   </ul>
 </template>
@@ -49,7 +35,7 @@ import {BvEvent} from '../../utils'
 import {computed, toRef, watch} from 'vue'
 import type {BPaginationProps, ClassValue} from '../../types'
 import {useAlignment, useDefaults} from '../../composables'
-import {createReusableTemplate, useToNumber} from '@vueuse/core'
+import {useToNumber} from '@vueuse/core'
 
 // Threshold of limit size when we start/stop showing ellipsis
 const ELLIPSIS_THRESHOLD = 3
@@ -59,6 +45,15 @@ const PREV_BUTTON = -2
 const NEXT_BUTTON = -3
 const LAST_BUTTON = -4
 const ELLIPSIS_BUTTON = -5
+
+// This is necessary because type inference isn't succeeding for the pages computed
+interface PageButton {
+  id: number
+  li: Record<string, unknown>
+  button: Record<string, unknown>
+  text: Record<string, unknown>
+  clickHandler: (e: Readonly<MouseEvent>) => void
+}
 
 const _props = withDefaults(defineProps<BPaginationProps>(), {
   align: 'start',
@@ -262,9 +257,6 @@ const lastButtonProps = computed(() =>
   })
 )
 
-const ReusableButton = createReusableTemplate<ReturnType<typeof getButtonProps>>()
-const ReusableEllipsis = createReusableTemplate()
-
 const ellipsisProps = computed(() => ({
   li: {
     class: [
@@ -342,7 +334,27 @@ watch(pagination, (oldValue, newValue) => {
   }
 })
 
-const buttons = computed(() => {
+const pages = computed(
+  () =>
+    elements.value.map((p) => {
+      switch (p) {
+        case FIRST_BUTTON:
+          return {id: FIRST_BUTTON, ...firstButtonProps.value}
+        case PREV_BUTTON:
+          return {id: PREV_BUTTON, ...prevButtonProps.value}
+        case NEXT_BUTTON:
+          return {id: NEXT_BUTTON, ...nextButtonProps.value}
+        case LAST_BUTTON:
+          return {id: LAST_BUTTON, ...lastButtonProps.value}
+        case ELLIPSIS_BUTTON:
+          return {id: ELLIPSIS_BUTTON, ...ellipsisProps.value}
+        default:
+          return {id: p, ...getPageButtonProps(p)}
+      }
+    }) as PageButton[]
+)
+
+const elements = computed(() => {
   // The idea here is to create an array of all the buttons on the page control.
   // This way we can keep the invariants in one place and the template code just
   // iterates over the array.

--- a/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
+++ b/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
@@ -349,7 +349,6 @@ const pages = computed(
         case ELLIPSIS_BUTTON:
           return {id: ELLIPSIS_BUTTON, ...ellipsisProps.value}
         default:
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           return {id: p, ...getPageButtonProps(p)}
       }
     }) as PageButton[]

--- a/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
+++ b/packages/bootstrap-vue-next/src/components/BPagination/BPagination.vue
@@ -349,7 +349,8 @@ const pages = computed(
         case ELLIPSIS_BUTTON:
           return {id: ELLIPSIS_BUTTON, ...ellipsisProps.value}
         default:
-          return {id: p, ...getPageButtonProps(p)}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          return {id: p, ...getPageButtonProps(p!)}
       }
     }) as PageButton[]
 )


### PR DESCRIPTION
# Describe the PR

This PR resolves #2146 

We don't really need to use reusable templates in BPagination after the refactor I did earlier this year. I almost pulled them out then, so I just pushed a bit more of the logic out to the script section and landed on a solution that just has a simple loop with a single if/else in the template.

## Small replication

See #2146

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
