### PR TITLE
docs: Fix lint errors in Layout.vue + styling of otp

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -703,43 +703,43 @@ watch(
         column-gap: 1.5rem;
       }
     }
-
-    .table-of-contents {
-      font-size: 0.875rem;
-
-      ul {
-        padding-left: 0;
-        margin-bottom: 0;
-        list-style: none;
-
-        a {
-          display: block;
-          padding: 0.125rem 0 0.125rem 0.75rem;
-          color: inherit;
-          text-decoration: none;
-          border-left: 0.125rem solid transparent;
-
-          &.active {
-            color: var(--bd-toc-color);
-            border-left-color: var(--bd-toc-color);
-          }
-
-          &:hover {
-            color: var(--bd-toc-color);
-            border-left-color: var(--bd-toc-color);
-          }
-        }
-
-        ul {
-          padding-left: 1rem;
-        }
-      }
-    }
   }
 
   .offcanvas.offcanvas-end {
     @media (max-width: 991px) {
       max-width: 15rem;
+    }
+  }
+}
+
+.table-of-contents {
+  font-size: 0.875rem;
+
+  ul {
+    padding-left: 0;
+    margin-bottom: 0;
+    list-style: none;
+
+    a {
+      display: block;
+      padding: 0.125rem 0 0.125rem 0.75rem;
+      color: inherit;
+      text-decoration: none;
+      border-left: 0.125rem solid transparent;
+
+      &.active {
+        color: var(--bd-toc-color);
+        border-left-color: var(--bd-toc-color);
+      }
+
+      &:hover {
+        color: var(--bd-toc-color);
+        border-left-color: var(--bd-toc-color);
+      }
+    }
+
+    ul {
+      padding-left: 1rem;
     }
   }
 }

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -1,5 +1,6 @@
+<!-- eslint-disable vue/multi-word-component-names -->
 <template>
-  <BNavbar variant="primary" sticky="top" toggleable="lg" :container="true" v-b-color-mode="'dark'">
+  <BNavbar v-b-color-mode="'dark'" variant="primary" sticky="top" toggleable="lg" :container="true">
     <BToastOrchestrator />
     <BModalOrchestrator />
     <div class="d-flex gap-2 align-items-center">
@@ -31,6 +32,7 @@
         <BNav>
           <BNavItem
             v-for="link in headerLinks"
+            :key="link.route"
             :to="link.route"
             :active="route.path === `${link.route}.html`"
             class="py-2"
@@ -46,6 +48,7 @@
         <BNav class="d-flex">
           <BNavItem
             v-for="link in headerExternalLinks"
+            :key="link.url"
             :href="link.url"
             :link-attrs="{'aria-label': link.label}"
             target="_blank"
@@ -81,7 +84,7 @@
     </div>
   </BNavbar>
   <ClientOnly>
-    <div class="py-4 px-3 text-end" v-if="!isLargeScreen">
+    <div v-if="!isLargeScreen" class="py-4 px-3 text-end">
       <BNavbarToggle v-b-toggle.otp-menu class="otp-menu-toggle">
         On this page
         <ChevronRight aria-hidden />
@@ -150,23 +153,23 @@ import {
   BCol,
   BCollapse,
   BContainer,
-  BNavItemDropdown,
   BDropdownItem,
+  BModalOrchestrator,
   BNav,
   BNavbar,
   BNavbarBrand,
   BNavbarNav,
   BNavbarToggle,
   BNavItem,
+  BNavItemDropdown,
   BOffcanvas,
   BRow,
-  useColorMode,
-  vBToggle,
-  vBColorMode,
   BToastOrchestrator,
-  BModalOrchestrator,
+  useColorMode,
+  vBColorMode,
+  vBToggle,
 } from 'bootstrap-vue-next'
-import {inject, ref, computed, onMounted, watch} from 'vue'
+import {computed, inject, onMounted, ref, watch} from 'vue'
 import GithubIcon from '~icons/bi/github'
 import OpencollectiveIcon from '~icons/simple-icons/opencollective'
 import DiscordIcon from '~icons/bi/discord'
@@ -176,9 +179,8 @@ import ChevronRight from '~icons/bi/chevron-right'
 import CircleHalf from '~icons/bi/circle-half'
 import {useData, useRoute, withBase} from 'vitepress'
 import {appInfoKey} from './keys'
-import {useMediaQuery, type BasicColorMode, type UseColorModeReturn} from '@vueuse/core'
+import {useMediaQuery} from '@vueuse/core'
 import TableOfContentsNav from '../../src/components/TableOfContentsNav.vue'
-// @ts-ignore
 import VPNavBarSearch from 'vitepress/dist/client/theme-default/components/VPNavBarSearch.vue'
 
 // https://vitepress.dev/reference/runtime-api#usedata
@@ -188,6 +190,10 @@ const route = useRoute()
 const globalData = inject(appInfoKey, {
   discordUrl: '',
   githubUrl: '',
+  githubPackageDirectory: '',
+  githubComponentsDirectory: '',
+  githubComposablesDirectory: '',
+  githubDirectivesDirectory: '',
   opencollectiveUrl: '',
 })
 


### PR DESCRIPTION
# Describe the PR

- Fixed several 'new' lint errors in `Layout.vue` (possibly due to the recent upgrade of eslint)
- The on this page formatting was being broken by the teleport when shown as an offfcanvas. I just pulled out the `.table-of-contents` styling from the otp-sidebar - we're only using `table-of-contents` in the one place, so it seemed the cleanest solution (and I suspect if we decide to do a TOC embedded elsewhere, we'd want these stylings anyway),

## Small replication

View the docs in a small window.
Open the on this page overlay.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
