### PR TITLE
docs: document css selectors for customizing styles on components

### DIFF
--- a/apps/docs/src/components/ComponentReference.vue
+++ b/apps/docs/src/components/ComponentReference.vue
@@ -32,6 +32,7 @@
                 </li>
               </ul>
             </BCol>
+            <BCol cols="4" class="text-md-right"><StyleExtension :component="component" /> </BCol>
           </BRow>
           <BRow class="my-3">
             <BCol>
@@ -248,6 +249,7 @@ const sortData = computed(() =>
   props.data.map((el: ComponentReference): MappedComponentReference => {
     const data: MappedComponentReference = {
       component: el.component,
+      styleSpec: el.styleSpec,
       sourcePath: el.sourcePath,
       props: Object.entries(el.props).map(([name, {_linkTo, ...rest}]) => ({
         name,

--- a/apps/docs/src/components/StyleExtension.vue
+++ b/apps/docs/src/components/StyleExtension.vue
@@ -1,0 +1,37 @@
+<!-- eslint-disable vue/no-v-html -->
+<template>
+  <div v-if="computedKind !== StyleKind.None">
+    <a href="../configurations/customizing-styles#adding-styles">Adding styles</a>:
+    <code v-html="computedValue" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import {computed} from 'vue'
+import {type MappedComponentReference, StyleKind} from '../types'
+import {kebabCase} from '../utils'
+
+const props = defineProps<{component: MappedComponentReference}>()
+
+const computedKind = computed(() => props.component.styleSpec?.kind ?? StyleKind.BootstrapClass)
+
+const computedValue = computed(() => {
+  const componentName = props.component.component
+
+  switch (computedKind.value) {
+    case StyleKind.BootstrapClass:
+      return formatClass(componentName.substring(1))
+    case StyleKind.BsvnClass:
+      return formatClass(componentName.substring(1))
+    case StyleKind.OverrideClass:
+    case StyleKind.Tag:
+      return repalceDashes(props.component.styleSpec?.value ?? 'UNDEFINED')
+    default:
+      return 'UNDEFINED'
+  }
+})
+
+const formatClass = (value: string) => `.${repalceDashes(kebabCase(value))}`
+
+const repalceDashes = (value: string) => value.replaceAll('-', '&#8209;')
+</script>

--- a/apps/docs/src/components/TableOfContentsNav.vue
+++ b/apps/docs/src/components/TableOfContentsNav.vue
@@ -214,6 +214,10 @@ const groupComputedList = computed(() => [
         name: 'Global Options',
         route: withBase('/docs/configurations/global-options'),
       },
+      {
+        name: 'Customizing Styles',
+        route: withBase('/docs/configurations/customizing-styles'),
+      },
     ],
   },
 ])

--- a/apps/docs/src/data/components/avatar.data.ts
+++ b/apps/docs/src/data/components/avatar.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 import {linkProps, linkTo} from '../../utils/link-props'
 
@@ -7,6 +7,7 @@ export default {
   load: (): ComponentReference[] => [
     {
       component: 'BAvatar',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BAvatar/BAvatar.vue',
       props: {
         '': {
@@ -155,6 +156,7 @@ export default {
     },
     {
       component: 'BAvatarGroup',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BAvatar/BAvatarGroup.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/button.data.ts
+++ b/apps/docs/src/data/components/button.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 import {linkProps, linkTo} from '../../utils/link-props'
 
@@ -7,6 +7,7 @@ export default {
   load: (): ComponentReference[] => [
     {
       component: 'BButton',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.btn'},
       sourcePath: '/BButton/BButton.vue',
       props: {
         '': {
@@ -114,6 +115,7 @@ export default {
     },
     {
       component: 'BCloseButton',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.btn-close'},
       sourcePath: '/BButton/BCloseButton.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/buttonGroup.data.ts
+++ b/apps/docs/src/data/components/buttonGroup.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BButtonGroup',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.btn-group'},
       sourcePath: '/BButton/BButtonGroup.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/buttonToolbar.data.ts
+++ b/apps/docs/src/data/components/buttonToolbar.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BButtonToolbar',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.btn-toolbar'},
       sourcePath: '/BButton/BButtonToolbar.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/card.data.ts
+++ b/apps/docs/src/data/components/card.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, omit, pick} from '../../utils'
 import {imageProps, linkTo} from '../../utils/image-props'
 
@@ -114,6 +114,7 @@ export default {
     },
     {
       component: 'BCardBody',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.card-body, .card-img-overlay'},
       sourcePath: '/BCard/BCardBody.vue',
       emits: [],
       props: {
@@ -184,6 +185,7 @@ export default {
     },
     {
       component: 'BCardGroup',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.card-deck, .ard-group, .card-columns'},
       sourcePath: '/BCard/BCardGroup.vue',
       emits: [],
       props: {

--- a/apps/docs/src/data/components/carousel.data.ts
+++ b/apps/docs/src/data/components/carousel.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
@@ -182,6 +182,7 @@ export default {
     },
     {
       component: 'BCarouselSlide',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.carousel-item'},
       sourcePath: '/BCarousel/BCarouselSlide.vue',
       emits: [],
       props: {

--- a/apps/docs/src/data/components/form.data.ts
+++ b/apps/docs/src/data/components/form.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BForm',
+      styleSpec: {kind: StyleKind.Tag, value: 'form'},
       sourcePath: '/BForm/BForm.vue',
       props: {
         '': {
@@ -34,6 +35,7 @@ export default {
     },
     {
       component: 'BFormDatalist',
+      styleSpec: {kind: StyleKind.Tag, value: 'datalist'},
       sourcePath: '/BForm/BFormDatalist.vue',
       props: {
         '': {
@@ -86,6 +88,7 @@ export default {
 
     {
       component: 'BFormFloatingLabel',
+      styleSpec: {kind: StyleKind.OverrideClass, value: 'floating-label'},
       sourcePath: '/BForm/BFormFloatingLabel.vue',
       props: {
         '': {
@@ -115,6 +118,7 @@ export default {
     },
     {
       component: 'BFormInvalidFeedback',
+      styleSpec: {kind: StyleKind.OverrideClass, value: 'invalid-feedback, invalid-tooltip'},
       sourcePath: '/BForm/BFormInvalidFeedback.vue',
       props: {
         '': {
@@ -141,6 +145,7 @@ export default {
     },
     {
       component: 'BFormRow',
+      styleSpec: {kind: StyleKind.OverrideClass, value: 'row'},
       sourcePath: '/BForm/BFormRow.vue',
       props: {
         '': {
@@ -184,6 +189,7 @@ export default {
     },
     {
       component: 'BFormValidFeedback',
+      styleSpec: {kind: StyleKind.OverrideClass, value: 'valid-feedback, valid-tooltip'},
       sourcePath: '/BForm/BFormValidFeedback.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/formRadio.data.ts
+++ b/apps/docs/src/data/components/formRadio.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BFormRadio',
+      styleSpec: {kind: StyleKind.Tag, value: 'input[type="radio"]'},
       sourcePath: '/BFormRadio/BFormRadio.vue',
       props: {
         '': {
@@ -85,6 +86,7 @@ export default {
     },
     {
       component: 'BFormRadioGroup',
+      styleSpec: {kind: StyleKind.Tag, value: 'dev[role="radiogroup"]'},
       sourcePath: '/BFormRadio/BFormRadioGroup.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/formSelect.data.ts
+++ b/apps/docs/src/data/components/formSelect.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 const optionSlot = {
@@ -29,6 +29,7 @@ export default {
   load: (): ComponentReference[] => [
     {
       component: 'BFormSelect',
+      styleSpec: {kind: StyleKind.Tag, value: 'select'},
       sourcePath: '/BFormSelect/BFormSelect.vue',
       props: {
         '': {
@@ -110,6 +111,7 @@ export default {
     },
     {
       component: 'BFormSelectOption',
+      styleSpec: {kind: StyleKind.Tag, value: 'option'},
       sourcePath: '/BFormSelect/BFormSelectOption.vue',
       emits: [],
       props: {
@@ -135,6 +137,7 @@ export default {
     },
     {
       component: 'BFormSelectOptionGroup',
+      styleSpec: {kind: StyleKind.Tag, value: 'optgroup'},
       sourcePath: '/BFormSelect/BFormSelectOptionGroup.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/formSpinbutton.data.ts
+++ b/apps/docs/src/data/components/formSpinbutton.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BFormSpinbutton',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BFormSpinbutton/BFormSpinbutton.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/formTags.data.ts
+++ b/apps/docs/src/data/components/formTags.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BFormTag',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BFormTag/BFormTag.vue',
       props: {
         '': {
@@ -63,6 +64,7 @@ export default {
     },
     {
       component: 'BFormTags',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BFormTags/BFormTags.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/formTextarea.data.ts
+++ b/apps/docs/src/data/components/formTextarea.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BFormTextarea',
+      styleSpec: {kind: StyleKind.Tag, value: 'textarea'},
       sourcePath: '/BFormTextarea/BFormTextarea.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/gridSystem.data.ts
+++ b/apps/docs/src/data/components/gridSystem.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {buildCommonProps, pick} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BContainer',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.container[-*]'},
       sourcePath: '/BContainer/BContainer.vue',
       props: {
         '': {
@@ -116,6 +117,7 @@ export default {
     },
     {
       component: 'BCol',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.col[-*]'},
       sourcePath: '/BContainer/BCol.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/image.data.ts
+++ b/apps/docs/src/data/components/image.data.ts
@@ -1,10 +1,11 @@
-import type {ComponentReference} from '../../types'
+import {type ComponentReference, StyleKind} from '../../types'
 import {imageProps} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BImg',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BImg/BImg.vue',
       props: {
         '': imageProps,

--- a/apps/docs/src/data/components/link.data.ts
+++ b/apps/docs/src/data/components/link.data.ts
@@ -1,9 +1,10 @@
-import type {ComponentReference} from '../../types'
+import {type ComponentReference, StyleKind} from '../../types'
 import {linkProps} from '../../utils'
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BLink',
+      styleSpec: {kind: StyleKind.Tag, value: 'a, router-link'},
       sourcePath: '/BLink/BLink.vue',
       props: {
         '': linkProps,

--- a/apps/docs/src/data/components/nav.data.ts
+++ b/apps/docs/src/data/components/nav.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {
   buildCommonProps,
   dropdownEmits,
@@ -83,6 +83,7 @@ export default {
     },
     {
       component: 'BNavForm',
+      styleSpec: {kind: StyleKind.Tag, value: 'li > form'},
       sourcePath: '/BNav/BNavForm.vue',
       props: {
         '': {
@@ -169,6 +170,7 @@ export default {
     },
     {
       component: 'BNavItemDropdown',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.nav-item.dropdown'},
       sourcePath: '/BNav/BNavItemDropdown.vue',
       props: {
         '': dropdownProps,
@@ -178,6 +180,7 @@ export default {
     },
     {
       component: 'BNavText',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.navbar-text'},
       sourcePath: '/BNav/BNavText.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/offcanvas.data.ts
+++ b/apps/docs/src/data/components/offcanvas.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {showHideProps} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BOffcanvas',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.offcanvas[-*]'},
       sourcePath: '/BOffcanvas/BOffcanvas.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/overlay.data.ts
+++ b/apps/docs/src/data/components/overlay.data.ts
@@ -1,10 +1,11 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BOverlay',
+      styleSpec: {kind: StyleKind.BsvnClass},
       sourcePath: '/BOverlay/BOverlay.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/placeholder.data.ts
+++ b/apps/docs/src/data/components/placeholder.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 
 export default {
   load: (): ComponentReference[] => [
@@ -43,6 +43,7 @@ export default {
     },
     {
       component: 'BPlaceholderCard',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.card'},
       sourcePath: '/BPlaceholder/BPlaceholderCard.vue',
       emits: [],
       props: {
@@ -150,6 +151,7 @@ export default {
     },
     {
       component: 'BPlaceholderWrapper',
+      styleSpec: {kind: StyleKind.None},
       sourcePath: '/BPlaceholder/BPlaceholderWrapper.vue',
       emits: [],
       props: {
@@ -176,6 +178,7 @@ export default {
     },
     {
       component: 'BPlaceholderTable',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.table'},
       sourcePath: '/BPlaceholder/BPlaceholderTable.vue',
       emits: [],
       props: {
@@ -274,6 +277,7 @@ export default {
     },
     {
       component: 'BPlaceholderButton',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.placeholder.btn'},
       sourcePath: '/BPlaceholder/BPlaceholderButton.vue',
       emits: [],
       slots: [],

--- a/apps/docs/src/data/components/popover.data.ts
+++ b/apps/docs/src/data/components/popover.data.ts
@@ -1,11 +1,12 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 import {showHideProps} from '../../utils'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BPopover',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.tooltip, .popover'},
       sourcePath: '/BPopover/BPopover.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/spinner.data.ts
+++ b/apps/docs/src/data/components/spinner.data.ts
@@ -1,10 +1,11 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BSpinner',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.spinner-*'},
       sourcePath: '/BSpinner/BSpinner.vue',
       props: {
         '': {

--- a/apps/docs/src/data/components/table.data.ts
+++ b/apps/docs/src/data/components/table.data.ts
@@ -1,5 +1,5 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 
 export default {
   load: (): ComponentReference[] => {
@@ -557,6 +557,7 @@ export default {
       },
       {
         component: 'BTbody',
+        styleSpec: {kind: StyleKind.Tag, value: 'tbody'},
         sourcePath: '/BTable/BTbody.vue',
         props: {
           '': {
@@ -577,6 +578,7 @@ export default {
       },
       {
         component: 'BTd',
+        styleSpec: {kind: StyleKind.Tag, value: 'td'},
         sourcePath: '/BTable/BTd.vue',
         props: {
           '': {
@@ -613,6 +615,7 @@ export default {
       },
       {
         component: 'BTfoot',
+        styleSpec: {kind: StyleKind.Tag, value: 'tfoot'},
         sourcePath: '/BTable/BTfoot.vue',
         props: {
           '': {
@@ -633,6 +636,7 @@ export default {
       },
       {
         component: 'BTh',
+        styleSpec: {kind: StyleKind.Tag, value: 'th'},
         sourcePath: '/BTable/BTh.vue',
         props: {
           '': {
@@ -669,6 +673,7 @@ export default {
       },
       {
         component: 'BThead',
+        styleSpec: {kind: StyleKind.Tag, value: 'thead'},
         sourcePath: '/BTable/BThead.vue',
         props: {
           '': {
@@ -689,6 +694,7 @@ export default {
       },
       {
         component: 'BTr',
+        styleSpec: {kind: StyleKind.Tag, value: 'tr'},
         sourcePath: '/BTable/BTr.vue',
         props: {
           '': {

--- a/apps/docs/src/data/components/tabs.data.ts
+++ b/apps/docs/src/data/components/tabs.data.ts
@@ -1,10 +1,11 @@
 import type {BvnComponentProps} from 'bootstrap-vue-next'
-import type {ComponentReference, PropertyReference} from '../../types'
+import {type ComponentReference, type PropertyReference, StyleKind} from '../../types'
 
 export default {
   load: (): ComponentReference[] => [
     {
       component: 'BTab',
+      styleSpec: {kind: StyleKind.OverrideClass, value: '.tab-pane'},
       sourcePath: '/BTabs/BTab.vue',
       props: {
         '': {

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -252,8 +252,6 @@ should provide some means of notification to the user as to why the tab is not a
 It is recommended to use the `disabled` attribute on the `<BTab>` component instead of using the
 `activate-tab` event (as `disabled` is more intuitive for screen reader users).
 
-<ComponentReference :data="data" />
-
 ## Advanced examples
 
 ### External controls using `v-model`
@@ -263,6 +261,8 @@ It is recommended to use the `disabled` attribute on the `<BTab>` component inst
 ### Dynamic tabs + tabs-end slot
 
 <<< DEMO ./demo/TabsDynamic.vue
+
+<ComponentReference :data="data" />
 
 <script lang="ts">
 import {data} from '../../data/components/tabs.data'

--- a/apps/docs/src/docs/configurations/customizing-styles.md
+++ b/apps/docs/src/docs/configurations/customizing-styles.md
@@ -1,0 +1,52 @@
+# Customizing Styles
+
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+## Bootstrap Customization
+
+There are many ways to customize the underlying [Bootstrap](https://getbootstrap.com/) styles. See
+[their documentation](https://getbootstrap.com/docs/5.3/customize/sass/#importing)
+for how to import customized styles
+
+## Adding styles
+
+It's common to want to enhance or modifiy the styles for a specific component. This can be done
+easily if you can determine a `.css` selector to use to specify the additional styles (and if
+you include your stylesheet after the bootstrap and bootstrap-vue-next style sheets, you can
+even override styles).
+
+Unfortunately, there isn't a full-proof pattern for determining the `.css` selector to use for each
+class, so we've included this information in the reference section for each component.
+
+The pattern for these selectors is as follows.
+
+Most components in `boostrap-vue-next` have a class attached to them on which you can add styles.
+This is often the class that triggers the bootstrap behaviors. For instance, the `BTable` component
+has a class called `table` class and `BAccordion` has a class called `accordion` both of which are
+defined by `bootstrap` and added by `bootstrap-vue-next` to trigger the bootstrap styling on the components.
+
+For most of the components where `bootstrap` doesn't define a class to trigger its behaviors, we've
+added a class of our own, which you can use to add styles. For instance, `bootstrap 5`
+[deprecated](https://getbootstrap.com/) the use of `form-group` along with other form-specific classes.
+So there was no easy way to add styling to `BFormGroup` other than wrapping it in your own component,
+which introduces additional overhead. So we've added the `b-form-group` class.
+
+See this [stack-blitz example](https://stackblitz.com/edit/github-lgg91u-usex9n?file=src%2FApp.vue).
+
+Another pattern is for components that are tightly tied to a `tag`, so adding
+styles should be done via the tag name. For instance, the `BForm` always generates its main
+element with the `form` tag.
+
+Finally, there are a number of variations where there isn't a single class or tag. Where these
+cases can be represented by `.css` selectors they are. For instance a popover may be defined
+by one of two classes, so you can use the css selector `.tooltip, .popover` to add styles to both
+(although you may well wan to style the tooltip and popover variations seperately). In cases where
+like the grid system classes, where there may be many different versions of the class defined by
+the breakpoints, we're simply using a placeholder such as `col[-*]` to represent `col`, `col-sm`,
+`col-md`, etc.

--- a/apps/docs/src/docs/configurations/global-options.md
+++ b/apps/docs/src/docs/configurations/global-options.md
@@ -1,5 +1,15 @@
 # Global options
 
+<ClientOnly>
+  <Teleport to=".bd-toc">
+
+[[toc]]
+
+  </Teleport>
+</ClientOnly>
+
+## Overview
+
 Global configurations allow you to set default prop values for all Vue components in your application. This is achieved using the createBootstrap plugin. Here's an example:
 
 ```ts

--- a/apps/docs/src/types/index.ts
+++ b/apps/docs/src/types/index.ts
@@ -29,8 +29,22 @@ export interface PropertyReference {
  */
 type PropsRecord = Record<string, Record<string, PropertyReference> & {_linkTo?: PropertyReference}>
 
+export enum StyleKind {
+  BootstrapClass = 'BOOTSTRAP-CLASS',
+  BsvnClass = 'BSVN-CLASS',
+  OverrideClass = 'OVERRIDE-CLASS',
+  Tag = 'TAG',
+  None = 'NONE',
+}
+
+export interface StyleSpec {
+  kind: StyleKind
+  value?: string
+}
+
 export interface ComponentReference {
   component: string
+  styleSpec?: StyleSpec
   /**
    * Use package directory relative links. ex: BAccordion.vue => /BAccordion/BAccordion.vue (slash required)
    *


### PR DESCRIPTION
# Describe the PR

This documents the CSS selectors that can be used to add styles to each component, as discussed [here](https://github.com/bootstrap-vue-next/bootstrap-vue-next/pull/2344#issuecomment-2481806547)

This ended up having more corner cases than I hoped, but if I'm reading the code correctly, I believe I've documented them all. The one component that I couldn't determine a CSS selector to uniquely identify was BSkelotonWrapper. I don't think that matters, though.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
