### PR TITLE
fix(BDropdown): focus returned to dropdown when escape key hit

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -75,7 +75,7 @@ import {
   size as sizeMiddleware,
   useFloating,
 } from '@floating-ui/vue'
-import {onClickOutside, onKeyStroke, useToNumber} from '@vueuse/core'
+import {onClickOutside, onKeyStroke, useFocus, useToNumber} from '@vueuse/core'
 import {
   computed,
   type CSSProperties,
@@ -181,20 +181,13 @@ const rootBoundary = computed<RootBoundary | undefined>(() =>
 
 const referencePlacement = computed(() => (!props.split ? splitButton.value : button.value))
 
-onKeyStroke(
-  'Escape',
-  () => {
-    modelValue.value = !modelValue.value
-  },
-  {target: referencePlacement}
-)
-onKeyStroke(
-  'Escape',
-  () => {
-    modelValue.value = !modelValue.value
-  },
-  {target: floating}
-)
+const {focused} = useFocus(referencePlacement)
+const handleEscape = () => {
+  modelValue.value = !modelValue.value
+  focused.value = true
+}
+onKeyStroke('Escape', handleEscape, {target: referencePlacement})
+onKeyStroke('Escape', handleEscape, {target: floating})
 
 const keynav = (e: Readonly<Event>, v: number) => {
   if (floating.value?.contains((e.target as HTMLElement)?.closest('form'))) return


### PR DESCRIPTION


# Describe the PR

Currently, when the escape key is hit focus is returned to where the dropdown is.  This could be the end of the body if you teleport to body.  This ensures the focus is returned to the dropdown button when escape key is pressed while in the dropdown.

## Small replication

unnecessary?

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
