### PR TITLE
docs: fix type errors from missing props

### DIFF
--- a/apps/docs/src/data/components/accordion.data.ts
+++ b/apps/docs/src/data/components/accordion.data.ts
@@ -124,37 +124,11 @@ export default {
             description:
               'When set, signifies that the accordion is part of a navbar, enabling certain features for navbar support',
           },
-          modelValue: {
-            type: 'boolean',
-            default: false,
-            description: 'Controls the visibility of the AccordionItem',
-          },
           title: {
             type: 'string',
             default: undefined,
             description:
               'Text to place in the header of the AccordionItem (title slot takes precedence)',
-          },
-          show: {
-            type: 'boolean',
-            default: false,
-            description:
-              "When set, and prop 'visible' is false on mount, will animate from closed to open on initial mount",
-          },
-          visible: {
-            type: 'boolean',
-            default: false,
-            description: "When 'true', open without animation",
-          },
-          lazy: {
-            type: 'boolean',
-            default: false,
-            description: 'When set, the content will not be mounted until opened',
-          },
-          unmountLazy: {
-            type: 'boolean',
-            default: false,
-            description: 'When set and `lazy` is true, the content will be unmounted when closed',
           },
           // transProps: {
           //   type: 'TransitionProps',
@@ -171,6 +145,7 @@ export default {
           //   default: false,
           //   description: 'Alias for `noAnimation`',
           // },
+          ...pick(showHideProps, ['modelValue', 'lazy', 'show', 'unmountLazy', 'visible']),
           ...pick(
             buildCommonProps({
               id: {

--- a/apps/docs/src/data/components/accordion.data.ts
+++ b/apps/docs/src/data/components/accordion.data.ts
@@ -1,6 +1,6 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
 import type {ComponentReference, PropertyReference} from '../../types'
-import {buildCommonProps, pick} from '../../utils'
+import {buildCommonProps, pick, showHideProps} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
@@ -20,22 +20,6 @@ export default {
             default: false,
             description: 'Accordion items will stay open when another item is opened',
           },
-          modelValue: {
-            type: 'string',
-            default: undefined,
-            description:
-              'The Id of the accordion item that is currently open (not compatible with the `free===true`)',
-          },
-          lazy: {
-            type: 'boolean',
-            default: false,
-            description: 'When set, the content will not be mounted until opened',
-          },
-          unmountLazy: {
-            type: 'boolean',
-            default: false,
-            description: 'When set and `lazy` is true, the content will be unmounted when closed',
-          },
           // transProps: {
           //   type: 'TransitionProps',
           //   default: undefined,
@@ -51,6 +35,7 @@ export default {
           //   default: false,
           //   description: 'Alias for `noAnimation`',
           // },
+          ...pick(showHideProps, ['initialAnimation', 'modelValue', 'lazy', 'unmountLazy']),
           ...pick(
             buildCommonProps({
               id: {

--- a/apps/docs/src/data/components/carousel.data.ts
+++ b/apps/docs/src/data/components/carousel.data.ts
@@ -65,10 +65,20 @@ export default {
             default: true,
             description: 'Enable keyboard navigation with the right and left arrow keys',
           },
+          labelIndicators: {
+            type: 'string',
+            default: 'Select a slide to display',
+            description: 'Set the aria-label for the indicators',
+          },
           modelValue: {
             type: 'number',
             default: 0,
             description: 'The index of the currently active slide',
+          },
+          noAnimation: {
+            type: 'boolean',
+            default: false,
+            description: 'When set, disables the animation',
           },
           noHoverPause: {
             type: 'boolean',

--- a/apps/docs/src/data/components/nav.data.ts
+++ b/apps/docs/src/data/components/nav.data.ts
@@ -86,7 +86,19 @@ export default {
       sourcePath: '/BNav/BNavForm.vue',
       props: {
         '': {
-          ...pick(buildCommonProps(), ['floating', 'id', 'novalidate', 'role', 'validated']),
+          formClass: {
+            type: 'ClassValue',
+            default: undefined,
+            description: 'CSS class (or classes) to add to the form element',
+          },
+          ...pick(buildCommonProps(), [
+            'floating',
+            'id',
+            'novalidate',
+            'role',
+            'validated',
+            'wrapperAttrs',
+          ]),
         } satisfies Record<keyof BvnComponentProps['BNavForm'], PropertyReference>,
       },
       emits: [


### PR DESCRIPTION
# Describe the PR

Fix type errors in a couple of our component references where the docs didn't match the code. Also removed a bit of redundancy in the docs in `accordian.data.ts`.

@VividLemon, @xvaara I'm also seeing this error in showhide-props.ts:

```
Property 'showHide' does not exist on type 'BvnComponentProps'.ts(2339)
```

`showHide`  doesn't appear to be declared in `bootstrap-vue-next.mjs`, but it is declared in `BoostrapVueOptions.ts` - I think that's what's being used to build the exports, but I can't follow the thread of how things are being built to figure out what is going on. I'm doing a `pnpm import`, is there something else I need to do to rebuild the exports from bsvn for local consumption by the docs?

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
