### PR TITLE
fix(grid): Correct some inconsistencies in breakpoint types

### DIFF
--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -199,6 +199,39 @@ type ColorVariant =
 
 </BCard>
 
+## ColsNumbers
+
+<BCard class="bg-body-tertiary">
+
+```ts
+export type ColsBaseNumbers = 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
+
+export type ColsNumbers =
+  | ColsBaseNumbers
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+
+export type GutterNumbers = ColsBaseNumbers | 0 | '0'
+
+export type ColsOrderNumbers = ColsBaseNumbers | 'first' | 'last'
+
+export type ColsOffsetNumbers = ColsNumbers | 0 | '0'
+```
+
+</BCard>
+
 ## CombinedPlacement
 
 <BCard class="bg-body-tertiary">

--- a/packages/bootstrap-vue-next/src/types/BreakpointProps.ts
+++ b/packages/bootstrap-vue-next/src/types/BreakpointProps.ts
@@ -1,10 +1,8 @@
 export type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | 'xxl'
+export type ColsBaseNumbers = 1 | 2 | 3 | 4 | 5 | '1' | '2' | '3' | '4' | '5'
+
 export type ColsNumbers =
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
+  | ColsBaseNumbers
   | 6
   | 7
   | 8
@@ -12,11 +10,6 @@ export type ColsNumbers =
   | 10
   | 11
   | 12
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
   | '6'
   | '7'
   | '8'
@@ -24,6 +17,10 @@ export type ColsNumbers =
   | '10'
   | '11'
   | '12'
+
+export type GutterNumbers = ColsBaseNumbers | 0 | '0'
+export type ColsOrderNumbers = ColsBaseNumbers | 'first' | 'last'
+export type ColsOffsetNumbers = ColsNumbers | 0 | '0'
 
 // Vue bug. Cant do this https://github.com/vuejs/core/issues/10962
 // type BreakpointFactory<V, P extends string = ''> = {
@@ -39,19 +36,19 @@ export type ColsNumbers =
 // export type RowColsBreakpointProps = BreakpointFactory<Numberish, 'cols'>
 
 export interface OffsetBreakpointProps {
-  offsetSm?: ColsNumbers
-  offsetMd?: ColsNumbers
-  offsetLg?: ColsNumbers
-  offsetXl?: ColsNumbers
-  offsetXxl?: ColsNumbers
+  offsetSm?: ColsOffsetNumbers
+  offsetMd?: ColsOffsetNumbers
+  offsetLg?: ColsOffsetNumbers
+  offsetXl?: ColsOffsetNumbers
+  offsetXxl?: ColsOffsetNumbers
 }
 
 export interface OrderBreakpointProps {
-  orderSm?: ColsNumbers
-  orderMd?: ColsNumbers
-  orderLg?: ColsNumbers
-  orderXl?: ColsNumbers
-  orderXxl?: ColsNumbers
+  orderSm?: ColsOrderNumbers
+  orderMd?: ColsOrderNumbers
+  orderLg?: ColsOrderNumbers
+  orderXl?: ColsOrderNumbers
+  orderXxl?: ColsOrderNumbers
 }
 
 export interface ColBreakpointProps {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -29,6 +29,9 @@ import type {
   Breakpoint,
   ColBreakpointProps,
   ColsNumbers,
+  ColsOffsetNumbers,
+  ColsOrderNumbers,
+  GutterNumbers,
   OffsetBreakpointProps,
   OrderBreakpointProps,
   RowColsBreakpointProps,
@@ -729,8 +732,8 @@ export interface BCollapseProps {
 
 export interface BContainerProps {
   fluid?: boolean | Breakpoint
-  gutterX?: ColsNumbers
-  gutterY?: ColsNumbers
+  gutterX?: GutterNumbers
+  gutterY?: GutterNumbers
   tag?: string
 }
 
@@ -1341,8 +1344,8 @@ export interface BModalProps extends TeleporterProps {
 
 export interface BRowProps extends RowColsBreakpointProps {
   tag?: string
-  gutterX?: ColsNumbers
-  gutterY?: ColsNumbers
+  gutterX?: GutterNumbers
+  gutterY?: GutterNumbers
   noGutters?: boolean
   alignV?: AlignmentVertical
   alignH?: AlignmentJustifyContent
@@ -1353,8 +1356,8 @@ export interface BRowProps extends RowColsBreakpointProps {
 export interface BColProps extends OffsetBreakpointProps, OrderBreakpointProps, ColBreakpointProps {
   alignSelf?: AlignmentVertical | 'auto'
   tag?: string
-  order?: ColsNumbers
-  offset?: ColsNumbers
+  order?: ColsOrderNumbers
+  offset?: ColsOffsetNumbers
   cols?: ColsNumbers | 'auto'
   col?: boolean
 }


### PR DESCRIPTION
# Describe the PR

Update types to more closely match what is allowed by bootstrap:

- Column Order values can only be 1-5, 'first' and 'last' now represented by `ColsOrderNumbers': https://getbootstrap.com/docs/5.3/layout/columns/#order-classes
- Column offsets can be number 0-12: https://getbootstrap.com/docs/5.3/layout/columns/#offsetting-columns
- Gutters can be 0-5: https://getbootstrap.com/docs/5.3/layout/gutters/#change-the-gutters

I found these while doing the parity pass on the grid system, I'll push up a separate PR for the documentation updates.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
