### PR TITLE
fix(vBPopover): add position absolute to floating directives

### DIFF
--- a/packages/bootstrap-vue-next/src/utils/floatingUi.ts
+++ b/packages/bootstrap-vue-next/src/utils/floatingUi.ts
@@ -117,6 +117,7 @@ export const bind = (
   props: BPopoverProps
 ) => {
   const div = document.createElement('span')
+  div.style.position = 'absolute'
   if (binding.modifiers.body) document.body.appendChild(div)
   else if (binding.modifiers.child) el.appendChild(div)
   else el.parentNode?.insertBefore(div, el.nextSibling)


### PR DESCRIPTION
# Describe the PR

closes #2225 

Placeholder `<span>`-elements generated by `vBPopover`- and `vBTooltip`-directives consumed space in flex containers. By adding `position: absolute` the placeholder element it won't effect the user`s layout anymore.

## Small replication

```vue
<template>
  <div style="margin: 10vw; border: 1px solid grey">
    <div class="d-flex justify-content-between align-items-center">
      Heading
      <BButton v-b-tooltip="'test'" size="sm" class="btn-smaller">
        Test
      </BButton>
    </div>
  </div>
</template>
```
Before:

![grafik](https://github.com/user-attachments/assets/9e3da1df-c52d-4ee4-9cea-0ea582669db8)

Now:

![grafik](https://github.com/user-attachments/assets/8e879faa-6fc3-43a9-8c12-f447a64cf1c5)

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
