### PR TITLE
doc(BDropdown): Parity pass on component and helpers

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -256,8 +256,8 @@ const sortData = computed(() =>
           .map(([key, value]) => ({prop: kebabCase(key), ...value}))
           .sort((a, b) => a.prop.localeCompare(b.prop)),
       })),
-      emits: el.emits.sort((a, b) => a.event.localeCompare(b.event)),
-      slots: el.slots.sort((a, b) => a.name.localeCompare(b.name)),
+      emits: el.emits?.sort((a, b) => a.event.localeCompare(b.event)),
+      slots: el.slots?.sort((a, b) => a.name.localeCompare(b.name)),
     }
 
     data.sections = (['Properties', 'Events', 'Slots'] as ComponentSection[]).filter(

--- a/apps/docs/src/data/components/accordion.data.ts
+++ b/apps/docs/src/data/components/accordion.data.ts
@@ -136,11 +136,6 @@ export default {
             default: false,
             description: 'When true, the AccordionItem will be visible',
           },
-          wrapperAttrs: {
-            type: 'Readonly<AttrsValue>',
-            default: undefined,
-            description: 'Attributes to be applied to the wrapper element',
-          },
           ...pick(
             buildCommonProps({
               id: {
@@ -148,7 +143,7 @@ export default {
                   'The Id to be injected to accordion items and used to in BCollapse for state managment',
               },
             }),
-            ['id', 'tag']
+            ['id', 'tag', 'wrapperAttrs']
           ),
         } satisfies Record<keyof BvnComponentProps['BAccordionItem'], PropertyReference>,
       },

--- a/apps/docs/src/data/components/dropdown.data.ts
+++ b/apps/docs/src/data/components/dropdown.data.ts
@@ -1,6 +1,7 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
 import type {ComponentReference, PropertyReference} from '../../types'
-import {buildCommonProps, pick} from '../../utils'
+import {buildCommonProps, omit, pick} from '../../utils'
+import {linkProps, linkTo} from '../../utils/link-props'
 
 export default {
   load: (): ComponentReference[] => [
@@ -295,28 +296,36 @@ export default {
     {
       component: 'BDropdownDivider',
       sourcePath: '/BDropdown/BDropdownDivider.vue',
-      emits: [],
-      slots: [],
       props: {
         '': {
-          tag: {
-            description: '',
-            type: 'string',
-            default: 'hr',
-          },
+          ...pick(
+            buildCommonProps({
+              tag: {
+                default: 'hr',
+              },
+            }),
+            ['tag']
+          ),
         } satisfies Record<keyof BvnComponentProps['BDropdownDivider'], PropertyReference>,
       },
     },
     {
       component: 'BDropdownForm',
       sourcePath: '/BDropdown/BDropdownForm.vue',
-      emits: [],
-      props: {} satisfies Record<keyof BvnComponentProps['BDropdownForm'], PropertyReference>,
+      props: {
+        '': {
+          formClass: {notYetImplemented: true},
+          inline: {notYetImplemented: true},
+          novalidate: {notYetImplemented: true},
+          validated: {notYetImplemented: true},
+        },
+      },
+      // Add the typing back in when props are implemented
+      // satisfies Record<keyof BvnComponentProps['BDropdownForm'], PropertyReference>,
       slots: [
         {
-          scope: [],
-          description: '',
           name: 'default',
+          description: 'Content to place in the dropdown form',
         },
       ],
     },
@@ -326,42 +335,28 @@ export default {
       emits: [],
       props: {
         '': {
-          ariaDescribedby: {
-            type: 'string',
-            default: undefined,
-          },
           header: {
             type: 'string',
             default: undefined,
           },
-          headerClass: {
-            type: 'ClassValue',
-            default: undefined,
-          },
-          headerTag: {
-            type: 'string',
-            default: 'header',
-          },
-          headerVariant: {
-            type: 'ColorVariant | null',
-            default: null,
-          },
-          id: {
-            type: 'string',
-            default: undefined,
-          },
+          ...pick(
+            buildCommonProps({
+              headerTag: {
+                default: 'header',
+              },
+            }),
+            ['ariaDescribedby', 'headerClass', 'headerTag', 'headerVariant', 'id']
+          ),
         } satisfies Record<keyof BvnComponentProps['BDropdownGroup'], PropertyReference>,
       },
       slots: [
         {
-          description: '',
-          scope: [],
           name: 'default',
+          description: 'Content (items) to place in the dropdown group',
         },
         {
-          scope: [],
-          description: '',
           name: 'header',
+          description: 'Optional header content for the dropdown group',
         },
       ],
     },
@@ -372,185 +367,84 @@ export default {
       props: {} satisfies Record<keyof BvnComponentProps['BDropdownHeader'], PropertyReference>,
       slots: [
         {
-          scope: [],
-          description: '',
           name: 'default',
+          description: 'Content to place in the dropdown header',
         },
       ],
     },
     {
       component: 'BDropdownItem',
       sourcePath: '/BDropdown/BDropdownItem.vue',
+      props: {
+        '': {
+          ...pick(buildCommonProps({}), ['linkClass', 'wrapperAttrs']),
+        } satisfies Record<
+          Exclude<keyof BvnComponentProps['BDropdownItem'], keyof typeof linkProps>,
+          PropertyReference
+        >,
+        'BLink props': {
+          _linkTo: {
+            type: linkTo,
+          },
+          ...omit(linkProps, ['routerTag']),
+        },
+      },
       emits: [
         {
           event: 'click',
+          description: 'Emitted when item is clicked',
           args: [
             {
-              arg: 'click',
-              description: '',
+              arg: 'value',
               type: 'MouseEvent',
+              description: 'Native click event object',
             },
           ],
-          description: '',
         },
       ],
-      props: {
-        '': {
-          active: {
-            type: 'boolean',
-            default: undefined,
-          },
-          activeClass: {
-            type: 'string',
-            default: undefined,
-          },
-          disabled: {
-            type: 'boolean',
-            default: undefined,
-          },
-          exactActiveClass: {
-            type: 'string',
-            default: undefined,
-          },
-          href: {
-            type: 'string',
-            default: undefined,
-          },
-          icon: {
-            type: 'boolean',
-            default: undefined,
-          },
-          linkClass: {
-            type: 'ClassValue',
-            default: undefined,
-          },
-          noPrefetch: {
-            type: 'boolean',
-          },
-          noRel: {
-            type: 'boolean',
-          },
-          opacity: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          opacityHover: {
-            type: '10 | 25 | 50 | 75 | 100 | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          prefetch: {
-            type: 'boolean',
-          },
-          prefetchedClass: {
-            type: 'ClassValue',
-          },
-          rel: {
-            type: 'string',
-            default: undefined,
-          },
-          replace: {
-            type: 'boolean',
-            default: undefined,
-          },
-          routerComponentName: {
-            type: 'string',
-            default: undefined,
-          },
-          stretched: {
-            type: 'boolean',
-            default: false,
-          },
-          target: {
-            type: 'LinkTarget',
-            default: undefined,
-          },
-          to: {
-            type: 'RouteLocationRaw',
-            default: undefined,
-          },
-          underlineOffset: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
-          },
-          underlineOffsetHover: {
-            type: '1 | 2 | 3 | "1" | "2" | "3"',
-            default: undefined,
-          },
-          underlineOpacity: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineOpacityHover: {
-            type: '0 | 10 | 25 | 50 | 75 | 100 | "0" | "10" | "25" | "50" | "75" | "100"',
-            default: undefined,
-          },
-          underlineVariant: {
-            type: 'ColorVariant | null',
-            default: undefined,
-          },
-          variant: {
-            type: 'ColorVariant | null',
-            default: null,
-          },
-          wrapperAttrs: {
-            type: 'Readonly<AttrsValue>',
-            default: undefined,
-          },
-        } satisfies Record<keyof BvnComponentProps['BDropdownItem'], PropertyReference>,
-      },
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the dropdown item',
         },
       ],
     },
     {
       component: 'BDropdownItemButton',
       sourcePath: '/BDropdown/BDropdownItemButton.vue',
-      emits: [
-        {
-          args: [
-            {
-              arg: 'click',
-              description: '',
-              type: 'MouseEvent',
-            },
-          ],
-          description: '',
-          event: 'click',
-        },
-      ],
       props: {
         '': {
-          active: {
-            type: 'boolean',
-            default: false,
-          },
-          activeClass: {
-            type: 'ClassValue',
-            default: 'active',
-          },
           buttonClass: {
             type: 'ClassValue',
             default: undefined,
+            description: 'Class or classes to apply to the inner button element',
           },
-          disabled: {
-            type: 'boolean',
-            default: false,
-          },
-          variant: {
-            type: 'ColorVariant | null',
-            default: null,
-          },
+          ...pick(buildCommonProps({}), [
+            'active',
+            'activeClass',
+            'disabled',
+            'variant',
+            'wrapperAttrs',
+          ]),
         } satisfies Record<keyof BvnComponentProps['BDropdownItemButton'], PropertyReference>,
       },
+      emits: [
+        {
+          event: 'click',
+          description: 'Emitted when item is clicked',
+          args: [
+            {
+              arg: 'value',
+              type: 'MouseEvent',
+              description: 'Native click event object',
+            },
+          ],
+        },
+      ],
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the dropdown item button',
         },
       ],
     },
@@ -561,17 +455,16 @@ export default {
       props: {
         '': {
           text: {
-            description: '',
+            default: undefined,
+            description: 'Content to place in the dropdown text. Default slot takes precedence',
             type: 'string',
-            default: '',
           },
         } satisfies Record<keyof BvnComponentProps['BDropdownText'], PropertyReference>,
       },
       slots: [
         {
-          description: '',
           name: 'default',
-          scope: [],
+          description: 'Content to place in the dropdown text',
         },
       ],
     },

--- a/apps/docs/src/data/components/dropdown.data.ts
+++ b/apps/docs/src/data/components/dropdown.data.ts
@@ -1,5 +1,6 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
 import type {ComponentReference, PropertyReference} from '../../types'
+import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
@@ -8,221 +9,286 @@ export default {
       sourcePath: '/BDropdown/BDropdown.vue',
       props: {
         '': {
-          ariaLabel: {
-            type: 'string',
-            default: undefined,
-          },
           autoClose: {
             type: "boolean | 'inside' | 'outside'",
             default: true,
+            description:
+              'Controls the automatic closing of the dropdown when clicking. See above for details.',
           },
           boundary: {
             type: 'Boundary | RootBoundary',
             default: 'clippingAncestors',
+            description:
+              "The boundary constraint of dropdown: any value of floating-us's Boundary or RootBoundary type. See above for details.",
           },
           boundaryPadding: {
             type: 'Padding',
             default: undefined,
+            description: 'The virtual padding around the boundary to check for overflow',
           },
           center: {
             type: 'boolean',
             default: false,
-          },
-          disabled: {
-            type: 'boolean',
-            default: false,
+            description: 'Centers the dropdown on the button',
           },
           dropend: {
             type: 'boolean',
             default: false,
+            description:
+              'When set, positions the menu to at the end (right for ltr reading) of the button',
           },
           dropstart: {
             type: 'boolean',
             default: false,
+            description:
+              'When set, positions the menu to at the start (left for ltr reading) of the button.',
           },
           dropup: {
             type: 'boolean',
             default: false,
+            description: 'When set, positions the menu on the top of the button',
           },
           end: {
             type: 'boolean',
             default: false,
+            description:
+              'Aligns the dropdown with the end (right for ltr reading) of the button. Default is start (left for ltr reading)',
           },
           floatingMiddleware: {
             type: 'Middleware[]',
             default: undefined,
-          },
-          id: {
-            type: 'string',
-            default: undefined,
+            description: 'Directly set the floating-ui middleware behavior. See above for details.',
           },
           isNav: {
             type: 'boolean',
             default: false,
+            description: 'Indicates the dropdown is a nav dropdown',
           },
           lazy: {
             type: 'boolean',
             default: false,
+            description:
+              'When set, will only mount the dropdown content into the DOM when the dropdown is open',
           },
           menuClass: {
             type: 'ClassValue',
             default: undefined,
+            description: 'CSS class (or classes) to add to the menu container',
           },
           modelValue: {
             type: 'boolean',
             default: false,
+            description: 'Controls the visibility of the dropdown',
           },
           noCaret: {
             type: 'boolean',
             default: false,
+            description: 'Hide the caret indicator on the toggle button',
           },
           noFlip: {
             type: 'boolean',
             default: false,
+            description: 'Prevent the menu from auto flipping positions',
           },
           noShift: {
             type: 'boolean',
             default: false,
+            description: 'Prevent the menu from automatically shifting positions',
           },
           noSize: {
             type: 'boolean',
             default: false,
+            description: 'Prevent the menu from automatically resizing',
           },
           offset: {
             type: 'number | string | {mainAxis?: number; crossAxis?: number; alignmentAxis?: number | null',
             default: 0,
-          },
-          role: {
-            type: 'string',
-            default: 'menu',
-          },
-          size: {
-            type: 'Size',
-            default: 'md',
+            description:
+              'Specify the number of pixels to shift the menu by. See above for details.',
           },
           skipWrapper: {
             type: 'boolean',
             default: false,
+            description: 'Do not render the dropdown wrapper element',
           },
           split: {
             type: 'boolean',
             default: false,
+            description: 'When set, renders a split button dropdown',
           },
           splitButtonType: {
             type: 'ButtonType',
             default: 'button',
+            description:
+              "Value to place in the 'type' attribute on the split button: 'button', 'submit', 'reset'",
           },
           splitClass: {
             type: 'ClassValue',
             default: undefined,
+            description: 'CSS class (or classes) to add to the split button',
           },
           splitDisabled: {
             type: 'boolean',
             default: undefined,
+            description: 'When set, the split button is disabled',
           },
           splitHref: {
             type: 'string',
             default: undefined,
+            description: 'Denotes the target URL of the link for the split button',
           },
           splitTo: {
             type: 'RouteLocationRaw',
             default: undefined,
+            description:
+              'Denotes the target route of the split button. When clicked, the value of the to prop will be passed to router.push() internally, so the value can be either a string or a Location descriptor object',
           },
           splitVariant: {
             type: 'ButtonVariant | null',
             default: undefined,
+            description:
+              "Applies one of the Bootstrap theme color variants to the split button. Defaults to the 'variant' prop value",
           },
           strategy: {
             type: 'Strategy',
             default: 'absolute',
+            description:
+              'The strategy used to determine when to hide the dropdown. See above for details.',
           },
           text: {
             type: 'string',
             default: undefined,
+            description: 'Text to place in the toggle button, or in the split button is split mode',
           },
           toggleClass: {
             type: 'ClassValue',
             default: undefined,
+            description: 'CSS class (or classes) to add to the toggle button',
           },
           toggleText: {
             type: 'string',
             default: 'Toggle dropdown',
-          },
-          variant: {
-            type: 'ButtonVariant | null',
-            default: 'secondary',
+            description:
+              'ARIA label (sr-only) to set on the toggle when in split mode. Overriden by the slot of the same name',
           },
           wrapperClass: {
             type: 'ClassValue',
             default: undefined,
           },
-          teleportDisabled: {},
-          teleportTo: {},
+          teleportDisabled: {
+            type: 'boolean',
+            default: false,
+            description: 'Renders the dropdown in the exact place it was defined',
+          },
+          teleportTo: {
+            type: 'string | RendererElement | null | undefined',
+            default: undefined,
+            description: 'Overrides the default teleport location',
+          },
+          ...pick(
+            buildCommonProps({
+              role: {
+                default: 'menu',
+              },
+              variant: {
+                default: 'secondary',
+              },
+            }),
+            ['ariaLabel', 'disabled', 'id', 'role', 'size', 'variant']
+          ),
         } satisfies Record<keyof BvnComponentProps['BDropdown'], PropertyReference>,
       },
       emits: [
         {
-          args: [],
-          event: 'show',
-          description: '',
-        },
-        {
-          args: [],
-          event: 'shown',
-          description: '',
-        },
-        {
-          args: [],
-          event: 'show-prevented',
-          description: '',
-        },
-        {
-          args: [],
           event: 'hide',
-          description: '',
-        },
-        {
-          args: [],
-          event: 'hidden',
-          description: '',
-        },
-        {
-          args: [],
-          event: 'hide-prevented',
-          description: '',
-        },
-        {
-          event: 'click',
-          description: '',
+          description: 'Emitted just before dropdown is hidden. Cancelable',
           args: [
             {
-              arg: 'click',
-              description: '',
-              type: 'MouseEvent',
+              arg: 'value',
+              type: 'BvTriggerableEvent',
+              description: 'Call value.preventDefault() to cancel hide',
             },
           ],
         },
         {
-          args: [],
+          event: 'hidden',
+          description: 'Called after dropdown is hidden',
+        },
+        {
+          event: 'hide-prevented',
+          description: 'Emitted when the dropdown tried to close, but was prevented from doing so.',
+        },
+        {
+          event: 'click',
+          description: 'Emitted when button is clicked',
+          args: [
+            {
+              arg: 'event',
+              type: 'MouseEvent',
+              description: 'Native click event object',
+            },
+          ],
+        },
+        {
+          event: 'show',
+          description: 'Emitted just before dropdown is shown. Cancelable',
+          args: [
+            {
+              arg: 'value',
+              type: 'BvTriggerableEvent',
+              description: 'Call value.preventDefault() to cancel show',
+            },
+          ],
+        },
+        {
+          event: 'shown',
+          description: 'Called after dropdown is shown',
+        },
+        {
+          event: 'show-prevented',
+          description: 'Emitted when the dropdown tried to open, but was prevented from doing so.',
+        },
+        {
+          event: 'split-click',
+          description: 'Emitted when split button is clicked in split mode',
+          args: [
+            {
+              arg: 'event',
+              type: 'MouseEvent',
+              description: 'Native click event object',
+            },
+          ],
+        },
+        {
           event: 'toggle',
-          description: '',
+          description: 'Emitted when toggle button is clicked',
         },
       ],
       slots: [
         {
-          description: '',
-          scope: [],
-          name: 'button-content',
-        },
-        {
-          description: '',
-          scope: [],
-          name: 'toggle-text',
-        },
-        {
-          scope: [],
-          description: '',
           name: 'default',
+          description: 'Optionally scoped default slot for dropdown menu content',
+          scope: [
+            {
+              prop: 'hide',
+              type: '() => void',
+              description: 'Can be used to close the dropdown',
+            },
+            {
+              prop: 'show',
+              type: '() => void',
+              description: 'Can be used to open the dropdown',
+            },
+          ],
+        },
+        {
+          name: 'button-content',
+          description: 'Can be used to implement custom text with icons and more styling',
+        },
+        {
+          name: 'toggle-text',
+          description:
+            'ARIA label (sr-only) to set on the toggle when in split mode. Overrides the toggle-text prop',
         },
       ],
     },

--- a/apps/docs/src/data/components/formCheckbox.data.ts
+++ b/apps/docs/src/data/components/formCheckbox.data.ts
@@ -37,6 +37,11 @@ export default {
             description:
               'When set, renders the checkbox as an inline element rather than as a 100% width block',
           },
+          inputClass: {
+            type: 'ClassValue',
+            default: undefined,
+            description: 'Class to be applied to the body of the checkbox item',
+          },
           modelValue: {
             type: 'CheckboxValue | readonly CheckboxValue[]',
             default: undefined,
@@ -64,16 +69,6 @@ export default {
             default: true,
             description: 'Value returned when this checkbox is checked',
           },
-          wrapperAttrs: {
-            type: 'Readonly<AttrsValue>',
-            default: undefined,
-            description: 'Attributes to be applied to the wrapper element',
-          },
-          inputClass: {
-            type: 'ClassValue',
-            default: undefined,
-            description: 'Class to be applied to the body of the accordion item',
-          },
           ...pick(buildCommonProps(), [
             'ariaLabel',
             'ariaLabelledby',
@@ -86,6 +81,7 @@ export default {
             'required',
             'size',
             'state',
+            'wrapperAttrs',
           ]),
         } satisfies Record<keyof BvnComponentProps['BFormCheckbox'], PropertyReference>,
       },

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -193,15 +193,15 @@ documentation for details
 
 <HighlightCard>
   <div class="d-grid gap-2">
-    <BButton block variant="primary">Block Level Button</BButton>
-    <BButton block variant="primary">Another Block Level Button</BButton>
+    <BButton variant="primary">Block Level Button</BButton>
+    <BButton variant="primary">Another Block Level Button</BButton>
   </div>
   <template #html>
 
 ```vue-html
 <div class="d-grid gap-2">
-  <BButton block variant="primary">Block Level Button</BButton>
-  <BButton block variant="primary">Another Block Level Button</BButton>
+  <BButton variant="primary">Block Level Button</BButton>
+  <BButton variant="primary">Another Block Level Button</BButton>
 </div>
 ```
 

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -137,8 +137,6 @@ You are also able to use the built in methods for going to the next, or previous
 
 <<< DEMO ./demo/CarouselFull.vue#template{vue-html}
 
-## Reference
-
 <ComponentReference :data="data" />
 
 <script lang="ts">

--- a/apps/docs/src/docs/components/demo/DropdownAccessibility.vue
+++ b/apps/docs/src/docs/components/demo/DropdownAccessibility.vue
@@ -1,0 +1,16 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown ARIA" variant="primary">
+    <BDropdownHeader id="dropdown-header-1">Groups</BDropdownHeader>
+    <BDropdownItemButton aria-describedby="dropdown-header-1">Add</BDropdownItemButton>
+    <BDropdownItemButton aria-describedby="dropdown-header-1">Delete</BDropdownItemButton>
+    <BDropdownHeader id="dropdown-header-2">Users</BDropdownHeader>
+    <BDropdownItemButton aria-describedby="dropdown-header-2">Add</BDropdownItemButton>
+    <BDropdownItemButton aria-describedby="dropdown-header-2">Delete</BDropdownItemButton>
+    <BDropdownDivider />
+    <BDropdownItemButton>
+      Something <strong>not</strong> associated with Users
+    </BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownAutoClose.vue
+++ b/apps/docs/src/docs/components/demo/DropdownAutoClose.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="d-flex flex-wrap gap-2">
+    <!-- #region template -->
+    <BDropdown text="Default Dropdown" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here</BDropdownItemButton>
+    </BDropdown>
+    <BDropdown text="Clickable outside (auto-close=inside)" auto-close="inside" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here</BDropdownItemButton>
+    </BDropdown>
+    <BDropdown text="Clickable inside (auto-close=outside)" auto-close="outside" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here</BDropdownItemButton>
+    </BDropdown>
+    <BDropdown text="Manual close (auto-close=false)" :auto-close="false" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here</BDropdownItemButton>
+    </BDropdown>
+    <!-- #endregion template -->
+  </div>
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Block Level Dropdown Menu" block variant="primary" menu-class="w-100">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
@@ -1,0 +1,22 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Block Level Dropdown" variant="primary" class="d-grid gap-2 mb-2">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here</BDropdownItem>
+  </BDropdown>
+  <div class="d-grid gap-2">
+    <BDropdown
+      text="Block Level Split Dropdown"
+      split
+      split-variant="outline-primary"
+      variant="primary"
+      split-class="w-100"
+    >
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here...</BDropdownItem>
+    </BDropdown>
+  </div>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
+++ b/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
@@ -1,0 +1,17 @@
+<template>
+  <!-- #region template -->
+  <div class="d-flex gap-2">
+    <BDropdown text="Button text via Prop" class="me-2">
+      <BDropdownItem href="#">An item</BDropdownItem>
+      <BDropdownItem href="#">Another item</BDropdownItem>
+    </BDropdown>
+    <BDropdown class="me-2">
+      <template #button-content>
+        Custom <strong>Content</strong> with <em>HTML</em> via Slot
+      </template>
+      <BDropdownItem href="#">An item</BDropdownItem>
+      <BDropdownItem href="#">Another item</BDropdownItem>
+    </BDropdown>
+  </div>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
+++ b/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="d-flex flex-wrap gap-2">
+    <!-- #region template -->
+    <BDropdown text="Primary" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown text="Success" variant="success" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown text="Outline Danger" variant="outline-danger" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <!-- #endregion template -->
+  </div>
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownDivider.vue
+++ b/apps/docs/src/docs/components/demo/DropdownDivider.vue
@@ -1,0 +1,10 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown with divider">
+    <BDropdownItemButton>First item</BDropdownItemButton>
+    <BDropdownItemButton>Second item</BDropdownItemButton>
+    <BDropdownDivider />
+    <BDropdownItemButton>Separated Item</BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownDropup.vue
+++ b/apps/docs/src/docs/components/demo/DropdownDropup.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown dropup text="Drop-Up" variant="primary" class="me-2">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownFloating.vue
+++ b/apps/docs/src/docs/components/demo/DropdownFloating.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Strategy fixed" strategy="fixed" class="me-2">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownForm.vue
+++ b/apps/docs/src/docs/components/demo/DropdownForm.vue
@@ -1,0 +1,29 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown with form" auto-close="outside">
+    <BDropdownForm>
+      <BFormGroup
+        label="Email address:"
+        label-for="email"
+        description="We'll never share your email with anyone else."
+      >
+        <BFormInput id="email" type="email" placeholder="Enter email" required />
+      </BFormGroup>
+      <BFormGroup
+        label="Passoword:"
+        label-for="password"
+        description="We'll never share your email with anyone else."
+      >
+        <BFormInput id="password" type="password" required />
+      </BFormGroup>
+      <BFormCheckbox id="remember" name="remember" value="remember" checked>
+        Remember me</BFormCheckbox
+      >
+      <BButton type="submit" variant="primary">Sign In</BButton>
+    </BDropdownForm>
+    <BDropdownDivider />
+    <BDropdownItemButton>New around here? Sign up</BDropdownItemButton>
+    <BDropdownItemButton>Forget Password</BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownGroup.vue
+++ b/apps/docs/src/docs/components/demo/DropdownGroup.vue
@@ -1,0 +1,18 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown with group">
+    <BDropdownItemButton> Non-grouped Item </BDropdownItemButton>
+    <BDropdownDivider />
+    <BDropdownGroup header="Group 1">
+      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
+      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
+    </BDropdownGroup>
+    <BDropdownGroup header="Group 2" header-variant="primary">
+      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
+      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
+    </BDropdownGroup>
+    <BDropdownDivider />
+    <BDropdownItemButton> Another Non-grouped Item </BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownHeader.vue
+++ b/apps/docs/src/docs/components/demo/DropdownHeader.vue
@@ -1,0 +1,11 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown with header">
+    <BDropdownHeader> Dropdown header </BDropdownHeader>
+    <BDropdownItemButton aria-describedby="dropdown-header-label"> First item </BDropdownItemButton>
+    <BDropdownItemButton aria-describedby="dropdown-header-label">
+      Second Item
+    </BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
+++ b/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
@@ -1,0 +1,10 @@
+<template>
+  <!-- #region template -->
+  <BDropdown size="lg" variant="link" toggle-class="text-decoration-none" no-caret>
+    <template #button-content> &#x1f50d;<span class="visually-hidden">Search</span> </template>
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here...</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownItem.vue
+++ b/apps/docs/src/docs/components/demo/DropdownItem.vue
@@ -1,0 +1,11 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown">
+    <BDropdownItem>First Action</BDropdownItem>
+    <BDropdownItem variant="primary">Second Action</BDropdownItem>
+    <BDropdownItem active>Active action</BDropdownItem>
+    <BDropdownItem disabled>Disabled action</BDropdownItem>
+    <BDropdownItem to="/docs/components/badge">Badge</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownItemButton.vue
+++ b/apps/docs/src/docs/components/demo/DropdownItemButton.vue
@@ -1,0 +1,10 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown using buttons as menu items">
+    <BDropdownItemButton>I am a button</BDropdownItemButton>
+    <BDropdownItemButton active>I am a active button</BDropdownItemButton>
+    <BDropdownItemButton disabled>I am a button, but disabled!</BDropdownItemButton>
+    <BDropdownItemButton>I do not look like a button, but I am!</BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownLazy.vue
+++ b/apps/docs/src/docs/components/demo/DropdownLazy.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- #region template -->
+  <BDropdown lazy text="Dropdown">
+    <BDropdownItem>First Action</BDropdownItem>
+    <BDropdownItem>Second Action</BDropdownItem>
+    <BDropdownItem>Third Action</BDropdownItem>
+    <BDropdownDivider />
+    <BDropdownItem active>Active action</BDropdownItem>
+    <BDropdownItem disabled>Disabled action</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="d-flex flex-wrap gap-2">
+    <!-- #region template -->
+    <BDropdown text="Default Alignment" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown start text="Start Alignment" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown end text="End Align" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <!-- #endregion template -->
+  </div>
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
@@ -16,6 +16,11 @@
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
+    <BDropdown center text="Center" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="d-flex flex-wrap gap-2">
+    <!-- #region template -->
+    <BDropdown offset="25" text="Offset Dropdown" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown
+      :offset="{alignmentAxis: 50, crossAxis: 60, mainAxis: 70}"
+      text="Offset Dropdown 2 dimensions"
+      class="me-2"
+    >
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <!-- #endregion template -->
+  </div>
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownModel.vue
+++ b/apps/docs/src/docs/components/demo/DropdownModel.vue
@@ -1,0 +1,23 @@
+<template>
+  <p>Open: {{ model }}</p>
+
+  <div class="d-flex gap-2 mb-2">
+    <BButton @click="model = true">Open Dropdown</BButton>
+    <BButton @click="model = false">Close Dropdown</BButton>
+  </div>
+
+  <BDropdown v-model="model" text="Dropdown Button" class="me-2">
+    <BDropdownItem>First Action</BDropdownItem>
+    <BDropdownItem>Second Action</BDropdownItem>
+    <BDropdownItem>Third Action</BDropdownItem>
+    <BDropdownDivider />
+    <BDropdownItem active>Active action</BDropdownItem>
+    <BDropdownItem disabled>Disabled action</BDropdownItem>
+  </BDropdown>
+</template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+
+const model = ref<boolean>(false)
+</script>

--- a/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
+++ b/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="No flipping" no-flip class="me-2">
+    <BDropdownItem href="#">An item</BDropdownItem>
+    <BDropdownItem href="#">Another item</BDropdownItem>
+    <BDropdownItem href="#">Yet Another item</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownOverview.vue
+++ b/apps/docs/src/docs/components/demo/DropdownOverview.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown Button" class="me-2">
+    <BDropdownItem>First Action</BDropdownItem>
+    <BDropdownItem>Second Action</BDropdownItem>
+    <BDropdownItem>Third Action</BDropdownItem>
+    <BDropdownDivider />
+    <BDropdownItem active>Active action</BDropdownItem>
+    <BDropdownItem disabled>Disabled action</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownSizing.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSizing.vue
@@ -1,0 +1,28 @@
+<template>
+  <!-- #region template -->
+  <div class="d-flex flex-wrap gap-2">
+    <BDropdown size="lg" text="Large" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here</BDropdownItemButton>
+    </BDropdown>
+    <BDropdown size="lg" split text="Large Split" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here...</BDropdownItemButton>
+    </BDropdown>
+  </div>
+  <div class="d-flex flex-wrap gap-2 mt-2">
+    <BDropdown size="sm" text="Small" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here...</BDropdownItemButton>
+    </BDropdown>
+    <BDropdown size="sm" split text="Small Split" class="me-2">
+      <BDropdownItemButton>Action</BDropdownItemButton>
+      <BDropdownItemButton>Another action</BDropdownItemButton>
+      <BDropdownItemButton>Something else here...</BDropdownItemButton>
+    </BDropdown>
+  </div>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown split text="Split Dropdown" class="me-2">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here...</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BDropdown split split-href="#foo/bar" text="Split Link" class="me-2">
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here...</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButtonVariant.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButtonVariant.vue
@@ -1,0 +1,15 @@
+<template>
+  <!-- #region template -->
+  <BDropdown
+    split
+    split-variant="outline-primary"
+    variant="primary"
+    text="Split Variant Dropdown"
+    class="me-2"
+  >
+    <BDropdownItem href="#">Action</BDropdownItem>
+    <BDropdownItem href="#">Another action</BDropdownItem>
+    <BDropdownItem href="#">Something else here...</BDropdownItem>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownStartEnd.vue
+++ b/apps/docs/src/docs/components/demo/DropdownStartEnd.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex flex-wrap gap-2">
+    <!-- #region template -->
+    <BDropdown dropend text="Drop-end" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <BDropdown dropstart text="Drop-start" variant="primary" class="me-2">
+      <BDropdownItem href="#">Action</BDropdownItem>
+      <BDropdownItem href="#">Another action</BDropdownItem>
+      <BDropdownItem href="#">Something else here</BDropdownItem>
+    </BDropdown>
+    <!-- #endregion template -->
+  </div>
+</template>

--- a/apps/docs/src/docs/components/demo/DropdownText.vue
+++ b/apps/docs/src/docs/components/demo/DropdownText.vue
@@ -1,0 +1,13 @@
+<template>
+  <!-- #region template -->
+  <BDropdown text="Dropdown with text">
+    <BDropdownText style="width: 240px">
+      Some example text that is free-flowing within the dropdown menu.
+    </BDropdownText>
+    <BDropdownText tag="span">And this is more example text.</BDropdownText>
+    <BDropdownDivider />
+    <BDropdownItemButton>First item</BDropdownItemButton>
+    <BDropdownItemButton>Second Item</BDropdownItemButton>
+  </BDropdown>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -157,8 +157,6 @@ Dar variants for components were deprecated in Bootstrap v 5.3.0. See
 
 ### Block level dropdowns
 
-<NotYetImplemented>Bootstrap 5's block button implementation doesn't appear to work for dropdowns.</NotYetImplemented>
-
 By default, dropdowns act like buttons and are displayed inline. Create a full-width, “block button”
 by adding the classes `d-grid` and `gap-2` to the `BDropdown`. For split buttons, wrap the `BDropdown` in a div
 that has the `d-grid` and `gap-2` classes and add `split-class="w-100"` to the `BDropdown` itself.
@@ -245,6 +243,8 @@ constrain/set the menu width.
 
 `BDropdownText` has the BootstrapVueNext custom class `.b-dropdown-text` applied to it which sets some basic styles which are suitable in most situations. By default, its width will be the same as the widest `BDropdownItem` content. You may need to place additional styles or helper classes on the component.
 
+<NotYetImplemented/>: While the basic `BDropdownText` works, none of the props are implemented to customize the text (`tag`, `text-class`, and `variant`)
+
 ### BDropdownGroup
 
 Group a set of dropdown sub-components with an optional associated header. Place a `BDropdownDivider` between your `BDropdownGroup` and other groups or non-grouped dropdown contents.
@@ -260,6 +260,16 @@ Add a header to label sections of actions in any dropdown menu.
 See Section [Headers and accessibility](#headers-and-accessibility) for details on making headers more accessible for users of assistive technologies.
 
 Using the `BDropdownGroup` sub-component simplifies creating accessible grouped dropdown items with an associated header.
+
+<NotYetImplemented/>: While the basic `BDropdownHeader` works, none of the props are implemented to customize the header (`id`, `tag`, and `variant`)
+
+### BDropdownForm
+
+Add a form into your dropdown with `BDropdownForm`.
+
+<<< DEMO ./demo/DropdownForm.vue#template{vue-html}
+
+<NotYetImplemented/>: While the basic `BDropdownForm` works, none of the props are implemented to customize the form (`formClass`, `inline`, `novalidate` and `validated`)
 
 ## Accessibility
 

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -152,7 +152,7 @@ split button its variant via the `split-variant` prop.
 
 ### Dark mode
 
-Dar variants for components were deprecated in Bootstrap v 5.3.0. See
+Dark variants for components were deprecated in Bootstrap v5.3.0. See
 [their documentation](https://getbootstrap.com/docs/5.3/components/dropdowns/#dark-dropdowns) for details.
 
 ### Block level dropdowns

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -14,36 +14,7 @@ Dropdowns are toggleable, contextual overlays for displaying lists of links and 
 
 `BDropdown` components are toggleable, contextual overlays for displaying lists of links, and more. They're toggled by clicking (or pressing space or enter when focused), not by hovering; this is an [intentional design decision](https://markdotto.com/2012/02/27/bootstrap-explained-dropdowns/).
 
-<HighlightCard>
-  <BDropdown v-model="show1" text="Dropdown Button" class="me-2">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown Button">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownOverview.vue#template{vue-html}
 
 ## Button content
 
@@ -51,44 +22,7 @@ You can customize the text of the dropdown button by using either the `text` pro
 
 If both the prop `text` and slot `button-content` are present, the slot `button-content` will take precedence.
 
-<HighlightCard>
-  <BDropdown v-model="show2" text="Button text via Prop" class="me-2">
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show3" class="me-2">
-    <template #button-content>
-    Custom <strong>Content</strong> with <em>HTML</em> via Slot
-    </template>
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" text="Button text via Prop" class="m-1">
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show2" class="m-1">
-    <template #button-content>
-      Custom <strong>Content</strong> with <em>HTML</em> via Slot
-    </template>
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownButtonContent.vue#template{vue-html}
 
 ## Positioning
 
@@ -98,83 +32,13 @@ Dropdown supports various positioning such as left and right aligned, dropdown a
 
 The dropdown menu can either be _start_ aligned (default) or _end_ aligned to the button above it. To have the dropdown aligned on the _end_, set the `end` prop.
 
-<HighlightCard>
-  <BDropdown v-model="show4" text="Default Alignment" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show5" start text="Start Alignment" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show6" end text="End Align" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" text="Default Alignment" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show2" start text="Start Alignment" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show3" end text="End Align" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-const show3 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownMenuAlignment.vue#template{vue-html}
 
 ### Dropup
 
 Turn your dropdown menu into a drop-up menu by setting the `dropup` prop.
 
-<HighlightCard>
-  <BDropdown v-model="show7" dropup text="Drop-Up" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" dropup text="Drop-up" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownDropup.vue#template{vue-html}
 
 ### Drop start or end
 
@@ -182,145 +46,25 @@ Turn your dropdown menu into a drop-end menu by setting the `dropend` prop. Or, 
 
 The order of precedence is top -> start -> end -> bottom.
 
-<HighlightCard>
-  <BDropdown v-model="show8" dropend text="Drop-end" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show9" dropstart text="Drop-start" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" dropend text="Drop-end" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show2" dropstart text="Drop-start" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownStartEnd.vue#template{vue-html}
 
 ### Auto "flipping"
 
 By default, dropdowns may flip to the top, or the bottom, based on their current position in the viewport. To disable this auto-flip feature, set the `no-flip` prop.
 
-<HighlightCard>
-  <BDropdown v-model="show10" text="No flipping" no-flip class="me-2">
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-    <BDropdownItem href="#">Yet Another item</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="No flipping" no-flip>
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-    <BDropdownItem href="#">Yet Another item</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownNoFlip.vue#template{vue-html}
 
 ### Menu offset
 
 Like to move your menu away from the toggle buttons a bit? Then use the `offset` prop to specify the number of pixels to push right (or left when negative) from the toggle button:
 
-<HighlightCard>
-  <BDropdown v-model="show11" offset="25" text="Offset Dropdown" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show12" :offset="{alignmentAxis: 50, crossAxis: 60, mainAxis: 70}" text="Offset Dropdown 2 dimensions" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" offset="25" text="Offset Dropdown">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown
-    v-model="show2"
-    :offset="{alignmentAxis: 50, crossAxis: 60, mainAxis: 70}"
-    text="Offset Dropdown 2 dimensions"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownMenuOffset.vue#template{vue-html}
 
 ### Floating Strategy
 
 By default, the floating element will render using _absolute_. You can change this using the `strategy` prop. The only other option is `fixed`.
 
-<HighlightCard>
-  <BDropdown v-model="show13" text="Strategy fixed" strategy="fixed" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Strategy fixed" strategy="fixed">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownFloating.vue#template{vue-html}
 
 ### Boundary constraint
 
@@ -343,66 +87,7 @@ The `auto-close`property has 4 options.
 - `inside` : the dropdown will be closed (only) by clicking inside the dropdown menu
 - `outside` : the dropdown will be closed (only) by clicking outside the dropdown menu
 
-<HighlightCard>
-  <BDropdown v-model="show14" text="Default Dropdown" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show15" text="Clickable outside (auto-close=inside)" auto-close="inside" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show16" text="Clickable inside (auto-close=outside)" auto-close="outside" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show17" text="Manual close (auto-close=false)" :auto-close="false" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" text="Default Dropdown">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-
-  <BDropdown v-model="show2" text="Clickable outside (auto-close=inside)" auto-close="inside">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-
-  <BDropdown v-model="show3" text="Clickable inside (auto-close=outside)" auto-close="outside">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-
-  <BDropdown v-model="show4" text="Manual close (auto-close=false)" :auto-close="false">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-const show3 = ref(false)
-const show4 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownAutoClose.vue#template{vue-html}
 
 ### Advanced floating-ui configuration
 
@@ -416,59 +101,13 @@ You can view the [Floating-ui docs](https://floating-ui.com/docs/middleware) to 
 
 Create a split dropdown button, where the left button provides standard `click` event and link support, while the right-hand side is the dropdown menu toggle button.
 
-<HighlightCard>
-  <BDropdown v-model="show18" split text="Split Dropdown" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" split text="Split Dropdown" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownSplitButton.vue#template{vue-html}
 
 ### Split button link support
 
 The left split button defaults to an element of type `<button>` (a `BButton` to be exact). To convert this button into a link or `RouterLink`, specify the href via the `split-href` prop or a router link `to` value via the `split-to` prop, while maintaining the look of a button.
 
-<HighlightCard>
-  <BDropdown v-model="show19" split split-href="#foo/bar" text="Split Link" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" split split-href="#foo/bar" text="Split Link">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownSplitButtonLink.vue#template{vue-html}
 
 ### Split button type
 
@@ -486,65 +125,7 @@ Dropdowns work with trigger buttons of all sizes, including default and split dr
 
 Set the `size` prop to either `sm` for a small button, or `lg` for a large button.
 
-<HighlightCard>
-  <BDropdown v-model="show20" size="lg" text="Large" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-    </BDropdown>
-    <BDropdown v-model="show21" size="lg" split text="Large Split" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show22" size="sm" text="Small" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show23" size="sm" split text="Small Split" class="me-2">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" size="lg" text="Large">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here</BDropdownItemButton>
-  </BDropdown>
-
-  <BDropdown v-model="show2" size="lg" split text="Large Split">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-  <BDropdown v-model="show3" size="sm" text="Small">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-
-  <BDropdown v-model="show4" size="sm" split text="Small Split">
-    <BDropdownItemButton>Action</BDropdownItemButton>
-    <BDropdownItemButton>Another action</BDropdownItemButton>
-    <BDropdownItemButton>Something else here...</BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-const show3 = ref(false)
-const show4 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownSizing.vue#template{vue-html}
 
 **Note:** _changing the size of the button(s) does not affect the size of the menu items!_
 
@@ -554,54 +135,7 @@ The dropdown toggle button can have one of the standard Bootstrap contextual var
 
 See the [Variant Reference](/docs/reference/color-variants) for a full list of built-in contextual variants.
 
-<HighlightCard>
-  <BDropdown v-model="show24" text="Primary" variant="primary" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show25" text="Success" variant="success" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown v-model="show26" text="Outline Danger" variant="outline-danger" class="me-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show1" text="Primary" variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show2" text="Success" variant="success">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown v-model="show3" text="Outline Danger" variant="outline-danger">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-const show3 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownColorVariants.vue#template{vue-html}
 
 You can also apply arbitrary classes to the toggle button via the `toggle-class` prop.
 
@@ -610,175 +144,28 @@ You can also apply arbitrary classes to the toggle button via the `toggle-class`
 By default, the left split button uses the same `variant` as the `toggle` button. You can give the
 split button its variant via the `split-variant` prop.
 
-<HighlightCard>
-  <BDropdown
-    v-model="show27"
-    split
-    split-variant="outline-primary"
-    variant="primary"
-    text="Split Variant Dropdown"
-    class="me-2"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown
-    v-model="show"
-    split
-    split-variant="outline-primary"
-    variant="primary"
-    text="Split Variant Dropdown"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownSplitButtonVariant.vue#template{vue-html}
 
 ### Dark mode
 
-### Deprecated Bootstrap v5.3
-
-You can render the dropdown menu in dark mode by setting the `dark` property.
-
-<HighlightCard>
-  <BDropdown v-model="show28" text="Dropdown Button" dark class="m-md-2">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown Button" dark>
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+Dar variants for components were deprecated in Bootstrap v 5.3.0. See
+[their documentation](https://getbootstrap.com/docs/5.3/components/dropdowns/#dark-dropdowns) for details.
 
 ### Block level dropdowns
 
-By default, dropdowns act like buttons and are displayed inline. To create block-level dropdowns (that span to the full width of a parent) set the `block` prop. Both, regular and split button dropdowns are supported.
+<NotYetImplemented>Bootstrap 5's block button implementation doesn't appear to work for dropdowns.</NotYetImplemented>
 
-<HighlightCard>
-  <BDropdown v-model="show29" text="Block Level Dropdown" block variant="primary" class="mb-2">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <BDropdown
-    v-model="show30"
-    text="Block Level Split Dropdown"
-    block
-    split
-    split-variant="outline-primary"
-    variant="primary"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-  <template #html>
+By default, dropdowns act like buttons and are displayed inline. Create a full-width, “block button”
+by adding the classes `d-grid` and `gap-2` to the `BDropdown`. For split buttons, wrap the `BDropdown` in a div
+that has the `d-grid` and `gap-2` classes and add `split-class="w-100"` to the `BDropdown` itself.
+See the [Bootstrap 5](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons) button documentation for details
 
-```vue
-<template>
-  <BDropdown v-model="show1" text="Block Level Dropdown" block variant="primary">
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-
-  <BDropdown
-    v-model="show2"
-    text="Block Level Split Dropdown"
-    block
-    split
-    split-variant="outline-primary"
-    variant="primary"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show1 = ref(false)
-const show2 = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownBlockToggle.vue#template{vue-html}
 
 If you want the dropdown menu to span to the full width of the parent container too, add the `w-100`
 utility class to the `menu-class` prop.
 
-<HighlightCard>
-  <BDropdown
-    v-model="show31"
-    text="Block Level Dropdown Menu"
-    block
-    variant="primary"
-    menu-class="w-100"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown
-    v-model="show"
-    text="Block Level Dropdown Menu"
-    block
-    variant="primary"
-    menu-class="w-100"
-  >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownBlockMenu.vue#template{vue-html}
 
 ### Dropdown sub-component color variants
 
@@ -789,88 +176,42 @@ Many of the supported dropdown [sub-components](#dropdown-supported-sub-componen
 
 The dropdown can be created with the toggle's caret visually hidden by setting the `no-caret` prop to `true`. This is useful when the dropdown is to be displayed as an icon.
 
-<HighlightCard>
-  <BDropdown v-model="show32" size="lg" variant="link" toggle-class="text-decoration-none" no-caret>
-    <template #button-content>
-      &#x1f50d;<span class="visually-hidden">Search</span>
-    </template>
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" size="lg" variant="link" toggle-class="text-decoration-none" no-caret>
-    <template #button-content> &#x1f50d;<span class="visually-hidden">Search</span> </template>
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownHiddenCaret.vue#template{vue-html}
 
 **Note:** The caret will always be shown when using `split` mode.
+
+## v-model support
+
+The dropdown's opened state is bound to the component's `v-model`. Programatic control of the state of the dropdown can be
+managed via the model. The model can also be used to observe the state of the dropdown.
+
+<<< DEMO ./demo/DropdownModel.vue
 
 ## Dropdown supported sub-components
 
 The following components can be placed inside your dropdowns. Using any other component or markup
 may break layout and/or keyboard navigation.
-| Sub-component | Description |
-| ----------------- | ---------------------------- |
-| `BDropdownItem` | Action items that provide click, link, and `RouterLink`/`NuxtLink` functionality. Renders as an `<a>` element by default |
-| <span style="white-space:nowrap;">`BDropdownItemButton`</span> | An alternative to `BDropdownItem` that renders a menu item using a `<button>` element |
-| `BDropdownDivider` | A divider/spacer which can be used to separate dropdown items |
-| `BDropdownText` | Free flowing text content in a menu |
-| `BDropdownGroup` | For grouping dropdown sub-components with an optional header |
-| `BDropdownHeader` | A header item, used to help identify a group of dropdown items |
+
+| Sub-component                                                  | Description                                                                                                              |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `BDropdownItem`                                                | Action items that provide click, link, and `RouterLink`/`NuxtLink` functionality. Renders as an `<a>` element by default |
+| <span style="white-space:nowrap;">`BDropdownItemButton`</span> | An alternative to `BDropdownItem` that renders a menu item using a `<button>` element                                    |
+| `BDropdownDivider`                                             | A divider/spacer which can be used to separate dropdown items                                                            |
+| `BDropdownText`                                                | Free flowing text content in a menu                                                                                      |
+| `BDropdownGroup`                                               | For grouping dropdown sub-components with an optional header                                                             |
+| `BDropdownHeader`                                              | A header item, used to help identify a group of dropdown items                                                           |
 
 **Note:** _Nested sub-menus are **not** supported._
 
-### `BDropdownItem`
+### BDropdownItem
 
 The `BDropdownItem` is typically used to create a navigation link inside your menu. Use either the `href` prop or the `to` prop (for router link support) to generate the appropriate navigation link. If neither `href` nor `to` are provided, a standard `<a>` link will be generated with an `href` of `#` (with an event handler that will prevent scroll to top behavior by preventing the default link action).
 
 Disabled the dropdown item by setting the `disabled` prop.
 
-<HighlightCard>
-  <BDropdown v-model="show33" text="Dropdown">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem variant="primary">Second Action</BDropdownItem>
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-    <BDropdownItem to="/docs/components/badge">Badge</BDropdownItem>
-  </BDropdown>
-  <template #html>
+<<< DEMO ./demo/DropdownItem.vue#template{vue-html}
 
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown Button">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem variant="primary">Second Action</BDropdownItem>
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-    <BDropdownItem href="/docs/components/badge">Badge</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
-
-### `BDropdownItemButton`
+### BDropdownItemButton
 
 Historically dropdown menu contents had to be links (`BDropdownItem`), but that is no longer the
 case with Bootstrap v5. Now you can optionally create `<button>` elements in your dropdowns by using
@@ -879,193 +220,40 @@ or `to` props.
 
 Disabled the dropdown item button by setting the `disabled` prop.
 
-<HighlightCard>
-  <BDropdown v-model="show34" text="Dropdown using buttons as menu items">
-    <BDropdownItemButton>I am a button</BDropdownItemButton>
-    <BDropdownItemButton active>I am a active button</BDropdownItemButton>
-    <BDropdownItemButton disabled>I am a button, but disabled!</BDropdownItemButton>
-    <BDropdownItemButton>I do not look like a button, but I am!</BDropdownItemButton>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown using buttons as menu items">
-    <BDropdownItemButton>I am a button</BDropdownItemButton>
-    <BDropdownItemButton active>I am an active button</BDropdownItemButton>
-    <BDropdownItemButton disabled>I am a button, but disabled!</BDropdownItemButton>
-    <BDropdownItemButton>I do not look like a button, but I am!</BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownItemButton.vue#template{vue-html}
 
 When the menu item does not trigger navigation, it is recommended to use the
 `BDropdownItemButton` sub-component.
 
-### `BDropdownDivider`
+### BDropdownDivider
 
 Separate groups of related menu items with `BDropdownDivider`.
 
-<HighlightCard>
-  <BDropdown v-model="show35" text="Dropdown with divider">
-    <BDropdownItemButton>First item</BDropdownItemButton>
-    <BDropdownItemButton>Second item</BDropdownItemButton>
-    <BDropdownDivider />
-    <BDropdownItemButton>Separated Item</BDropdownItemButton>
-  </BDropdown>
-  <template #html>
+<<< DEMO ./demo/DropdownDivider.vue#template{vue-html}
 
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown with divider">
-    <BDropdownItemButton>First item</BDropdownItemButton>
-    <BDropdownItemButton>Second item</BDropdownItemButton>
-    <BDropdownDivider />
-    <BDropdownItemButton>Separated Item</BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
-
-### `BDropdownText`
+### BDropdownText
 
 Place any freeform text within a dropdown menu using the `BDropdownText` sub-component or use
-text and use spacing utilities. Note that you'll likely need additional sizing styles to
+text combined with spacing utilities. Note that you'll likely need additional sizing styles to
 constrain/set the menu width.
 
-<HighlightCard>
-  <BDropdown v-model="show36" text="Dropdown with text">
-    <BDropdownText style="width: 240px;">
-      Some example text that is free-flowing within the dropdown menu.
-    </BDropdownText>
-    <BDropdownText  tag="span">And this is more example text.</BDropdownText>
-    <BDropdownDivider />
-    <BDropdownItemButton>First item</BDropdownItemButton>
-    <BDropdownItemButton>Second Item</BDropdownItemButton>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown with text">
-    <BDropdownText style="width: 240px;">
-      Some example text that is free-flowing within the dropdown menu.
-    </BDropdownText>
-    <BDropdownText>And this is more example text.</BDropdownText>
-    <BDropdownDivider />
-    <BDropdownItemButton>First item</BDropdownItemButton>
-    <BDropdownItemButton>Second Item</BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownText.vue#template{vue-html}
 
 `BDropdownText` has the BootstrapVueNext custom class `.b-dropdown-text` applied to it which sets some basic styles which are suitable in most situations. By default, its width will be the same as the widest `BDropdownItem` content. You may need to place additional styles or helper classes on the component.
 
-~~By default, `BDropdownText` renders using tag `<p>`. You can change the rendered tag by setting the `tag` prop to any valid HTML5 tag on the `BDropdownText` sub-component~~.
-
-### `BDropdownGroup`
+### BDropdownGroup
 
 Group a set of dropdown sub-components with an optional associated header. Place a `BDropdownDivider` between your `BDropdownGroup` and other groups or non-grouped dropdown contents.
 
-<HighlightCard>
-  <BDropdown v-model="show37" text="Dropdown with group">
-    <BDropdownItemButton> Non-grouped Item </BDropdownItemButton>
-    <BDropdownDivider />
-    <BDropdownGroup header="Group 1">
-      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
-      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
-    </BDropdownGroup>
-    <BDropdownGroup header="Group 2" header-variant="primary">
-      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
-      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
-    </BDropdownGroup>
-    <BDropdownDivider />
-    <BDropdownItemButton> Another Non-grouped Item </BDropdownItemButton>
-  </BDropdown>
-  <template #html>
+<<< DEMO ./demo/DropdownGroup.vue#template{vue-html}
 
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown with group">
-    <BDropdownItemButton> Non-grouped Item </BDropdownItemButton>
-    <BDropdownDivider />
-    <BDropdownGroup header="Group 1">
-      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
-      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
-    </BDropdownGroup>
-    <BDropdownGroup header="Group 2" header-variant="primary">
-      <BDropdownItemButton>First Grouped item</BDropdownItemButton>
-      <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
-    </BDropdownGroup>
-    <BDropdownDivider />
-    <BDropdownItemButton> Another Non-grouped Item </BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
-
-### `BDropdownHeader`
+### BDropdownHeader
 
 Add a header to label sections of actions in any dropdown menu.
 
-<HighlightCard>
-  <BDropdown v-model="show38" text="Dropdown with header">
-    <BDropdownHeader> Dropdown header </BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-label">
-      First item
-    </BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-label">
-      Second Item
-    </BDropdownItemButton>
-  </BDropdown>
-  <template #html>
+<<< DEMO ./demo/DropdownHeader.vue#template{vue-html}
 
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown with header">
-    <BDropdownHeader> Dropdown header </BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-label"> First item </BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-label">
-      Second Item
-    </BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
-
-See Section [Dropdown headers and accessibility](#headers-and-accessibility) for details on making headers more accessible for users of assistive technologies.
+See Section [Headers and accessibility](#headers-and-accessibility) for details on making headers more accessible for users of assistive technologies.
 
 Using the `BDropdownGroup` sub-component simplifies creating accessible grouped dropdown items with an associated header.
 
@@ -1081,47 +269,7 @@ When a menu item does not trigger navigation, it is recommended to use the `BDro
 
 When using `BDropdownHeader` components in the dropdown menu, it is recommended to add an `id` attribute to each of the headers, and then set the `aria-describedby` attribute (set to the `id` value of the associated header) on each following dropdown items under that header. This will provide users of assistive technologies (i.e. sight-impaired users) additional context about the dropdown item:
 
-<HighlightCard>
-  <BDropdown v-model="show39" text="Dropdown ARIA" variant="primary">
-    <BDropdownHeader id="dropdown-header-1">Groups</BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-1">Add</BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-1">Delete</BDropdownItemButton>
-    <BDropdownHeader id="dropdown-header-2">Users</BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-2">Add</BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-2">Delete</BDropdownItemButton>
-    <BDropdownDivider />
-    <BDropdownItemButton>
-      Something <strong>not</strong> associated with Users
-    </BDropdownItemButton>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" text="Dropdown ARIA" variant="primary">
-    <BDropdownHeader id="dropdown-header-1">Groups</BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-1">Add</BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-1">Delete</BDropdownItemButton>
-
-    <BDropdownHeader id="dropdown-header-2">Users</BDropdownHeader>
-    <BDropdownItemButton aria-describedby="dropdown-header-2">Add</BDropdownItemButton>
-    <BDropdownItemButton aria-describedby="dropdown-header-2">Delete</BDropdownItemButton>
-
-    <BDropdownDivider />
-
-    <BDropdownItemButton>
-      Something <strong>not</strong> associated with Users
-    </BDropdownItemButton>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownAccessibility.vue#template{vue-html}
 
 As a simplified alternative, use the `BDropdownGroup` instead to easily associate header text to the contained dropdown sub-components.
 
@@ -1135,36 +283,7 @@ Note that <kbd>Down</kbd> and <kbd>Up</kbd> will not move focus into `BDropdownF
 
 Dropdown menus can have their inner content rendered lazily through the `lazy` prop. By default, this is turned off. For navigation elements, it may be beneficial to keep lazy off, so web crawlers can properly comb through your sites navigation.
 
-<HighlightCard>
-  <BDropdown v-model="show40" lazy text="Dropdown">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-  <template #html>
-
-```vue
-<template>
-  <BDropdown v-model="show" lazy text="Dropdown">
-    <BDropdownItem>First Action</BDropdownItem>
-    <BDropdownItem>Second Action</BDropdownItem>
-    <BDropdownItem>Third Action</BDropdownItem>
-    <BDropdownDivider />
-    <BDropdownItem active>Active action</BDropdownItem>
-    <BDropdownItem disabled>Disabled action</BDropdownItem>
-  </BDropdown>
-</template>
-
-<script setup lang="ts">
-const show = ref(false)
-</script>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/DropdownLazy.vue#template{vue-html}
 
 ## Implementation notes
 
@@ -1172,87 +291,17 @@ The dropdown menu is rendered with semantic `<ul>` and `<li>` elements for acces
 
 ## See also
 
-- [`BNavItemDropdown`](/bootstrap-vue-next/components/nav#dropdown-support) for dropdown support inside `BNav` and `BNavbar`
-- [Router Link Support](/bootstrap-vue-next/reference/router-links) reference for information about router-link specific props available on `BDropdownItem`
+- [`BNavItemDropdown`](/docs/components/nav#dropdown) for dropdown support inside `BNav` and `BNavbar`
+- [Router Link Support](/docs/reference/router-links) reference for information about router-link specific props available on `BDropdownItem`
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
+<script lang="ts">
 import {data} from '../../data/components/dropdown.data'
-import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
-import HighlightCard from '../../components/HighlightCard.vue'
-import {
-  BDropdownGroup,
-  BDropdownText,
-  BDropdownItemButton,
-  BDropdownHeader,
-  BCard,
-  BDropdown,
-  BDropdownDivider,
-  BDropdownItem
-} from 'bootstrap-vue-next'
-import {ref} from 'vue'
 
-const show = ref(false)
-
-const show1 = ref(false)
-
-const show2 = ref(false)
-const show3 = ref(false)
-
-const show4 = ref(false)
-const show5 = ref(false)
-const show6 = ref(false)
-
-const show7 = ref(false)
-
-const show8 = ref(false)
-const show9 = ref(false)
-
-const show10 = ref(false)
-
-const show11 = ref(false)
-const show12 = ref(false)
-
-const show13 = ref(false)
-const show14 = ref(false)
-const show15 = ref(false)
-const show16 = ref(false)
-
-const show17 = ref(false)
-
-const show18 = ref(false)
-const show19 = ref(false)
-
-const show20 = ref(false)
-const show21 = ref(false)
-const show22 = ref(false)
-const show23 = ref(false)
-
-const show24 = ref(false)
-const show25 = ref(false)
-const show26 = ref(false)
-
-const show27 = ref(false)
-
-const show28 = ref(false)
-
-const show29 = ref(false)
-const show30 = ref(false)
-const show31 = ref(false)
-
-const show32 = ref(false)
-
-const show33 = ref(false)
-
-const show34 = ref(false)
-const show35 = ref(false)
-const show36 = ref(false)
-const show37 = ref(false)
-const show38 = ref(false)
-
-const show39 = ref(false)
-
-const show40 = ref(false)
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -63,14 +63,18 @@ Like to move your menu away from the toggle buttons a bit? Then use the `offset`
 ### Floating Strategy
 
 By default, the floating element will render using _absolute_. You can change this using the `strategy` prop. The only other option is `fixed`.
+See the [floating-ui documentation](https://floating-ui.com/docs/hide#strategy) for details.
 
 <<< DEMO ./demo/DropdownFloating.vue#template{vue-html}
 
 ### Boundary constraint
 
-By default, dropdowns are visually constrained to their clipping ancestors, which will suffice in most situations. However, if you place a dropdown inside an element that has `overflow: scroll` (or similar) set, the dropdown menu may - in some situations - get cut off. To get around this, you can specify a boundary element via the `boundary` prop. Supported values are `clippingAncestors` (the default), `viewport`, `document`, or a reference to an HTML element.
+By default, dropdowns are visually constrained to their clipping ancestors, which will suffice in most situations. However, if you place a dropdown inside an element that has `overflow: scroll` (or similar) set, the dropdown menu may - in some situations - get cut off. To get around this, you can specify a boundary element via the `boundary` prop. Supported values any values from [floating-ui](https://floating-ui.com/)
+[Boundary](https://floating-ui.com/docs/detectoverflow#boundary) or [RootBoundary](https://floating-ui.com/docs/detectoverflow#rootboundary) types. The default value is `clippingAncestors`.
 
 **Note:** When `boundary` is any value other than the default of `clippingAncestors`, the style `position: static` is applied to the dropdown component's root element to allow the menu to "break out" of its scroll container. In some situations, this may affect your layout or positioning of the dropdown trigger button. In these cases, you may need to wrap your dropdown inside another element
+
+**Note:** BootstrapVueNext uses [floating-ui](https://floating-ui.com/) under the hood, so please read [their options documnetation](https://floating-ui.com/docs/detectoverflow#options) for details on `boundary` and `boundary-padding`.
 
 ### Container element
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -23,6 +23,8 @@ For instance, there are likely many places where you use `Bootstrap` utility cla
 classes that involve `left` and `right` (or `l` and `r`) to be `start` and `end` (or `s` and `e`). This
 will affect compents such as `BNavBar` in unexpected ways that BSVN has no control over.
 
+Similarly, `left` and `right` props and values in the `bootstrap-vue-next` API are generally replaced by `start` and `end`.
+
 Bootstrap-vue-next will commit to breaking changes whenever Bootstrap marks something as "deprecated". These changes may be resolved automatically, or they might necessitate manual action from the library's users.
 
 ## Sync modifier
@@ -161,6 +163,26 @@ events on this component.
 `$root` instance events `bv::collapse::state` and `bv::toggle::collapse` are deprecrated.
 
 <NotYetImplemented>The `appear` prop.</NotYetImplemented>
+
+## BDropdown
+
+BootstrapVueNext uses [floating-ui](https://floating-ui.com/) to implemented dropdowns. This affects values and behaviors
+for properties souch as `boundary` as well as the alignent and placement properties. For fine control, use `floating-middleware`
+in place of `popper-opts`. Check out [our documentation](/docs/components/dropdown) and [theirs] for details.
+
+The `block` prop is deprecated. See our [`BDropdown` documentation](/docs/components/dropdown#block-level-dropdowns)
+and [Bootstrap's documentation](https://getbootstrap.com/docs/5.3/components/buttons/#block-buttons) for
+details.
+
+The `right` prop is replaced by `end` see the [overview section](#overview) of this page for details.
+
+The `html` prop has been deprecated, use the `button-content`.
+
+`$root` instance events `bv::dropdown::hide` and `bv::dropdown::show` are deprecrated.
+
+<NotYetImplemented>`toggleAttrs`</NotYetImplementd>
+
+<NotYetImplemented/>The props on `BDropdownForm`, `BDropdownHeader`, and `BDropdownText`.
 
 ## BForm
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -180,7 +180,7 @@ The `html` prop has been deprecated, use the `button-content`.
 
 `$root` instance events `bv::dropdown::hide` and `bv::dropdown::show` are deprecrated.
 
-<NotYetImplemented>`toggleAttrs`</NotYetImplementd>
+<NotYetImplemented>`toggleAttrs`</NotYetImplemented>
 
 <NotYetImplemented/>The props on `BDropdownForm`, `BDropdownHeader`, and `BDropdownText`.
 

--- a/apps/docs/src/types/index.ts
+++ b/apps/docs/src/types/index.ts
@@ -38,12 +38,12 @@ export interface ComponentReference {
    */
   sourcePath: string | null
   props: PropsRecord
-  emits: {
+  emits?: {
     event: string
     args?: EmitArgReference[]
     description?: string
   }[]
-  slots: {
+  slots?: {
     scope?: SlotScopeReference[]
     name: string
     description?: string

--- a/apps/docs/src/types/index.ts
+++ b/apps/docs/src/types/index.ts
@@ -40,7 +40,7 @@ export interface ComponentReference {
   props: PropsRecord
   emits: {
     event: string
-    args: EmitArgReference[]
+    args?: EmitArgReference[]
     description?: string
   }[]
   slots: {

--- a/apps/docs/src/utils/common-props.ts
+++ b/apps/docs/src/utils/common-props.ts
@@ -2,6 +2,18 @@ import {type PropertyReference} from '../types'
 
 export const commonProps = () =>
   ({
+    active: {
+      type: 'boolean',
+      default: false,
+      description:
+        'When set to `true`, places the component in the active state with active styling',
+    },
+    activeClass: {
+      type: 'ClassValue',
+      default: 'active',
+      description:
+        "Configure the active CSS class applied when the link is active. Typically you will want to set this to class name 'active'",
+    },
     alt: {
       type: 'string',
       default: 'undefined',
@@ -12,6 +24,12 @@ export const commonProps = () =>
       default: undefined,
       description:
         'If this component controls another component or element, set this to the ID of the controlled component or element',
+    },
+    ariaDescribedby: {
+      type: 'string',
+      default: undefined,
+      description:
+        'The ID of the element that provides a description for this component. Used as the value for the `aria-describedby` attribute',
     },
     ariaInvalid: {
       type: 'AriaInvalid',
@@ -218,6 +236,11 @@ export const commonProps = () =>
       description:
         'When set, the input is formatted on blur instead of each keystroke (if there is a formatter specified)',
     },
+    linkClass: {
+      type: 'ClassValue',
+      default: undefined,
+      description: 'Class or classes to apply to the inner link element',
+    },
     list: {
       type: 'string',
       default: 'undefined',
@@ -227,6 +250,17 @@ export const commonProps = () =>
       type: 'string',
       default: undefined,
       description: 'Sets the value of the `name` attribute on the form control',
+    },
+    noHoverPause: {
+      type: 'boolean',
+      default: false,
+      description: 'When set to true, disables pausing the timer on hover behavior',
+    },
+    noResumeOnHoverLeave: {
+      type: 'boolean',
+      default: false,
+      description:
+        'When set to true, the timer will not resume when the mouse leaves the element. It will need to be manually resumed',
     },
     options: {
       type: 'readonly CheckboxOptionRaw[]',
@@ -366,15 +400,9 @@ export const commonProps = () =>
       description:
         'Applies one of the Bootstrap theme color variants to the component. When implemented `bg-variant` and `text-variant` will take precedence',
     },
-    noHoverPause: {
-      type: 'boolean',
-      default: false,
-      description: 'When set to true, disables pausing the timer on hover behavior',
-    },
-    noResumeOnHoverLeave: {
-      type: 'boolean',
-      default: false,
-      description:
-        'When set to true, the timer will not resume when the mouse leaves the element. It will need to be manually resumed',
+    wrapperAttrs: {
+      type: 'Readonly<AttrsValue>',
+      default: undefined,
+      description: 'Attributes to be applied to the wrapper element',
     },
   }) satisfies Record<string, PropertyReference>

--- a/apps/docs/src/utils/link-props.ts
+++ b/apps/docs/src/utils/link-props.ts
@@ -63,7 +63,9 @@ export const linkProps = {
     type: 'string',
     default: undefined,
     description: 'Not Yet Implmented: A class to apply to links that have been prefetched.',
+    notYetImplemented: true,
   },
+  noRel: {},
   rel: {
     type: 'string',
     default: undefined,
@@ -133,5 +135,8 @@ export const linkProps = {
     default: null,
     description: 'Set the color variant for the link',
   },
-  noRel: {},
-} as const satisfies Record<keyof BvnComponentProps['BLink'], PropertyReference>
+  // TODO: remove the hard-coded NYI props below when they are implemented
+} as const satisfies Record<
+  keyof BvnComponentProps['BLink'] | 'noPrefetch' | 'prefetch' | 'prefetchedClass',
+  PropertyReference
+>


### PR DESCRIPTION
# Describe the PR

- Cleaned up documentation & fixed some docs bugs
- Refactored examples
- Updated the migration guide
- Filled out component references
- Filled out parity spreadsheet

In addition

I made slots, emits and slot scoped args optional in the documentation - there are plenty of places where these are empty and it's just cleaner to not have to specify empty arrays.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
