### PR TITLE
docs(migration): Document unimplemented components

### DIFF
--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -78,6 +78,10 @@ For consistency with other components properties, slots and events that use the 
 now use the term `close`. For example the `dismissed` event is now the `closed` event and the `dsimiss` slot is
 now the `close` slot.
 
+## BAspect
+
+<NotYetImplemented/>
+
 ## BAvatar
 
 Icon support has been deprecated. Icons support can be implemented using the default slot including
@@ -125,6 +129,10 @@ embedded svg for the close icon. See [their migration guide](https://getbootstra
 [Keyboard navigation](https://bootstrap-vue.org/docs/components/button-toolbar#keyboard-navigation) is
 not implemented.
 
+## BCalendar
+
+<NotYetImplemented><BLink href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1860#event-14531487213">See issue #1860</BLink></NotYetImplemented>
+
 ## BCard
 
 Image placement is accomplished by the single `img-placement` prop, which takes the values
@@ -148,6 +156,10 @@ and `BCardTitle` components.
 
 `body-border-variant` and `body-variant` are not implemented on `BCard` and `border-variant` is not
 implemented on `BCardBody`.
+
+## BCardImgLazy
+
+This functionality has been replaced by lazy loading on `<BImg>` see [BImg notes](#bimg) for details.
 
 ## BCarousel
 
@@ -227,6 +239,10 @@ use the `form-class` prop.
 
 The `disabled` prop is deprecated, set the disabled prop on individual components as you do with `BForm`.
 
+## BEmbed
+
+<NotYetImplemented/>
+
 ## BForm
 
 Bootstrap 5 has dropped form-specific layout classes for the grid system. See the
@@ -246,6 +262,10 @@ property and `update:model-value` events. Bootstrap-vue-next no longer provides 
 
 See the [Vue 3 migration guide](https://v3-migration.vuejs.org/breaking-changes/v-model.html)
 for more info.
+
+## BFormDatePicker
+
+<NotYetImplemented><BLink href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1860#event-14531487213">See issue #1860</BLink></NotYetImplemented>
 
 ## BFormGroup
 
@@ -267,12 +287,24 @@ They work as documented in vue.js, so there is no longer a need for the properti
 
 [Options as an object](https://bootstrap-vue.org/docs/components/form-select#options-as-an-object) was deprecated in BootstrapVue and never implemented in BootstrapVueNext
 
+## BFormTimePicker
+
+<NotYetImplemented><BLink href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1860#event-14531487213">See issue #1860</BLink></NotYetImplemented>
+
+## BFormRating
+
+<NotYetImplemented><BLink href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/2051">See issue #2051</BLink></NotYetImplemented>
+
 ## BImg
 
 See the [Rounding](#rounding) section.
 
 Lazy loading is now achieved through the native `loading` attribute rather than a seperate component. Thus
 `BImgLazy` and `BCardImgLazy` are deprecated.
+
+## BImgLazy
+
+This functionality has been replaced by lazy loading on `<BImg>` see [BImg](#bimg) for details.
 
 ## BInputGroup
 
@@ -310,6 +342,14 @@ a limitation that affect your scenario, please [file an issue](https://github.co
 [`trim`, `lazy`, and `number`](https://vuejs.org/guide/essentials/forms.html#modifiers).
 They work as documented in vue.js, so there is no longer a need for the properties.
 
+## BJumbotron
+
+<NotYetImplemened/>
+
+Note that Bootstrap has deprecated their Jumbotron component, but it can be replicated using
+utility classes. See their [migration guide](https://getbootstrap.com/docs/5.3/migration/#jumbotron)
+for details.
+
 ## BLink
 
 Bootstrap Vue used `Vue Router 3`, BSVN uses [`Vue Router 4`](https://router.vuejs.org/) please read the
@@ -340,6 +380,13 @@ BSVN no longer emits the `bv::link::clicked` event on `$root`.
 
 See [BLink](#blink) for changes to link and router behavior.
 
+## BMedia
+
+<NotYetImplemened/>
+
+Note that Bootstrap has deprecated their Media object, but it can be replicated using
+flex utility classes. See their [documentation](https://getbootstrap.com/docs/5.3/utilities/flex/#media-object) for details.
+
 ## BModal
 
 ### Replacement for Modal Message boxes
@@ -369,3 +416,15 @@ Keyboard Navigation and Small Screen Support.
 ## BPaginationNav
 
 <NotYetImplemented/>
+
+## BSkeleton
+
+`<BSkeleton*>` components have been replaced by the more appropriately named `<BPlaceholder*>` components.
+
+`<BSkeletonIcon>` is deprecated along with the rest of the the BootstrapVue icon support. See our
+[icon documentation](/docs/icons) for details. This functionality can be replicated by using
+`<BplaceholderWrapper>` with your choice of icon replacement in the `loading` slot.
+
+## BTime
+
+<NotYetImplemented><BLink href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/1860#event-14531487213">See issue #1860</BLink></NotYetImplemented>


### PR DESCRIPTION
# Describe the PR

As part of the parity pass, I went through and added notes for all not yet implemented or deprecated components. I errored towards marking things as NYI rather than deprecated. I don't think that any of the currently unimplemented components would necessarily block us from declaring a v1 (other than possibly the date/time related ones, which I believe @VividLemon is looking at now). Things like Jubotron, and Media, and PaginationNav can reasonably be worked around using straight bootstrap classes - if someone feels compelled to smooth things out by implementing BSVN components the wouldn't be breaking changes and could be added at any time, including after we declare the library production ready.

I'd be fine with drawing the line differently if @VividLemon or @xvaara has an opinion.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
