### PR TITLE
doc(variant): interaction between variant, bg-variant & text-variant

### DIFF
--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -232,27 +232,28 @@ Use the `variant` prop to specify one of Bootstrap theme variant colors. The def
   </template>
 </HighlightCard>
 
-When displaying text inside the avatar, text colors are calculated based on the `variant` prop. The result is either `light` or `dark`. You can override the calculated text color by manually specifying the `bg-variant` and `text-variant` props. In order to do so, you must override the default for the variant prop by
-setting it to null - `:variant='null'`
+When displaying text inside the avatar, text colors are calculated based on the `variant` prop. The result is either `light` or `dark`. You can override the calculated text color by manually specifying the `bg-variant` and `text-variant` props. Note that
+`bg-variant` and `text-variant` take precedence over `variant`. See the
+[Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
 
 <HighlightCard>
   <div class="d-flex" style="column-gap: 1%;">
-    <BAvatar :variant="null" bg-variant="primary" text="P" />
-    <BAvatar :variant="null" bg-variant="primary" text-variant="info" text="P" />
-    <BAvatar :variant="null" bg-variant="secondary" text="A" />
-    <BAvatar :variant="null" bg-variant="secondary" text-variant="info" text="A" />
-    <BAvatar :variant="null" bg-variant="warning" text="A" />
-    <BAvatar :variant="null" bg-variant="warning" text-variant="light" text="A" />
+    <BAvatar bg-variant="primary" text="P" />
+    <BAvatar bg-variant="primary" text-variant="info" text="P" />
+    <BAvatar bg-variant="secondary" text="A" />
+    <BAvatar bg-variant="secondary" text-variant="info" text="A" />
+    <BAvatar bg-variant="warning" text="A" />
+    <BAvatar bg-variant="warning" text-variant="light" text="A" />
   </div>
   <template #html>
 
 ```vue-html
-<BAvatar :variant="null" bg-variant="primary" text="P" />
-<BAvatar :variant="null" bg-variant="primary" text-variant="info" text="P" />
-<BAvatar :variant="null" bg-variant="secondary" text="A" />
-<BAvatar :variant="null" bg-variant="secondary" text-variant="info" text="A" />
-<BAvatar :variant="null" bg-variant="warning" text="A" />
-<BAvatar :variant="null" bg-variant="warning" text-variant="light" text="A" />
+<BAvatar bg-variant="primary" text="P" />
+<BAvatar bg-variant="primary" text-variant="info" text="P" />
+<BAvatar bg-variant="secondary" text="A" />
+<BAvatar bg-variant="secondary" text-variant="info" text="A" />
+<BAvatar bg-variant="warning" text="A" />
+<BAvatar bg-variant="warning" text-variant="light" text="A" />
 ```
 
   </template>

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -232,26 +232,27 @@ Use the `variant` prop to specify one of Bootstrap theme variant colors. The def
   </template>
 </HighlightCard>
 
-When displaying text inside the avatar, text colors are calculated based on the `variant` property. The result is either `light` or `dark`. You can override the calculated text color by specifying the `text-variant` property.
+When displaying text inside the avatar, text colors are calculated based on the `variant` prop. The result is either `light` or `dark`. You can override the calculated text color by manually specifying the `bg-variant` and `text-variant` props. In order to do so, you must override the default for the variant prop by
+setting it to null - `:variant='null'`
 
 <HighlightCard>
   <div class="d-flex" style="column-gap: 1%;">
-    <BAvatar variant="primary" text="P" />
-    <BAvatar variant="primary" text-variant="dark" text="P" />
-    <BAvatar variant="secondary" text="A" />
-    <BAvatar variant="secondary" text-variant="info" text="A" />
-    <BAvatar variant="warning" text="A" />
-    <BAvatar variant="warning" text-variant="primary" text="A" />
+    <BAvatar :variant="null" bg-variant="primary" text="P" />
+    <BAvatar :variant="null" bg-variant="primary" text-variant="info" text="P" />
+    <BAvatar :variant="null" bg-variant="secondary" text="A" />
+    <BAvatar :variant="null" bg-variant="secondary" text-variant="info" text="A" />
+    <BAvatar :variant="null" bg-variant="warning" text="A" />
+    <BAvatar :variant="null" bg-variant="warning" text-variant="light" text="A" />
   </div>
   <template #html>
 
 ```vue-html
-<BAvatar variant="primary" text="P" />
-<BAvatar variant="primary" text-variant="dark" text="P" />
-<BAvatar variant="secondary" text="A" />
-<BAvatar variant="secondary" text-variant="info" text="A" />
-<BAvatar variant="warning" text="A" />
-<BAvatar variant="warning" text-variant="primary" text="A" />
+<BAvatar :variant="null" bg-variant="primary" text="P" />
+<BAvatar :variant="null" bg-variant="primary" text-variant="info" text="P" />
+<BAvatar :variant="null" bg-variant="secondary" text="A" />
+<BAvatar :variant="null" bg-variant="secondary" text-variant="info" text="A" />
+<BAvatar :variant="null" bg-variant="warning" text="A" />
+<BAvatar :variant="null" bg-variant="warning" text-variant="light" text="A" />
 ```
 
   </template>

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -152,8 +152,9 @@ Using color to add meaning only provides a visual indication, which will not be 
 <div class="mt-2"></div>
 
 ::: warning Interactions between Variant props
-`BBadge` implements `bg-variant` and `text-variant` to provide finer control of colors, but there
-are non-intutive interactions between these props. See the [Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
+`BBadge` implements `bg-variant` and `text-variant` to provide finer control of colors, they take
+precedence over the `variant` prop. See the
+[Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
 :::
 
 ## Pill badges

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -149,6 +149,13 @@ Add any of the following variants via the `variant` prop to change the appearanc
 Using color to add meaning only provides a visual indication, which will not be conveyed to users of assistive technologies – such as screen readers. Ensure that information denoted by the color is either obvious from the content itself (e.g. the visible text), or is included through alternative means, such as additional text hidden with the `.visually-hidden` class.
 :::
 
+<div class="mt-2"></div>
+
+::: warning Interactions between Variant props
+`BBadge` implements `bg-variant` and `text-variant` to provide finer control of colors, but there
+are non-intutive interactions between these props. See the [Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
+:::
+
 ## Pill badges
 
 Use the `pill` prop to make badges more rounded with a larger border-radius.

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -178,8 +178,9 @@ padding and size of a button.
 **Tip:** remove the hover underline from a link variant button by setting `underline-opacity="0"`.
 
 ::: warning Interactions between Variant props
-`BButton` implements `bg-variant` and `text-variant` to provide finer control of colors, but there
-are non-intutive interactions between these props. See the [Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
+`BButton` implements `bg-variant` and `text-variant` to provide finer control of colors, they take
+precedence over the `variant` prop. See the
+[Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
 :::
 
 ## Block level buttons

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -177,6 +177,11 @@ padding and size of a button.
 
 **Tip:** remove the hover underline from a link variant button by setting `underline-opacity="0"`.
 
+::: warning Interactions between Variant props
+`BButton` implements `bg-variant` and `text-variant` to provide finer control of colors, but there
+are non-intutive interactions between these props. See the [Color Variant Reference](/docs/reference/color-variants#variant-interactions) for details.
+:::
+
 ## Block level buttons
 
 Create responsive stacks of full-width, “block buttons” by wrapping the button(s) in a div and specifying

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -110,17 +110,13 @@ These variants are used by components (such as `BCard`, `BModal`, etc.) that pro
 
 ## Variant Interactions
 
-The `variant` prop takes precedence over `bg-variant` and `text-variant` props. In general, you should set
-**either** `variant` **or** `bg-variant` and `text-variant`, but not a combination of `variant` with
-the other two as they will be ignored.
+The `bg-variant` and `text-variant` props take precedence over the `variant` prop. It is more
+straightforward to set **either** `variant` **or** `bg-variant` and `text-variant`, but not a
+combination of `variant` with the other two. But the more specific props effectively override
+the `text` or `bg` portion of the `variant` prop, so an alternative is to use the `variant`
+prop and then override the `text` or `bg` as needed.
 
-The exception to the above is that the components [`<BAvatar>`](/docs/components/avatar),
-[`<BBadge>`](/docs/components/badge), and [`<BButton>`](/docs/components/button) specify defaults for
-their `variant` props, which overrided the values of the `bg-vairaint` and `text-variant` props even
-if they are set explicitly. To get around this behavior, manually set `:variant='null'` and then your
-`bg-variant` and `text-variant` props will be respected.
-
-<<< DEMO ./demo/VariantInteractions.vue#templage{vue-html}
+<<< DEMO ./demo/VariantInteractions.vue#template{vue-html}
 
 ## Component specific variants
 

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -108,6 +108,20 @@ These translate to class names `text-{variant}`
 
 These variants are used by components (such as `BCard`, `BModal`, etc.) that provide `text-variant` and `*-text-variant` props.
 
+## Variant Interactions
+
+The `variant` prop takes precedence over `bg-variant` and `text-variant` props. In general, you should set
+**either** `variant` **or** `bg-variant` and `text-variant`, but not a combination of `variant` with
+the other two as they will be ignored.
+
+The exception to the above is that the components [`<BAvatar>`](/docs/components/avatar),
+[`<BBadge>`](/docs/components/badge), and [`<BButton>`](/docs/components/button) specify defaults for
+their `variant` props, which overrided the values of the `bg-vairaint` and `text-variant` props even
+if they are set explicitly. To get around this behavior, manually set `:variant='null'` and then your
+`bg-variant` and `text-variant` props will be respected.
+
+<<< DEMO ./demo/VariantInteractions.vue#templage{vue-html}
+
 ## Component specific variants
 
 Some Bootstrap v5 components require additional CSS styling, or additional pseudo selector styling (i.e buttons), and hence have their own underlying variant CSS classes.
@@ -118,11 +132,15 @@ All the base variants
 
 These translate to class names `alert-{variant}`.
 
+See [Variant Interactions](#variant-interactions) for details on interactions between `variant`, `bg-variant`, and `text-variant`.
+
 ### Badge variants
 
 All the base variants
 
 These translate to class names `badge-{variant}`.
+
+See [Variant Interactions](#variant-interactions) for details on interactions between `variant`, `bg-variant`, and `text-variant`.
 
 ### Button variants
 
@@ -134,6 +152,8 @@ All the base variants plus:
 These translate to class names `btn-{variant}` and `btn-outline-{variant}`.
 
 Note the `link` variant does not have an outline version.
+
+See [Variant Interactions](#variant-interactions) for details on interactions between `variant`, `bg-variant`, and `text-variant`.
 
 ### Table variants
 
@@ -171,7 +191,7 @@ You may also use the underlying class names directly on elements (and some compo
 
 ## Creating custom variants
 
-When creating custom variants, follow the Bootstrap v4 variant CSS class naming scheme and they will become available to the various components that use that scheme (i.e. create a custom CSS class `btn-purple` and `purple` becomes a valid variant to use on `BButton`).
+When creating custom variants, follow the Bootstrap v5 variant CSS class naming scheme and they will become available to the various components that use that scheme (i.e. create a custom CSS class `btn-purple` and `purple` becomes a valid variant to use on `BButton`).
 
 Alternatively, you can create new variant theme colors by supplying custom Bootstrap SCSS theme color maps. The default theme color map is (from `bootstrap/scss/\_variables.scss`):
 

--- a/apps/docs/src/docs/reference/demo/VariantInteractions.vue
+++ b/apps/docs/src/docs/reference/demo/VariantInteractions.vue
@@ -1,5 +1,28 @@
 <template>
   <!-- #region template -->
-  <BBadge text-variant="primary" bg-variant="danger" :variant="null"> testing </BBadge>
+  <BRow
+    ><BCol>Set 'variant': <BBadge variant="success"> testing </BBadge></BCol></BRow
+  >
+  <BRow
+    ><BCol>Set 'bg-variant': <BBadge bg-variant="info"> testing </BBadge></BCol></BRow
+  >
+  <BRow
+    ><BCol
+      >Set 'text-variant' (background is 'secondary' since 'variant' defaults to 'secondary'):
+      <BBadge text-variant="info"> testing </BBadge></BCol
+    ></BRow
+  >
+  <BRow
+    ><BCol
+      >Set 'text-variant' and 'bg-variant':
+      <BBadge text-variant="primary" bg-variant="danger"> testing </BBadge></BCol
+    ></BRow
+  >
+  <BRow
+    ><BCol
+      >Set all three - 'variant' is overridden by 'bg-variant' and 'text-variant':
+      <BBadge text-variant="primary" bg-variant="danger" variant="success"> testing </BBadge></BCol
+    ></BRow
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/reference/demo/VariantInteractions.vue
+++ b/apps/docs/src/docs/reference/demo/VariantInteractions.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- #region template -->
+  <BBadge text-variant="primary" bg-variant="danger" :variant="null"> testing </BBadge>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -363,7 +363,8 @@ export const commonProps = () =>
     variant: {
       type: 'ColorVariant | null',
       default: null,
-      description: 'Applies one of the Bootstrap theme color variants to the component',
+      description:
+        'Applies one of the Bootstrap theme color variants to the component. When implemented `bg-variant` and `text-variant` will take precedence',
     },
     noHoverPause: {
       type: 'boolean',

--- a/packages/bootstrap-vue-next/src/composables/useColorVariantClasses.ts
+++ b/packages/bootstrap-vue-next/src/composables/useColorVariantClasses.ts
@@ -12,7 +12,7 @@ export const useColorVariantClasses = (obj: MaybeRefOrGetter<ColorExtendables>) 
     }
     return {
       [`text-bg-${props.variant}`]: props.variant !== null,
-      [`text-${props.textVariant}`]: props.textVariant !== null && props.variant === null,
-      [`bg-${props.bgVariant}`]: props.bgVariant !== null && props.variant === null,
+      [`text-${props.textVariant}`]: props.textVariant !== null,
+      [`bg-${props.bgVariant}`]: props.bgVariant !== null,
     }
   })

--- a/packages/bootstrap-vue-next/tests/composables/useColorVariantClasses.spec.ts
+++ b/packages/bootstrap-vue-next/tests/composables/useColorVariantClasses.spec.ts
@@ -65,16 +65,16 @@ describe('useColorVariantClasses blackbox test', () => {
     })
   })
 
-  it('value returns text-bg-{type} when everything is active, but prop variant takes priority over all', () => {
+  it('variat props are independent', () => {
     const backgroundVariant = useColorVariantClasses(() => ({
       bgVariant: 'danger',
-      textVariant: 'danger',
-      variant: 'danger',
+      textVariant: 'info',
+      variant: 'success',
     }))
     expect(backgroundVariant.value).toEqual({
-      'text-bg-danger': true,
-      'text-danger': false,
-      'bg-danger': false,
+      'text-bg-success': true,
+      'text-info': true,
+      'bg-danger': true,
     })
   })
 
@@ -95,8 +95,8 @@ describe('useColorVariantClasses blackbox test', () => {
     react.variant = 'danger'
     expect(backgroundVariant.value).toEqual({
       'text-bg-danger': true,
-      'text-info': false,
-      'bg-info': false,
+      'text-info': true,
+      'bg-info': true,
     })
   })
 })


### PR DESCRIPTION
# Describe the PR

This PR addresses #2122 among other things. Since the bootstrap 5 behavior makes `bg-variant` and `text-variant` override `variant` (it's actually `bg-*` and `text-*` classes overriding `text-bg-*` classes) - the most straightforward was to solve this problem is to just all of the variant props set their respective classes and let bootstrap sort it out.

## Small replication

See #2122

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
