### PR TITLE
docs: Fix type errors in  OpenCollective components

### DIFF
--- a/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
+++ b/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
@@ -66,6 +66,7 @@
 
 <script setup lang="ts">
 import {type CollectiveMembersResponse, type CollectivePartialResponse} from '../types'
+// @ts-expect-error - Vitepress isn't correctly mocking the type in this case
 import {data} from '../data/opencollective.data'
 
 const OpenCollectiveData = data as CollectivePartialResponse

--- a/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
+++ b/apps/docs/src/components/OpenCollectiveMemberDisplay.vue
@@ -65,11 +65,22 @@
 </template>
 
 <script setup lang="ts">
-import {data as OpenCollectiveData} from '../data/opencollective.data'
+import {type CollectiveMembersResponse, type CollectivePartialResponse} from '../types'
+import {data} from '../data/opencollective.data'
+
+const OpenCollectiveData = data as CollectivePartialResponse
 
 const filteredKeys = ['HOST', 'FOLLOWER']
+const roleNames = ['ADMIN', 'CONTRIBUTOR', 'BACKER'] as const
+type RoleNames = (typeof roleNames)[number]
+
+type RoleGroups = Record<RoleNames, CollectiveMembersResponse[]>
 const filteredMembers = OpenCollectiveData.members.filter((el) => !filteredKeys.includes(el.role))
-const groupedCollectiveMembers = Object.groupBy(filteredMembers, (el) => el.role)
+const groupedCollectiveMembers: RoleGroups = {
+  ...Object.fromEntries(roleNames.map((role) => [role, []])),
+  ...Object.groupBy(filteredMembers, (el) => el.role),
+} as RoleGroups
+
 /**
  * Profiles are used because for some reason MemberIds are not the same between roles?
  */
@@ -96,22 +107,33 @@ const inactiveFinancialBackers = groupedCollectiveMembers.BACKER.filter((el) => 
   const lastTransactionDate = new Date(el.lastTransactionAt)
   return lastTransactionDate < oneYearAgo && lastTransactionDate >= twoYearsAgo
 })
-// Grouping active financial backers by tier
-const groupedActiveFinancialBackers = Object.groupBy(activeFinancialBackers, (el) => el.tier)
 
-/**
- * The priority of the tiers
- */
-const sortTiers = [
+// Grouping active financial backers by tier
+
+const tierNames = [
   'Platinum Sponsor',
   'Gold Sponsor',
   'Silver Sponsor',
   'Bronze Sponsor',
   'Sponsor',
   'Backer',
-].filter((el) =>
+] as const
+
+type TierNames = (typeof tierNames)[number]
+
+type BackerGroups = Partial<Record<TierNames, CollectiveMembersResponse[]>>
+
+const groupedActiveFinancialBackers: BackerGroups = Object.groupBy(
+  activeFinancialBackers,
+  (el) => el.tier
+)
+
+/**
+ * The priority of the tiers
+ */
+const sortTiers = tierNames.filter((el) =>
   Object.keys(groupedActiveFinancialBackers)
     .map((v) => v.toLowerCase())
     .includes(el.toLowerCase())
-)
+) as (keyof BackerGroups)[]
 </script>

--- a/apps/docs/src/components/OpenCollectiveMemberDisplayAvatarCard.vue
+++ b/apps/docs/src/components/OpenCollectiveMemberDisplayAvatarCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-wrap justify-content-center">
+  <div v-if="members" class="d-flex flex-wrap justify-content-center">
     <BCard
       v-for="member in members"
       :key="member.MemberId"
@@ -8,7 +8,7 @@
       <template #img>
         <BAvatar
           class="mt-2"
-          :src="member.image"
+          :src="member.image ?? undefined"
           :href="member.profile"
           target="_blank"
           :alt="member.name"
@@ -31,9 +31,9 @@
 </template>
 
 <script setup lang="ts">
-import type {CollectiveMembersResponse} from '../data/opencollective.data'
+import type {CollectiveMembersResponse} from '../types'
 
 defineProps<{
-  members: CollectiveMembersResponse[]
+  members?: CollectiveMembersResponse[]
 }>()
 </script>

--- a/apps/docs/src/data/opencollective.data.ts
+++ b/apps/docs/src/data/opencollective.data.ts
@@ -4,11 +4,6 @@ const collectiveSlug = 'bootstrap-vue-next'
 const openCollectiveBaseURL = 'https://opencollective.com'
 const openCollectiveMembersFetchUrl = `${openCollectiveBaseURL}/${collectiveSlug}/members/all.json`
 
-// This is a stubbed export to satisfy typescript, for some reason
-//  the generated export from vitepress data isn't being recognized in this case
-//  but vitepress is generating the correct export at runtime
-export const data: CollectivePartialResponse = {members: []}
-
 export default {
   load: async (): Promise<CollectivePartialResponse> => {
     const response = await fetch(openCollectiveMembersFetchUrl)

--- a/apps/docs/src/data/opencollective.data.ts
+++ b/apps/docs/src/data/opencollective.data.ts
@@ -1,33 +1,16 @@
-export type CollectiveMembersResponse = {
-  MemberId: number
-  createdAt: string
-  type: string
-  role: string
-  tier: string
-  isActive: boolean
-  totalAmountDonated: number
-  currency: string
-  lastTransactionAt: string
-  lastTransactionAmount: number
-  profile: string
-  name: string
-  company: null | null
-  description: string | null
-  image: string | null
-  email: null | string
-  twitter: null | string
-  github: string | null
-  website: null | string
-}
+import {type CollectivePartialResponse} from '../types'
 
 const collectiveSlug = 'bootstrap-vue-next'
 const openCollectiveBaseURL = 'https://opencollective.com'
 const openCollectiveMembersFetchUrl = `${openCollectiveBaseURL}/${collectiveSlug}/members/all.json`
 
+// This is a stubbed export to satisfy typescript, for some reason
+//  the generated export from vitepress data isn't being recognized in this case
+//  but vitepress is generating the correct export at runtime
+export const data: CollectivePartialResponse = {members: []}
+
 export default {
-  load: async (): Promise<{
-    members: CollectiveMembersResponse[]
-  }> => {
+  load: async (): Promise<CollectivePartialResponse> => {
     const response = await fetch(openCollectiveMembersFetchUrl)
     const data = await response.json()
     return {

--- a/apps/docs/src/types/index.ts
+++ b/apps/docs/src/types/index.ts
@@ -68,3 +68,29 @@ export interface ComponentReference {
 export type MappedComponentReference = Omit<ComponentReference, 'props'> & {
   props: {name: string; linkTo?: string; ref: (PropertyReference & {prop: string})[]}[]
 }
+
+export type CollectiveMembersResponse = {
+  MemberId: number
+  createdAt: string
+  type: string
+  role: string
+  tier: string
+  isActive: boolean
+  totalAmountDonated: number
+  currency: string
+  lastTransactionAt: string
+  lastTransactionAmount: number
+  profile: string
+  name: string
+  company: null | null
+  description: string | null
+  image: string | null
+  email: null | string
+  twitter: null | string
+  github: string | null
+  website: null | string
+}
+
+export type CollectivePartialResponse = {
+  members: CollectiveMembersResponse[]
+}


### PR DESCRIPTION
# Describe the PR

General clean-up of types in the OpenCollective components, mostly to do with grouping resulting in unknown types and how to deal with the possibility of null members in the resulting groups.

The other is that for some reason, while [vitepress build time data loading](https://vitepress.dev/guide/data-loading#build-time-data-loading) is working, whatever magic they are using to lie to typescript to tell it that the `*.data.ts` file contains a named export called `data` isn't working. I wasn't able to find an existing but on vitepress about this. However, I was able to work around it by stubbing the `data` export. This fixes typescript, and doesn't break the data loading - would be delighted with a better solution if anyone has one.

```
Module '"../data/opencollective.data"' has no exported member 'data'. Did you mean to use 'import data from "../data/opencollective.data"' instead?
```

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
