### PR TITLE
fix(BTable): reflect single select mode on programmatic selection

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -956,14 +956,18 @@ const exposedSelectableUtilities = {
     selectedItemsSetUtilities.clear()
   },
   selectAllRows: () => {
-    if (!props.selectable) return
+    if (!props.selectable || props.selectMode === 'single') return
     selectedItemsToSet.value = new Set([...computedItems.value])
   },
   selectRow: (index: number) => {
     if (!props.selectable) return
     const item = computedItems.value[index]
     if (!item || selectedItemsSetUtilities.has(item)) return
-    selectedItemsSetUtilities.add(item)
+    if (props.selectMode === 'single') {
+      selectedItemsSetUtilities.set([item])
+    } else {
+      selectedItemsSetUtilities.add(item)
+    }
   },
   unselectRow: (index: number) => {
     if (!props.selectable) return


### PR DESCRIPTION
# Describe the PR

closes #2433 

This pull request changes the behavior when programmatically selecting a row in a BTable:

If the select mode is "single":
- only the row with the passed id will be selected
- selectAllRows() will return without performing an action


## Small replication

See: #2433 

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
