### PR TITLE
docs: Work around unplugin bug

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -77,14 +77,16 @@
                     </BTable>
                     <template v-if="component.props.some((el) => el.name.trim() !== '')">
                       <span
-                        v-b-tooltip="
-                          'Extensions are selected properties from another component, integrated here. It may not include all original properties'
-                        "
+                        id="extension-info"
                         :style="{cursor: 'help'}"
                         class="text-decoration-underline text-info cursor-help"
                       >
                         Extensions:
                       </span>
+                      <b-tooltip
+                        target="extension-info"
+                        title="Extensions are selected properties from another component, integrated here. It may not include all original properties"
+                      />
                       <BAccordion free>
                         <BAccordionItem
                           v-for="(table, index) in component.props.filter(
@@ -216,8 +218,8 @@ import {
   BLink,
   BRow,
   BTable,
+  BTooltip,
   type TableFieldRaw,
-  vBTooltip,
 } from 'bootstrap-vue-next'
 import type {
   ComponentItem,

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -48,6 +48,12 @@ Use slot `prepend` to put content before the breadcrumb. Use slot `append` to pu
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/breadcrumb.data'
+
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -215,6 +215,12 @@ set them to display: inline-block as column-break-inside: avoid is not a bulletp
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/card.data'
+
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -141,27 +141,12 @@ You are also able to use the built in methods for going to the next, or previous
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/carousel.data'
-import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
-import HighlightCard from '../../components/HighlightCard.vue'
-import {BButton, BButtonGroup, BAlert, BCarouselSlide, BCarousel} from 'bootstrap-vue-next'
-import {ref} from 'vue'
 
-const firstSlide = ref(0)
-
-const secondSlide = ref(2)
-
-const slideInterval = ref(5000)
-
-const myCarousel = ref<null | InstanceType<typeof BCarousel>>(null)
-const pause = () => myCarousel.value?.pause()
-const resume = () => myCarousel.value?.resume()
-
-const mySecondCarousel = ref<null | InstanceType<typeof BCarousel>>(null)
-const prev = () => mySecondCarousel.value?.prev()
-const next = () => mySecondCarousel.value?.next()
-
-const slideThreshold = ref(50)
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -136,6 +136,12 @@ We implement this `lazy` prop using the native `loading` attribute. See the [MDN
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/image.data'
+
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -161,6 +161,12 @@ recommended unless the content of the button textually conveys its purpose.
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/pagination.data'
+
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -282,8 +282,3 @@ Keyboard Navigation and Small Screen Support.
 ## BPaginationNav
 
 <NotYetImplemented/>
-
-<script setup lang="ts">
-import {computed, ref} from 'vue'
-import {useModalController} from 'bootstrap-vue-next'
-</script>


### PR DESCRIPTION
# Describe the PR

It looks like `unplugin-vue-components` has a bug where it doesn't correctly handle `<script setup='ts'>`  in vitepress (possibly in SSR mode in general). I will continue to refine https://github.com/unplugin/unplugin-vue-components/issues/801 and see if I can get an upstream fix, but this workaround gets us up and running again.

All the docs that were depending on `unplugin-vue-component` now use `<script>` rather than `<script setup>` sections. Since all we're doing in these files is importing data for the component reference, this still seems like a big win over not using `unplugin-vue-component`.

I also started getting a circular reference error when using the tooltip composable, so I converted to the component.

## Small replication

Look at the breadcrumb or carousel documentation under `app\docs` after doing a `pnpm build` followed by `pnpm preview`

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
