### PR TITLE
fix(useShowHide): add all the emits

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -15,11 +15,13 @@
       :lazy="props.lazy || parentData?.lazy.value"
       :unmount-lazy="props.unmountLazy || parentData?.unmountLazy.value"
       @show="emit('show', $event)"
-      @shown="emit('shown')"
+      @shown="emit('shown', $event)"
       @hide="emit('hide', $event)"
-      @hidden="emit('hidden')"
-      @hide-prevented="emit('hide-prevented')"
-      @show-prevented="emit('show-prevented')"
+      @hidden="emit('hidden', $event)"
+      @hide-prevented="emit('hide-prevented', $event)"
+      @show-prevented="emit('show-prevented', $event)"
+      @toggle-prevented="emit('toggle-prevented', $event)"
+      @toggle="emit('toggle', $event)"
     >
       <template #header="{visible: toggleVisible, toggle: slotToggle}">
         <component
@@ -56,7 +58,7 @@ import {accordionInjectionKey} from '../../utils/keys'
 import {useDefaults} from '../../composables/useDefaults'
 import {useId} from '../../composables/useId'
 import type {BAccordionItemProps} from '../../types/ComponentProps'
-import type {BvTriggerableEvent} from '../../utils'
+import type {showHideEmits} from '../../composables/useShowHide'
 
 defineOptions({
   inheritAttrs: false,
@@ -85,14 +87,7 @@ const _props = withDefaults(defineProps<Omit<BAccordionItemProps, 'modelValue'>>
 })
 const props = useDefaults(_props, 'BAccordionItem')
 
-const emit = defineEmits<{
-  'hidden': []
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': []
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': []
-  'shown': []
-}>()
+const emit = defineEmits<showHideEmits>()
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
@@ -38,8 +38,7 @@ import {useDefaults} from '../../composables/useDefaults'
 import {useId} from '../../composables/useId'
 import {collapseInjectionKey, globalCollapseStorageInjectionKey} from '../../utils/keys'
 import type {BCollapseProps} from '../../types/ComponentProps'
-import {BvTriggerableEvent} from '../../utils'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 
 defineOptions({
   inheritAttrs: false,
@@ -60,15 +59,7 @@ const _props = withDefaults(defineProps<Omit<BCollapseProps, 'modelValue'>>(), {
 
 const props = useDefaults(_props, 'BCollapse')
 
-const emit = defineEmits<{
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-  'toggle': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<showHideEmits>()
 
 type SharedSlotsData = {
   hide: () => void

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -95,14 +95,13 @@ import {
 import {useDefaults} from '../../composables/useDefaults'
 import {useId} from '../../composables/useId'
 import type {BDropdownProps} from '../../types/ComponentProps'
-import {BvTriggerableEvent} from '../../utils'
 import BButton from '../BButton/BButton.vue'
 import ConditionalWrapper from '../ConditionalWrapper.vue'
 import ConditionalTeleport from '../ConditionalTeleport.vue'
 import {isBoundary, isRootBoundary} from '../../utils/floatingUi'
 import {getElement} from '../../utils/getElement'
 import {buttonGroupKey, dropdownInjectionKey, inputGroupKey} from '../../utils/keys'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 
 const _props = withDefaults(defineProps<Omit<BDropdownProps, 'modelValue'>>(), {
   ariaLabel: undefined,
@@ -148,17 +147,11 @@ const _props = withDefaults(defineProps<Omit<BDropdownProps, 'modelValue'>>(), {
 })
 const props = useDefaults(_props, 'BDropdown')
 
-const emit = defineEmits<{
-  'click': [event: MouseEvent]
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-  'toggle': [value: BvTriggerableEvent]
-  'toggle-prevented': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    click: [event: MouseEvent]
+  } & showHideEmits
+>()
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
@@ -136,7 +136,7 @@ import {useSafeScrollLock} from '../../composables/useSafeScrollLock'
 import {isEmptySlot} from '../../utils/dom'
 import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
 import {useModalManager} from '../../composables/useModalManager'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 import ConditionalTeleport from '../ConditionalTeleport.vue'
 
 defineOptions({
@@ -214,19 +214,15 @@ const _props = withDefaults(defineProps<Omit<BModalProps, 'modelValue'>>(), {
 })
 const props = useDefaults(_props, 'BModal')
 
-const emit = defineEmits<{
-  'backdrop': [value: BvTriggerableEvent]
-  'cancel': [value: BvTriggerableEvent]
-  'close': [value: BvTriggerableEvent]
-  'esc': [value: BvTriggerableEvent]
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'ok': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    backdrop: [value: BvTriggerableEvent]
+    cancel: [value: BvTriggerableEvent]
+    close: [value: BvTriggerableEvent]
+    esc: [value: BvTriggerableEvent]
+    ok: [value: BvTriggerableEvent]
+  } & showHideEmits
+>()
 
 type SharedSlotsData = {
   cancel: () => void

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
@@ -11,8 +11,9 @@
       @hidden="emit('hidden', $event)"
       @hide-prevented="emit('hide-prevented', $event)"
       @show-prevented="emit('show-prevented', $event)"
-      @click="emit('click', $event)"
+      @toggle-prevented="emit('toggle-prevented', $event)"
       @toggle="emit('toggle', $event)"
+      @click="emit('click', $event)"
     >
       <template #button-content>
         <slot name="button-content" />
@@ -29,10 +30,10 @@
 
 <script setup lang="ts">
 import {useTemplateRef} from 'vue'
-import {BvTriggerableEvent} from '../../utils'
 import BDropdown from '../BDropdown/BDropdown.vue'
 import type {BDropdownProps} from '../../types/ComponentProps'
 import {useDefaults} from '../../composables/useDefaults'
+import type {showHideEmits} from '../../composables/useShowHide'
 
 const _props = withDefaults(defineProps<Omit<BDropdownProps, 'modelValue'>>(), {
   ariaLabel: undefined,
@@ -74,16 +75,11 @@ const _props = withDefaults(defineProps<Omit<BDropdownProps, 'modelValue'>>(), {
 })
 const props = useDefaults(_props, 'BNavItemDropdown')
 
-const emit = defineEmits<{
-  'click': [event: MouseEvent]
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-  'toggle': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    click: [event: MouseEvent]
+  } & showHideEmits
+>()
 
 const modelValue = defineModel<Exclude<BDropdownProps['modelValue'], undefined>>({default: false})
 

--- a/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
+++ b/packages/bootstrap-vue-next/src/components/BOffcanvas/BOffcanvas.vue
@@ -90,7 +90,7 @@ import BCloseButton from '../BButton/BCloseButton.vue'
 import ConditionalTeleport from '../ConditionalTeleport.vue'
 import {useSafeScrollLock} from '../../composables/useSafeScrollLock'
 import {isEmptySlot} from '../../utils/dom'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 import type {Placement} from '../../types/Alignment'
 
 // TODO once the responsive stuff may be implemented correctly,
@@ -138,18 +138,14 @@ const _props = withDefaults(defineProps<Omit<BOffcanvasProps, 'modelValue'>>(), 
 })
 const props = useDefaults(_props, 'BOffcanvas')
 
-const emit = defineEmits<{
-  'close': [value: BvTriggerableEvent]
-  'esc': [value: BvTriggerableEvent]
-  'backdrop': [value: BvTriggerableEvent]
-  'breakpoint': [value: BvTriggerableEvent]
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    close: [value: BvTriggerableEvent]
+    esc: [value: BvTriggerableEvent]
+    backdrop: [value: BvTriggerableEvent]
+    breakpoint: [value: BvTriggerableEvent]
+  } & showHideEmits
+>()
 
 type SharedSlotsData = {
   visible: boolean

--- a/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
@@ -90,7 +90,7 @@ import {BvTriggerableEvent} from '../../utils'
 import {isBoundary, isRootBoundary, resolveBootstrapPlacement} from '../../utils/floatingUi'
 import {getElement} from '../../utils/getElement'
 import ConditionalTeleport from '../ConditionalTeleport.vue'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 
 defineOptions({
   inheritAttrs: false,
@@ -136,18 +136,14 @@ const _props = withDefaults(defineProps<Omit<BPopoverProps, 'modelValue'>>(), {
 
 const props = useDefaults(_props, 'BPopover')
 
-const emit = defineEmits<{
-  'hidden': [value: BvTriggerableEvent]
-  'hide': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-  'pointerleave': [value: BvTriggerableEvent]
-  'blur': [value: BvTriggerableEvent]
-  'click-outside': [value: BvTriggerableEvent]
-  'close-on-hide': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    'pointerleave': [value: BvTriggerableEvent]
+    'blur': [value: BvTriggerableEvent]
+    'click-outside': [value: BvTriggerableEvent]
+    'close-on-hide': [value: BvTriggerableEvent]
+  } & showHideEmits
+>()
 
 const slots = defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BToast/BToast.vue
+++ b/packages/bootstrap-vue-next/src/components/BToast/BToast.vue
@@ -71,7 +71,7 @@ import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
 import {useDefaults} from '../../composables/useDefaults'
 import {useCountdownHover} from '../../composables/useCountdownHover'
 import {useId} from '../../composables/useId'
-import {useShowHide} from '../../composables/useShowHide'
+import {type showHideEmits, useShowHide} from '../../composables/useShowHide'
 
 const _props = withDefaults(defineProps<Omit<BToastProps, 'modelValue'>>(), {
   bgVariant: null,
@@ -125,16 +125,12 @@ const _props = withDefaults(defineProps<Omit<BToastProps, 'modelValue'>>(), {
 })
 const props = useDefaults(_props, 'BToast')
 
-const emit = defineEmits<{
-  'close': [value: BvTriggerableEvent]
-  'close-countdown': [value: number]
-  'hide': [value: BvTriggerableEvent]
-  'hidden': [value: BvTriggerableEvent]
-  'show': [value: BvTriggerableEvent]
-  'shown': [value: BvTriggerableEvent]
-  'show-prevented': [value: BvTriggerableEvent]
-  'hide-prevented': [value: BvTriggerableEvent]
-}>()
+const emit = defineEmits<
+  {
+    'close': [value: BvTriggerableEvent]
+    'close-countdown': [value: number]
+  } & showHideEmits
+>()
 
 const slots = defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/composables/useShowHide.ts
+++ b/packages/bootstrap-vue-next/src/composables/useShowHide.ts
@@ -13,6 +13,17 @@ export const fadeBaseTransitionProps = {
   css: true,
 }
 
+export interface showHideEmits {
+  'hide': [value: BvTriggerableEvent]
+  'hide-prevented': [value: BvTriggerableEvent]
+  'hidden': [value: BvTriggerableEvent]
+  'show': [value: BvTriggerableEvent]
+  'show-prevented': [value: BvTriggerableEvent]
+  'shown': [value: BvTriggerableEvent]
+  'toggle': [value: BvTriggerableEvent]
+  'toggle-prevented': [value: BvTriggerableEvent]
+}
+
 interface TransitionProps {
   onBeforeEnter?: (el: Element) => void
   onEnter?: (el: Element) => void


### PR DESCRIPTION
# Describe the PR

fixes:
> * `toggle-prevented` event is  missing on `BCollapse`, `BNavItemDropdown`
> * `*-prevented` should have value arg of BvTriggerableEvent
> * `BOffCanvas`, `BPopover`, and `BToast` don't declare events `toggle` or `toggle-prevented`, but they expose `toggle`, so I think they will emit those events?


## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
