### PR TITLE
docs: Enable optional type-checking and clean up several issues

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,3 +1,3 @@
 components.d.ts
-
+tsconfig.app.tsbuildinfo
 .vitepress/cache

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vitepress dev --port 8000",
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vitepress build",
+    "type-check": "vue-tsc --noEmit -p tsconfig.app.json",
     "preview": "vitepress preview",
     "lint": "eslint --fix src",
     "test:lint": "eslint src",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev --port 8000",
-    "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vitepress build",
+    "build-only": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vitepress build",
     "type-check": "vue-tsc --noEmit -p tsconfig.app.json",
+    "build": "pnpm run build-only",
     "preview": "vitepress preview",
     "lint": "eslint --fix src",
     "test:lint": "eslint src",

--- a/apps/docs/src/data/components/tabs.data.ts
+++ b/apps/docs/src/data/components/tabs.data.ts
@@ -150,6 +150,10 @@ export default {
             type: 'boolean',
             default: false,
           },
+          noKeyNav: {
+            type: 'boolean',
+            default: false,
+          },
           noNavStyle: {
             type: 'boolean',
             default: false,
@@ -165,6 +169,10 @@ export default {
           tag: {
             type: 'string',
             default: 'div',
+          },
+          underline: {
+            type: 'boolean',
+            default: false,
           },
           tabClass: {
             type: 'ClassValue',

--- a/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-const alertEvent = (event: PointerEvent) => {
+const alertEvent = (event: MouseEvent) => {
   // eslint-disable-next-line no-alert
   alert(`Event ${event.target}`)
 }

--- a/apps/docs/src/docs/components/demo/CardBorderedVariants.vue
+++ b/apps/docs/src/docs/components/demo/CardBorderedVariants.vue
@@ -29,12 +29,7 @@
       <BCard border-variant="info" header="Info" align="center">
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard
-        border-variant="warning"
-        header="Warning"
-        header-bg-variant="transparent"
-        align="center"
-      >
+      <BCard border-variant="warning" header="Warning" align="center">
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
       <BCard

--- a/apps/docs/src/docs/demo/SyncAfter.vue
+++ b/apps/docs/src/docs/demo/SyncAfter.vue
@@ -5,3 +5,9 @@
   </BFormCheckbox>
   <!-- #endregion template -->
 </template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const checked = ref(false)
+const indeterminate = ref(false)
+</script>

--- a/apps/docs/src/docs/demo/SyncBefore.vue
+++ b/apps/docs/src/docs/demo/SyncBefore.vue
@@ -1,7 +1,14 @@
+<!-- eslint-disable vue/no-deprecated-v-bind-sync -->
 <template>
   <!-- #region template -->
-  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate"
+  <BFormCheckbox v-model="checked" :indeterminate.sync="indeterminate"
     >Click me to see what happens</BFormCheckbox
   >
   <!-- #endregion template -->
 </template>
+
+<script setup lang="ts">
+import {ref} from 'vue'
+const checked = ref(false)
+const indeterminate = ref(false)
+</script>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prepare": "husky && turbo run build",
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
+    "build-only": "turbo run build-only",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "test:lint": "turbo run test:lint",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "lint": "turbo run lint",
+    "type-check": "turbo run type-check",
     "test:lint": "turbo run test:lint",
     "test:unit": "turbo run test:unit",
     "test:coverage": "turbo run test:coverage",

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "build-only": {
+      "dependsOn": ["^build-only"],
+      "outputs": ["dist/**"]
+    },
     "test": {
       "outputs": []
     },

--- a/turbo.json
+++ b/turbo.json
@@ -50,6 +50,9 @@
         "**/*.test.js"
       ]
     },
+    "type-check": {
+      "outputs": []
+    },
     "lint": {
       "outputs": []
     },


### PR DESCRIPTION
# Describe the PR

See #2418 

This PR sets up a type-check command for docs and cleans up the errors in component reference data and samples.

I'll chip away at the other errors as time permits

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
