### PR TITLE
docs: Use Not Yet Implemented Component consistently

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -70,6 +70,10 @@
                           {{ normalizeDefault(d.item.default) }}
                         </code>
                       </template>
+                      <template #cell(description)="d">
+                        <NotYetImplemented v-if="d.item.notYetImplemented" />
+                        {{ d.item.description }}
+                      </template>
                     </BTable>
                     <template v-if="component.props.some((el) => el.name.trim() !== '')">
                       <span
@@ -171,6 +175,7 @@
                           v-for="scope in d.item.scope as SlotScopeReference[]"
                           :key="scope.prop"
                         >
+                          <span v-if="scope.notYetImplemented"><NotYetImplemented />: </span>
                           <code>{{ kebabCase(scope.prop) }}</code>
                           <code>: {{ scope.type }}</code>
                           <span v-if="!!scope.description"> - {{ scope.description }}</span>

--- a/apps/docs/src/components/NotYetImplemented.vue
+++ b/apps/docs/src/components/NotYetImplemented.vue
@@ -1,7 +1,13 @@
 <template>
   <a
     href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#developing"
-    style="color: red"
-    >Not yet implemented <span v-if="$slots.default">: </span><slot
+    ><span style="color: red">Not yet implemented</span><span v-if="$slots.default">: </span><slot
   /></a>
 </template>
+
+<script setup lang="ts">
+defineSlots<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default?: (props: Record<string, never>) => any
+}>()
+</script>

--- a/apps/docs/src/data/components/formTags.data.ts
+++ b/apps/docs/src/data/components/formTags.data.ts
@@ -412,7 +412,8 @@ export default {
             {
               prop: 'remove',
               type: '() => void',
-              description: 'Method to fully reset the tags input [Not yet implemented]',
+              description: 'Method to fully reset the tags input',
+              notYetImplemented: true,
             },
             {
               prop: 'removeTag',

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -181,7 +181,9 @@ For more information on using `BNav` in card headers, refer to the
 ## Card groups
 
 In addition to styling the content within cards, BootstrapVueNext includes a `BCardGroup` component
-for laying out series of cards. For the time being, these layout options are not yet responsive.
+for laying out series of cards.
+
+<NotYetImplemented>For the time being, these layout options are not responsive.</NotYetImplemented>
 
 ### Default card group
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -182,7 +182,7 @@ not implemented.
 
 The `sliding-start` and `sliding-end` events have been renamed to `slide` and `slid`.
 The `label-indicators` prop has been renamed to `indicators-button-label`.
-The `label-goto-slide`and `no-animation` props are not yet implemented.
+<NotYetImplemented>The `label-goto-slide`and `no-animation` props.</NotYetImplemented>
 
 ## BForm
 
@@ -214,7 +214,7 @@ Use `label-visually-hidden` instead of `label-sronly` per
 Access to the native `input` element is implemented differently due to changes in how Vue 3
 handles references. See the [BFormInput documentation](/docs/components/form-input#exposed-input-element) for more details.
 
-Datalist and disabling mousewheel events are not yet implemented.
+<NotYetImplemented>Disabling mousewheel events.</NotYetImplemented>
 
 `trim`, `lazy`, or `number` properties have been deprecated. We support the native modifiers
 [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
@@ -422,7 +422,7 @@ Keyboard Navigation and Small Screen Support.
 
 ## BPaginationNav
 
-This component is not yet implemented
+<NotYetImplemented/>
 
 <script setup lang="ts">
 import {computed, ref} from 'vue'

--- a/apps/docs/src/types/index.ts
+++ b/apps/docs/src/types/index.ts
@@ -1,12 +1,18 @@
 export type ComponentItem = Exclude<keyof ComponentReference, 'component' | 'sections'>
 export type ComponentSection = 'Properties' | 'Events' | 'Slots'
 export type EmitArgReference = {arg: string; type: string; description?: string}
-export type SlotScopeReference = {prop: string; type: string | string[]; description?: string}
+export type SlotScopeReference = {
+  prop: string
+  type: string | string[]
+  description?: string
+  notYetImplemented?: boolean
+}
 
 export interface PropertyReference {
   type?: string
   description?: string
   default?: unknown
+  notYetImplemented?: boolean
 }
 
 /**

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -221,8 +221,7 @@ export const commonProps = () =>
     list: {
       type: 'string',
       default: 'undefined',
-      description:
-        'The ID of the associated datalist element or component (Datalist is Not Yet Implemented)',
+      description: 'The ID of the associated datalist element or component',
     },
     name: {
       type: 'string',

--- a/apps/docs/src/utils/link-props.ts
+++ b/apps/docs/src/utils/link-props.ts
@@ -39,7 +39,8 @@ export const linkProps = {
     type: 'boolean',
     default: false,
     description:
-      'Not Yet Implemented: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `no-prefetch` will disabled this feature for the specific link',
+      'To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `no-prefetch` will disabled this feature for the specific link',
+    notYetImplemented: true,
   },
   opacity: {
     type: "10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'",
@@ -55,7 +56,8 @@ export const linkProps = {
     type: 'boolean',
     default: undefined,
     description:
-      'Not Yet Implemented: To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `prefetch` to `true` or `false` will overwrite the default value of `router.prefetchLinks`',
+      'To improve the responsiveness of your Nuxt.js applications, when the link will be displayed within the viewport, Nuxt.js will automatically prefetch the code splitted page. Setting `prefetch` to `true` or `false` will overwrite the default value of `router.prefetchLinks`',
+    notYetImplemented: true,
   },
   prefetchedClass: {
     type: 'string',


### PR DESCRIPTION
# Describe the PR

- Small tweak to the NYI component to make it a little less red
- Used NYI in all of the *.md files that previously had free-text notes
- Added an notYetImplemented flag to props and scoped slot args

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
