### PR TITLE
BTable : make it possible to style custom footers

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -199,7 +199,11 @@
         </BTh>
       </BTr>
     </BTfoot>
-    <BTfoot v-else-if="$slots['custom-foot']" :variant="props.footVariant" :class="props.tfootClass">
+    <BTfoot
+      v-else-if="$slots['custom-foot']"
+      :variant="props.footVariant"
+      :class="props.tfootClass"
+    >
       <slot
         name="custom-foot"
         :fields="computedFields"

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -438,7 +438,7 @@ const showComputedHeaders = computed(() => {
 const footerProps = computed(() => ({
   variant: props.footerVariant,
   class: props.tfootClass
-})
+}))
 
 const itemAttributes = (item: Items, fieldKey: string, attr?: unknown) => {
   const val = get(item, fieldKey)

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -436,7 +436,7 @@ const showComputedHeaders = computed(() => {
 })
 
 const footerProps = computed(() => ({
-  variant: props.footerVariant,
+  variant: props.footVariant,
   class: props.tfootClass
 }))
 

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -437,7 +437,7 @@ const showComputedHeaders = computed(() => {
 
 const footerProps = computed(() => ({
   variant: props.footVariant,
-  class: props.tfootClass
+  class: props.tfootClass,
 }))
 
 const itemAttributes = (item: Items, fieldKey: string, attr?: unknown) => {

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -163,7 +163,7 @@
         </BTr>
       </slot>
     </BTbody>
-    <BTfoot v-if="props.footClone" :variant="props.footVariant" :class="props.tfootClass">
+    <BTfoot v-if="props.footClone" v-bind="footerProps">
       <BTr :variant="props.footRowVariant" :class="props.tfootTrClass">
         <BTh
           v-for="field in computedFields"
@@ -199,11 +199,7 @@
         </BTh>
       </BTr>
     </BTfoot>
-    <BTfoot
-      v-else-if="$slots['custom-foot']"
-      :variant="props.footVariant"
-      :class="props.tfootClass"
-    >
+    <BTfoot v-else-if="$slots['custom-foot']" v-bind="footerProps">
       <slot
         name="custom-foot"
         :fields="computedFields"
@@ -437,6 +433,11 @@ const showComputedHeaders = computed(() => {
   if (computedFieldsTotal.value > 0 && computedFields.value.every((el) => el._noHeader === true))
     return false
   return true
+})
+
+const footerProps = computed(() => ({
+  variant: props.footerVariant,
+  class: props.tfootClass
 })
 
 const itemAttributes = (item: Items, fieldKey: string, attr?: unknown) => {

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -199,7 +199,7 @@
         </BTh>
       </BTr>
     </BTfoot>
-    <BTfoot v-else-if="$slots['custom-foot']">
+    <BTfoot v-else-if="$slots['custom-foot']" :variant="props.footVariant" :class="props.tfootClass">
       <slot
         name="custom-foot"
         :fields="computedFields"


### PR DESCRIPTION
Hi,
I recently tried to migrate a BTable that has a custom footer.
Sadly it's not possible to add a variant (or some styles) on the BTfoot component itself.
In following example, the `dark` variant would not be applied on the footer:

```vue
    <BTable foot-variant="dark" ... >
      <template v-slot:custom-foot="fields">
        <BTr>
          <BTh class="text-center align-middle text-nowrap">{{ value1 }}</BTh>
          <BTh class="text-center align-middle text-nowrap">{{ value2 }}</BTh>
        </BTr>
      </template>
    </BTable>
```

This little patch should be enough to fix the issue.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
