### PR TITLE
docs: Migration Guide refactor

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -29,8 +29,7 @@ export default defineConfig({
     plugins: [
       Icons(),
       Components({
-        dirs: ['components', 'docs/components/demo'],
-        extensions: ['vue'],
+        globs: ['components/*.vue', 'docs/**/demo/*.vue'],
         dts: true,
         include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
         resolvers: [BootstrapVueNextResolver()],

--- a/apps/docs/.vitepress/plugins/demo-container.ts
+++ b/apps/docs/.vitepress/plugins/demo-container.ts
@@ -3,12 +3,16 @@ import type {RuleBlock} from 'markdown-it/lib/parser_block.mjs'
 import path from 'path'
 
 // This plugin is inspired by vitepress' snippet plugin and must run before it to work
+//  https://vitepress.dev/guide/markdown.html#import-code-snippets
 //  It accepts all of the same syntax as the snippet plugin, but will render the demo
 //  _and_ display the example code inside of a HighlightCard component
+// To invoke this plugin use <<< DEMO /path/to/file.extension#region{meta} for a running demo
+//  and example code or <<< FRAGMENT /path/to/file.extension#region{meta} for just the example code
 
 export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
   const blockParser: RuleBlock = (state, startLine, endLine, silent) => {
-    const sentinal = '<<< DEMO '
+    const demoSentinal = '<<< DEMO '
+    const fragmentSentinal = '<<< FRAGMENT '
     const pos = state.bMarks[startLine] + state.tShift[startLine]
     const max = state.eMarks[startLine]
 
@@ -17,26 +21,30 @@ export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
       return false
     }
 
-    if (state.src.slice(pos, pos + sentinal.length) !== sentinal) {
+    const isDemo = state.src.slice(pos, pos + demoSentinal.length) === demoSentinal
+    const isFragment = state.src.slice(pos, pos + fragmentSentinal.length) === fragmentSentinal
+
+    if (!isDemo && !isFragment) {
       return false
     }
+    const sentinalLength = isDemo ? demoSentinal.length : fragmentSentinal.length
 
     if (silent) {
       return true
     }
 
-    const start = pos + sentinal.length
+    const start = pos + sentinalLength
     const end = state.skipSpacesBack(max, pos)
 
     const rawPath = state.src.slice(start, end).trim().replace(/^@/, srcDir).trim()
 
     const {filepath, extension, region, lines, lang, title} = rawPathToToken(rawPath)
-    const component = title.substring(0, title.indexOf('.'))
+    const component = isDemo ? `<${title.substring(0, title.indexOf('.'))}/>` : ''
 
     state.line += 1
 
     const prefixToken = state.push('html_block', '', 0)
-    prefixToken.content = `<HighlightCard><${component}/><template #html>`
+    prefixToken.content = `<HighlightCard>${component}<template #html>`
 
     const codeToken = state.push('fence', 'code', 0)
     codeToken.info = `${lang || extension}${lines ? `{${lines}}` : ''}${title ? `[${title}]` : ''}`

--- a/apps/docs/src/components/HighlightCard.vue
+++ b/apps/docs/src/components/HighlightCard.vue
@@ -1,6 +1,6 @@
 <template>
   <BCard no-body class="mb-5">
-    <BCardBody>
+    <BCardBody v-if="$slots.default">
       <slot />
     </BCardBody>
     <template v-if="$slots.html">

--- a/apps/docs/src/docs/demo/AlertAfter.vue
+++ b/apps/docs/src/docs/demo/AlertAfter.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- #region template -->
+  <BAlert :model-value="true" variant="primary">A simple primary alert—check it out!</BAlert>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/demo/AlertBefore.vue
+++ b/apps/docs/src/docs/demo/AlertBefore.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- #region template -->
+  <BAlert variant="primary" show>A simple primary alert—check it out!</BAlert>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/demo/AvatarIcon.vue
+++ b/apps/docs/src/docs/demo/AvatarIcon.vue
@@ -1,0 +1,25 @@
+<template>
+  <BContainer>
+    <BRow>
+      <BCol>
+        <!-- #region template -->
+        <BAvatar>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="80%"
+            height="80%"
+            fill="currentColor"
+            class="bi bi-person-hearts"
+            viewBox="0 0 16 16"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M11.5 1.246c.832-.855 2.913.642 0 2.566-2.913-1.924-.832-3.421 0-2.566M9 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m-9 8c0 1 1 1 1 1h10s1 0 1-1-1-4-6-4-6 3-6 4m13.5-8.09c1.387-1.425 4.855 1.07 0 4.277-4.854-3.207-1.387-5.702 0-4.276ZM15 2.165c.555-.57 1.942.428 0 1.711-1.942-1.283-.555-2.281 0-1.71Z"
+            />
+          </svg>
+        </BAvatar>
+        <!-- #endregion template -->
+      </BCol>
+    </BRow>
+  </BContainer>
+</template>

--- a/apps/docs/src/docs/demo/AvatarIcon.vue
+++ b/apps/docs/src/docs/demo/AvatarIcon.vue
@@ -1,25 +1,19 @@
 <template>
-  <BContainer>
-    <BRow>
-      <BCol>
-        <!-- #region template -->
-        <BAvatar>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="80%"
-            height="80%"
-            fill="currentColor"
-            class="bi bi-person-hearts"
-            viewBox="0 0 16 16"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M11.5 1.246c.832-.855 2.913.642 0 2.566-2.913-1.924-.832-3.421 0-2.566M9 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m-9 8c0 1 1 1 1 1h10s1 0 1-1-1-4-6-4-6 3-6 4m13.5-8.09c1.387-1.425 4.855 1.07 0 4.277-4.854-3.207-1.387-5.702 0-4.276ZM15 2.165c.555-.57 1.942.428 0 1.711-1.942-1.283-.555-2.281 0-1.71Z"
-            />
-          </svg>
-        </BAvatar>
-        <!-- #endregion template -->
-      </BCol>
-    </BRow>
-  </BContainer>
+  <!-- #region template -->
+  <BAvatar>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="80%"
+      height="80%"
+      fill="currentColor"
+      class="bi bi-person-hearts"
+      viewBox="0 0 16 16"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M11.5 1.246c.832-.855 2.913.642 0 2.566-2.913-1.924-.832-3.421 0-2.566M9 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m-9 8c0 1 1 1 1 1h10s1 0 1-1-1-4-6-4-6 3-6 4m13.5-8.09c1.387-1.425 4.855 1.07 0 4.277-4.854-3.207-1.387-5.702 0-4.276ZM15 2.165c.555-.57 1.942.428 0 1.711-1.942-1.283-.555-2.281 0-1.71Z"
+      />
+    </svg>
+  </BAvatar>
+  <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/demo/ModalConfirm.vue
+++ b/apps/docs/src/docs/demo/ModalConfirm.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <BButton @click="confirmBox">Show Confirm</BButton>
+    <div>Result: {{ confirmResult ?? 'null' }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {useModalController} from 'bootstrap-vue-next'
+import {ref} from 'vue'
+
+const {confirm} = useModalController()
+const confirmResult = ref<boolean | null | undefined>(null)
+
+const confirmBox = async () => {
+  confirmResult.value = await confirm?.({
+    props: {
+      body: 'Are you sure you want to do this?',
+      title: 'Confirm',
+      okTitle: 'Yes',
+      cancelTitle: 'No',
+    },
+  })
+}
+</script>

--- a/apps/docs/src/docs/demo/ModalMessageBox.vue
+++ b/apps/docs/src/docs/demo/ModalMessageBox.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <BButton @click="okBox">Show Message</BButton>
+    <div>Result: {{ okResult }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {useModalController} from 'bootstrap-vue-next'
+import {ref} from 'vue'
+
+const {show} = useModalController()
+
+const okResult = ref<boolean | null | undefined>(undefined)
+
+const okBox = async () => {
+  okResult.value = await show?.({
+    props: {
+      body: 'This is an informational message',
+      title: 'Message',
+      okOnly: true,
+    },
+  })
+}
+</script>

--- a/apps/docs/src/docs/demo/SyncAfter.vue
+++ b/apps/docs/src/docs/demo/SyncAfter.vue
@@ -1,0 +1,7 @@
+<template>
+  <!-- #region template -->
+  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate">
+    Click me to see what happens
+  </BFormCheckbox>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/demo/SyncBefore.vue
+++ b/apps/docs/src/docs/demo/SyncBefore.vue
@@ -1,0 +1,7 @@
+<template>
+  <!-- #region template -->
+  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate"
+    >Click me to see what happens</BFormCheckbox
+  >
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -108,45 +108,7 @@ now the `close` slot.
 Icon support has been deprecated. Icons support can be implemented using the default slot including
 either [unplug icons](/docs/icons) or by embedding an `.svg`.
 
-<HighlightCard>
-  <BAvatar>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="80%"
-      height="80%"
-      fill="currentColor"
-      class="bi bi-person-hearts"
-      viewBox="0 0 16 16"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.5 1.246c.832-.855 2.913.642 0 2.566-2.913-1.924-.832-3.421 0-2.566M9 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m-9 8c0 1 1 1 1 1h10s1 0 1-1-1-4-6-4-6 3-6 4m13.5-8.09c1.387-1.425 4.855 1.07 0 4.277-4.854-3.207-1.387-5.702 0-4.276ZM15 2.165c.555-.57 1.942.428 0 1.711-1.942-1.283-.555-2.281 0-1.71Z"
-      /></svg
-  ></BAvatar>
-
-<template #html>
-
-```vue
-<template>
-  <BAvatar>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="80%"
-      height="80%"
-      fill="currentColor"
-      class="bi bi-person-hearts"
-      viewBox="0 0 16 16"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.5 1.246c.832-.855 2.913.642 0 2.566-2.913-1.924-.832-3.421 0-2.566M9 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0m-9 8c0 1 1 1 1 1h10s1 0 1-1-1-4-6-4-6 3-6 4m13.5-8.09c1.387-1.425 4.855 1.07 0 4.277-4.854-3.207-1.387-5.702 0-4.276ZM15 2.165c.555-.57 1.942.428 0 1.711-1.942-1.283-.555-2.281 0-1.71Z"
-      /></svg
-  ></BAvatar>
-</template>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/AvatarIcon.vue#template{vue-html}
 
 ### Badge Positioning
 
@@ -340,99 +302,11 @@ for `msgBoxOk` and `msgBoxConfirm`.
 
 Example using `useModalController.show` to replace `msgBoxOk` (Remember to include `<BModalOrchestrator />` in your App Root):
 
-<HighlightCard>
-  <div>
-    <BButton @click="okBox">Show Message</BButton>
-    <div>Result: {{ okResult }}</div>
-  </div>
-
-<template #html>
-
-```vue
-<template>
-  <div>
-    <BButton @click="okBox">Show Message</BButton>
-    <div>Result: {{ okResult }}</div>
-  </div>
-</template>
-
-<script setup lang="ts">
-import {BButton} from './components'
-import {useModalController} from './composables'
-import {ref} from 'vue'
-
-const {confirm, show} = useModalController()
-
-const confirmResult = ref<boolean | null | undefined>(null)
-
-const confirmBox = async () => {
-  confirmResult.value = await confirm?.({
-    props: {
-      body: 'Are you sure you want to do this?',
-      title: 'Confirm',
-      okTitle: 'Yes',
-      cancelTitle: 'No',
-    },
-  })
-}
-
-const okResult = ref<boolean | null | undefined>(undefined)
-
-const okBox = async () => {
-  okResult.value = await show?.({
-    props: {
-      body: 'This is an informational message',
-      title: 'Message',
-      okOnly: true,
-    },
-  })
-}
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/ModalMessageBox.vue
 
 Example using `useModalController.confirm` to replace `msgBoxConfirm` (Remember to include `<BModalOrchestrator />` in your App Root):
 
-<HighlightCard>
-  <div>
-    <BButton @click="confirmBox">Show Confirm</BButton>
-    <div>Result: {{ confirmResult ?? 'null' }}</div>
-  </div>
-
-<template #html>
-
-```vue
-<template>
-  <div>
-    <BButton @click="confirmBox">Show Confirm</BButton>
-    <div>Result: {{ confirmResult ?? 'null' }}</div>
-  </div>
-</template>
-
-<script setup lang="ts">
-import {BButton, useModalController} from 'bootstrap-vue-next'
-import {ref} from 'vue'
-
-const {confirm} = useModalController()
-const confirmResult = ref<boolean | null | undefined>(null)
-
-const confirmBox = async () => {
-  confirmResult.value = await confirm?.({
-    props: {
-      body: 'Are you sure you want to do this?',
-      title: 'Confirm',
-      okTitle: 'Yes',
-      cancelTitle: 'No',
-    },
-  })
-}
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/ModalConfirm.vue
 
 The `show` and `confirm` `props` object accespts all of the properties that are defined on
 [BModal](/docs/components/modal#component-reference) excpet for `modelValue`.

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -31,31 +31,11 @@ on the the model (generally named models).
 For instance, in order to two-way bind to the `indeterminate` property in `BFormCheckBox` you `v-bind` to the the model
 named `indeterminate` rather than adding the sync modifier to the `indeterminate` property:
 
-<HighlightCard>
-  <template #html>
-
-```vue-html
-    <BFormCheckbox v-model="checked" :indeterminate.sync="indeterminate">
-      Click me to see what happens
-    </BFormCheckbox>
-```
-
-  </template>
-</HighlightCard>
+<<< FRAGMENT ./demo/SyncBefore.vue#template{vue-html}
 
 becomes
 
-<HighlightCard>
-  <template #html>
-
-```vue-html
-  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate"
-    >Click me to see what happens</BFormCheckbox
-  >
-```
-
-  </template>
-</HighlightCard>
+<<< FRAGMENT ./demo/SyncAfter.vue#template{vue-html}
 
 See the [Vue 3 migration guide](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
 for more info.
@@ -77,27 +57,11 @@ This takes the place of `top`, `bottom`, `left`, and `right` values for the `rou
 As in `bootstrap-vue`, a simple `BAlert` is not visible by default. However, the means of showing the alert are different.
 The `bootstrap-vue` `show` prop is deprecated, use `model-value` instead.
 
-<HighlightCard>
-  <template #html>
-
-```vue-html
-  <BAlert variant="primary" show>A simple primary alert—check it out!</BAlert>
-```
-
-  </template>
-</HighlightCard>
+<<< FRAGMENT ./demo/AlertBefore.vue#template{vue-html}
 
 becomes
 
-<HighlightCard>
-  <template #html>
-
-```vue-html
-  <BAlert :model-value="true" variant="primary">A simple primary alert—check it out!</BAlert>
-```
-
-  </template>
-</HighlightCard>
+<<< FRAGMENT ./demo/AlertAfter.vue#template{vue-html}
 
 For consistency with other components properties, slots and events that use the term `dismissible` in `bootstrap-vue`
 now use the term `close`. For example the `dismissed` event is now the `closed` event and the `dsimiss` slot is


### PR DESCRIPTION
# Describe the PR

- Refactor the migration guide to put code into separate files
- Add the idea of a code fragment in our `markdown.it` plug-in for where we're just displaying the sample code, not running the demo (useful for migration before/after among other things)
- Make HighlightCard recognize when there isn't a running component, and don't add in the first `BCardBody`, which was just an annoying amount of blank space.
- Generalize the configuration of the auto-resolver to grab *.vue files in any demo directory so samples can be in a demo directory directly adjacent to the *.md file in various places in our docs.


## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
