### PR TITLE
fix(BModal): fix backdrop when modal is shown using v-if

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
@@ -102,7 +102,7 @@
       </div>
     </Transition>
     <slot v-if="!props.hideBackdrop" name="backdrop" v-bind="sharedSlots">
-      <Transition @after-enter="fadeIn" @before-leave="fadeOut">
+      <Transition :appear="modelValue" @after-enter="fadeIn" @before-leave="fadeOut">
         <div
           v-if="modelValue"
           class="modal-backdrop"


### PR DESCRIPTION
# Describe the PR

Adds `:appear="modelValue"` to the backdrop teleport so the after-enter event which shows the backdrop is fired upon initial render. This matches the behavior of the modal teleport itself -- it also has that same attribute set.

fixes #2268 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
