### PR TITLE
fix(RadiusElement): Add 'md' value

### DIFF
--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -364,6 +364,7 @@ type RadiusElement =
   | 'pill'
   | 'none'
   | 'sm'
+  | 'md'
   | 'lg'
   | '0'
   | '1'

--- a/packages/bootstrap-vue-next/src/types/RadiusElement.ts
+++ b/packages/bootstrap-vue-next/src/types/RadiusElement.ts
@@ -3,6 +3,7 @@ export type RadiusElement =
   | 'pill'
   | 'none'
   | 'sm'
+  | 'md'
   | 'lg'
   | '0'
   | '1'


### PR DESCRIPTION
# Describe the PR

I believe that `RadiusElement` should include a `md` value. My guess it that it was left out because in most cases this is the default. But when going through the `BAvatar` examples with linting enabled, we have cases where we want to explicitly set one edge to 'md' when the rest of the avatar defaults to 'circle'. If there is a reason to have a type that doesn't include 'md' we can split it out, but I'm not seeing one right now.

## Small replication

https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/avatar.html#rounding

```vue
<BAvatar rounded-start="md" />
<BAvatar rounded-end="md" />
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
