### PR TITLE
fix(BPagination): hide-goto-end doesn't hide first-page or last-page

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BPagination/pagination.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BPagination/pagination.spec.ts
@@ -126,11 +126,37 @@ describe('pagination', () => {
     expect(wrapper.find('[aria-label="Go to first page"]').exists()).toBeFalsy()
   })
 
+  it('has page 1 button when hideGotoEndButtons="true" and firstNumber="true"', () => {
+    const wrapper = mount(BPagination, {
+      props: {
+        totalRows: 100,
+        perPage: 1,
+        modelValue: 1,
+        hideGotoEndButtons: true,
+        firstNumber: true,
+      },
+    })
+    expect(wrapper.find('[aria-label="Go to page 1"]').exists()).toBeTruthy()
+  })
+
   it('does not have last button when hideGotoEndButtons="true"', () => {
     const wrapper = mount(BPagination, {
       props: {totalRows: 100, perPage: 1, modelValue: 5, hideGotoEndButtons: true},
     })
     expect(wrapper.find('[aria-label="Go to last page"]').exists()).toBeFalsy()
+  })
+
+  it('has page n button when hideGotoEndButtons="true" and lastNumber="true"', () => {
+    const wrapper = mount(BPagination, {
+      props: {
+        totalRows: 100,
+        perPage: 1,
+        modelValue: 5,
+        hideGotoEndButtons: true,
+        lastNumber: true,
+      },
+    })
+    expect(wrapper.find('[aria-label="Go to page 100"]').exists()).toBeTruthy()
   })
 
   it('has end ellipses in correct place when hideGotoEndButtons="true"', () => {


### PR DESCRIPTION
# Describe the PR

This PR addresses #2165 

I misunderstood the intention of the `hide-goto-end-buttons` flag. It should just hide the explicit `first` and `last` buttons, not the  first page or last page button (which are labeled with the page numbers). That is how BSV works and it seems reasonable so I've reimplemented it that way.

I also discovered an issue that was either because of the refactor I recently did or a change in how vue handles keys in a for loop. In either case, having a duplicate key in the array for the ellipsis causes some weird update problems (at lest in dev mode) so I removed that ambiguity while I was at it.

## Small replication

See #2165

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
