### PR TITLE
fix(useShowHide): fix transition triggering in production build

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
@@ -5,7 +5,7 @@
     v-bind="transitionProps"
     :enter-active-class="computedNoAnimation ? '' : 'collapsing'"
     :leave-active-class="computedNoAnimation ? '' : 'collapsing'"
-    :appear="true"
+    :appear="modelValue || props.visible"
   >
     <component
       :is="props.tag"

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -44,7 +44,11 @@
       :to="props.teleportTo"
       :disabled="!props.teleportTo || props.teleportDisabled"
     >
-      <Transition v-if="renderRef || contentShowing" v-bind="transitionProps" :appear="true">
+      <Transition
+        v-if="renderRef || contentShowing"
+        v-bind="transitionProps"
+        :appear="modelValue || props.visible"
+      >
         <ul
           v-show="showRef"
           :id="computedId + '-menu'"

--- a/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
@@ -3,7 +3,7 @@
     <Transition
       v-if="renderRef || contentShowing"
       v-bind="transitionProps"
-      :appear="true"
+      :appear="modelValue || props.visible"
       @after-enter="onAfterEnter"
     >
       <div

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -6,7 +6,7 @@
     <Transition
       v-if="renderRef || contentShowing || isOpenByBreakpoint"
       v-bind="transitionProps"
-      :appear="true"
+      :appear="modelValue || props.visible"
     >
       <div
         v-show="

--- a/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
@@ -5,7 +5,11 @@
     :to="props.teleportTo"
     :disabled="!props.teleportTo || props.teleportDisabled"
   >
-    <Transition v-if="renderRef || contentShowing" v-bind="transitionProps" :appear="true">
+    <Transition
+      v-if="renderRef || contentShowing"
+      v-bind="transitionProps"
+      :appear="modelValue || props.visible"
+    >
       <div
         v-show="showRef && !hidden"
         :id="computedId"

--- a/packages/bootstrap-vue-next/src/components/BToast/BToast.vue
+++ b/packages/bootstrap-vue-next/src/components/BToast/BToast.vue
@@ -1,5 +1,9 @@
 <template>
-  <Transition v-if="renderRef || contentShowing" v-bind="transitionProps" :appear="true">
+  <Transition
+    v-if="renderRef || contentShowing"
+    v-bind="transitionProps"
+    :appear="!!modelValue || props.visible"
+  >
     <div
       v-show="isToastVisible"
       :id="props.id"


### PR DESCRIPTION
# Describe the PR

It seems vue transitions with prop appear behave differently in dev and production builds.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
