### PR TITLE
fix(BCollapse): reintroduce `closing` class to restore toggle state logic

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
+++ b/packages/bootstrap-vue-next/src/components/BCollapse/BCollapse.vue
@@ -4,7 +4,7 @@
     v-if="renderRef || contentShowing"
     v-bind="transitionProps"
     :enter-active-class="computedNoAnimation ? '' : 'collapsing'"
-    :leave-active-class="computedNoAnimation ? '' : 'collapsing'"
+    :leave-active-class="computedNoAnimation ? '' : 'collapsing closing'"
     :appear="modelValue || props.visible"
   >
     <component


### PR DESCRIPTION
# Describe the PR
The `closing` class was previously removed in commit 673529d86d35b8052d12ab7d1d8aa73028b269b6. Its absence broke the logic for applying `collapsed` and `not-collapsed` classes to the toggle button. Reintroducing the `closing` class in the collapse transitions fixes this behavior.

fixes #2412

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
