### PR TITLE
docs: use page header data to build "on this page" table of contents

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -56,5 +56,6 @@ export default defineConfig({
       md.use(markdownItClass, {table: ['table', 'table-striped']})
       md.use(demoContainer, 'src')
     },
+    headers: true,
   },
 })

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -137,7 +137,7 @@
                 header-class="pb-0 d-flex offcanvas-hidden-width"
                 body-class="py-2"
               >
-                <div class="bd-toc" />
+                <PageContents />
               </BOffcanvas>
             </ClientOnly>
           </aside>
@@ -180,7 +180,6 @@ import CircleHalf from '~icons/bi/circle-half'
 import {useData, useRoute, withBase} from 'vitepress'
 import {appInfoKey} from './keys'
 import {useMediaQuery} from '@vueuse/core'
-import TableOfContentsNav from '../../src/components/TableOfContentsNav.vue'
 import VPNavBarSearch from 'vitepress/dist/client/theme-default/components/VPNavBarSearch.vue'
 
 // https://vitepress.dev/reference/runtime-api#usedata

--- a/apps/docs/src/components/ComponentSidebar.vue
+++ b/apps/docs/src/components/ComponentSidebar.vue
@@ -1,7 +1,0 @@
-<template>
-  <ContentsSidebar>
-    <template #default>
-      <PageContents />
-    </template>
-  </ContentsSidebar>
-</template>

--- a/apps/docs/src/components/ComponentSidebar.vue
+++ b/apps/docs/src/components/ComponentSidebar.vue
@@ -1,20 +1,7 @@
 <template>
   <ContentsSidebar>
     <template #default>
-      <slot />
-    </template>
-    <template #after>
-      <nav class="table-of-contents">
-        <ul>
-          <li>
-            <a href="#component-reference">Component Reference</a>
-          </li>
-        </ul>
-      </nav>
+      <PageContents />
     </template>
   </ContentsSidebar>
 </template>
-
-<script setup lang="ts">
-import ContentsSidebar from './ContentsSidebar.vue'
-</script>

--- a/apps/docs/src/components/ContentsSidebar.vue
+++ b/apps/docs/src/components/ContentsSidebar.vue
@@ -1,5 +1,0 @@
-<template>
-  <ClientOnly>
-    <Teleport to=".bd-toc"><slot /><slot name="after" /></Teleport>
-  </ClientOnly>
-</template>

--- a/apps/docs/src/components/PageContents.vue
+++ b/apps/docs/src/components/PageContents.vue
@@ -4,7 +4,7 @@
       <li v-for="header in headers" :key="header.slug">
         <PageContentsItem :item="header" />
       </li>
-      <li>
+      <li v-if="isComponentPage">
         <a href="#component-reference">Component Reference</a>
       </li>
     </ul>
@@ -17,4 +17,5 @@ import {useData} from 'vitepress'
 
 const data = useData()
 const headers = computed(() => data.page.value.headers)
+const isComponentPage = computed(() => data.page.value.relativePath.includes('/components/'))
 </script>

--- a/apps/docs/src/components/PageContents.vue
+++ b/apps/docs/src/components/PageContents.vue
@@ -1,0 +1,20 @@
+<template>
+  <nav v-if="headers.length > 0" class="table-of-contents">
+    <ul>
+      <li v-for="header in headers" :key="header.slug">
+        <PageContentsItem :item="header" />
+      </li>
+      <li>
+        <a href="#component-reference">Component Reference</a>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import {computed} from 'vue'
+import {useData} from 'vitepress'
+
+const data = useData()
+const headers = computed(() => data.page.value.headers)
+</script>

--- a/apps/docs/src/components/PageContentsItem.vue
+++ b/apps/docs/src/components/PageContentsItem.vue
@@ -1,0 +1,16 @@
+<template>
+  <li>
+    <a :href="item.link">{{ item.title }}</a>
+    <ul v-if="item.children?.length > 0">
+      <PageContentsItem v-for="child in item.children" :key="child.slug" :item="child" />
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import {type Header} from 'vitepress'
+
+defineProps<{
+  item: Header
+}>()
+</script>

--- a/apps/docs/src/docs.md
+++ b/apps/docs/src/docs.md
@@ -1,13 +1,5 @@
 # Introduction
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
-
-[[toc]]
-
-  </Teleport>
-</ClientOnly>
-
 <div class="lead">
 
 Get started with BootstrapVueNext and Bootstrap `v5`, the world’s most popular framework for building responsive, mobile-first sites.

--- a/apps/docs/src/docs/components/accordion.md
+++ b/apps/docs/src/docs/components/accordion.md
@@ -1,7 +1,5 @@
 # Accordion
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Build vertically collapsing accordions in combination with `BCollapse` component.

--- a/apps/docs/src/docs/components/accordion.md
+++ b/apps/docs/src/docs/components/accordion.md
@@ -1,10 +1,6 @@
 # Accordion
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -1,10 +1,6 @@
 # Alert
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -1,7 +1,5 @@
 # Alert
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages.

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -1,7 +1,5 @@
 # Avatar
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Avatars are a custom component, and are typically used to display a user profile as a

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -1,10 +1,6 @@
 # Avatar
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -1,7 +1,5 @@
 # Badge
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Documentation and examples for badges, our small count and labeling component.
@@ -221,6 +219,5 @@ Quickly provide actionable badges by specifying either the `href` prop (links) o
 import {data} from '../../data/components/badge.data'
 import {BButton, BBadge} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -1,10 +1,6 @@
 # Badge
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -1,10 +1,6 @@
 # Breadcrumb
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -1,7 +1,5 @@
 # Breadcrumb
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Indicate the current page’s location within a navigational hierarchy that automatically adds separators via CSS.

--- a/apps/docs/src/docs/components/button-group.md
+++ b/apps/docs/src/docs/components/button-group.md
@@ -1,10 +1,6 @@
 # Button Group
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/button-group.md
+++ b/apps/docs/src/docs/components/button-group.md
@@ -1,7 +1,5 @@
 # Button Group
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Group a series of buttons together on a single line or stack them in a vertical column with `BButtonGroup`.
@@ -181,6 +179,5 @@ toolbars containing button groups and input groups.
 import {data} from '../../data/components/buttonGroup.data'
 import {BDropdownItem, BDropdownDivider, BButton, BButtonGroup, BDropdown} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/button-toolbar.md
+++ b/apps/docs/src/docs/components/button-toolbar.md
@@ -1,7 +1,5 @@
 # Button Toolbar
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Group a series of button-groups and/or input-groups together on a single line.
@@ -259,6 +257,5 @@ input groups and dropdowns, by setting the prop `justify`.
 import {data} from '../../data/components/buttonToolbar.data'
 import {BButtonGroup, BDropdown, BInputGroup, BDropdownItem, BButton, BButtonToolbar, BFormInput} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 </script>

--- a/apps/docs/src/docs/components/button-toolbar.md
+++ b/apps/docs/src/docs/components/button-toolbar.md
@@ -1,10 +1,6 @@
 # Button Toolbar
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -1,7 +1,5 @@
 # Button
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Use Bootstrap's custom `BButton` component for actions in forms, dialogs, and more. Includes support for a handful of contextual variations, sizes, states, and more.
@@ -413,7 +411,6 @@ import {data} from '../../data/components/button.data'
 import {ref, computed} from 'vue'
 import {BButtonGroup, BButton} from 'bootstrap-vue-next'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import NotYetImplemented from '../../components/NotYetImplemented.vue'
 

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -1,10 +1,6 @@
 # Button
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -1,10 +1,6 @@
 # Card
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -1,7 +1,5 @@
 # Card
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 A card is a flexible and extensible content container. It includes options for headers and footers, a wide variety of content, contextual background colors, and powerful display options.

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -1,7 +1,5 @@
 # Carousel
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 The carousel is a slideshow for cycling through a series of content. It works with a series of images, text,

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -1,10 +1,6 @@
 # Carousel
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -1,7 +1,5 @@
 # Collapse
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Easily toggle visibility of almost any content on your pages in a vertically collapsing container.

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -1,10 +1,6 @@
 # Collapse
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -1,10 +1,6 @@
 # Dropdown
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -1,7 +1,5 @@
 # Dropdown
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Dropdowns are toggleable, contextual overlays for displaying lists of links and actions in a dropdown menu format.

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -1,10 +1,6 @@
 # Form Checkbox
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -1,7 +1,5 @@
 # Form Checkbox
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 For cross browser consistency, `BFormCheckboxGroup` and `BFormCheckbox` use Bootstrap's custom checkbox input to replace the browser default checkbox input. It is built on top of semantic and accessible markup, so it is a solid replacement for the default checkbox input.

--- a/apps/docs/src/docs/components/form-file.md
+++ b/apps/docs/src/docs/components/form-file.md
@@ -1,10 +1,6 @@
 # Form File
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-file.md
+++ b/apps/docs/src/docs/components/form-file.md
@@ -1,7 +1,5 @@
 # Form File
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 File input control that supports single and multiple file modes
@@ -227,7 +225,6 @@ The BFormFile exposes functions to control the component: `focus(), blur(), rese
 <script setup lang="ts">
 import {data} from '../../data/components/formFile.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BFormFile, BAlert, BLink} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -1,10 +1,6 @@
 # Form Group
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -1,7 +1,5 @@
 # Form Group
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 The `BFormGroup` component is the easiest way to add some structure to forms. Its purpose is to pair form controls with a legend or label, and to provide help text and invalid/valid feedback text, as well as visual (color) contextual state feedback.
@@ -495,7 +493,6 @@ scoped `default` slot.
 <script setup lang="ts">
 import {data} from '../../data/components/formGroup.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BFormRadioGroup, BFormGroup, BFormInput} from 'bootstrap-vue-next'
 import {computed, ref} from 'vue'

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -1,7 +1,5 @@
 # Form Input
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Create various type inputs such as: `text`, `password`, `number`, `url`, `email`, `search`, `range`, `date` and more.
@@ -693,7 +691,6 @@ const selectAllText = () => inputRef?.value?.element?.select()
 <script setup lang="ts">
 import {data} from '../../data/components/formInput.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import NotYetImplemented from '../../components/NotYetImplemented.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BButton, BFormText, BFormInvalidFeedback, BRow, BCol, BContainer, BCard, BCardBody, BFormInput } from 'bootstrap-vue-next'

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -1,10 +1,6 @@
 # Form Input
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-radio.md
+++ b/apps/docs/src/docs/components/form-radio.md
@@ -1,10 +1,6 @@
 # Form Radio
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-radio.md
+++ b/apps/docs/src/docs/components/form-radio.md
@@ -1,7 +1,5 @@
 # Form Radio
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 For cross browser consistency, `BFormRadioGroup` and `BFormRadio` uses Bootstrap's custom radio input to replace the browser default radio input. It is built on top of semantic and accessible markup, so it is a solid replacement for the default radio input.

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -1,7 +1,5 @@
 # Form Select
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Bootstrap custom `<select>` using custom styles. Optionally specify options based on an array, array of objects, or an object.

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -1,10 +1,6 @@
 # Form Select
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-spinbutton.md
+++ b/apps/docs/src/docs/components/form-spinbutton.md
@@ -1,7 +1,5 @@
 # Form Spinbutton
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 The Form SpinButton allows the user to adjusting a numeric range with finite control
@@ -343,7 +341,6 @@ Note the the `repeat-delay`, `repeat-threshold` and `repeat-interval` only appli
 <script setup lang="ts">
 import {data} from '../../data/components/formSpinbutton.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BButton, BProgressBar, BCard, BCardBody, BProgress, BFormSpinbutton, BFormSelect, BRow, BCol} from 'bootstrap-vue-next'
 import {ref} from 'vue'

--- a/apps/docs/src/docs/components/form-spinbutton.md
+++ b/apps/docs/src/docs/components/form-spinbutton.md
@@ -1,10 +1,6 @@
 # Form Spinbutton
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -1,7 +1,5 @@
 # Form Tags
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Lightweight custom tagged input form control, with options for customized interface rendering, duplicate tag detection and optional tag validation.
@@ -1046,7 +1044,6 @@ Note `<BFormTag>` requires BootstrapVueNext's custom CSS/SCSS for proper styling
 <script setup lang="ts">
   import {data} from '../../data/components/formTags.data'
   import ComponentReference from '../../components/ComponentReference.vue'
-  import ComponentSidebar from '../../components/ComponentSidebar.vue'
   import HighlightCard from '../../components/HighlightCard.vue'
   import {BFormTags, BFormText, BFormGroup, BInputGroupText, BButton, BCard, BInputGroup, BFormTag, BFormInput, BFormSelect, BFormCheckbox, BFormInvalidFeedback, BDropdownForm, BDropdownDivider, BDropdownItemButton, BDropdownText, BDropdown} from 'bootstrap-vue-next'
   import {ref, computed, watch} from 'vue'

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -1,10 +1,6 @@
 # Form Tags
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 
@@ -1116,11 +1112,11 @@ Note `<BFormTag>` requires BootstrapVueNext's custom CSS/SCSS for proper styling
   const customDropdownOptions = ref<string[]>(['Apple', 'Orange', 'Banana', 'Lime', 'Peach', 'Chocolate', 'Strawberry'])
   const customDropdownSearch = ref<string>('')
   const customDropdownTags = ref<string[]>([])
-  
+
   const criteria = computed(() => customDropdownSearch.value.trim().toLowerCase())
   const customDropdownAvailableOptions = computed(() => {
   const searchCriteria = criteria.value
-  
+
   // Filter out already selected options
   const optionsFiltered = customDropdownOptions.value.filter(opt => customDropdownTags.value.indexOf(opt) === -1)
     if (searchCriteria) {

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -1,10 +1,6 @@
 # Form Textarea
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -1,7 +1,5 @@
 # Form Textarea
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Create multi-line text inputs with support for auto height sizing, minimum and maximum number of rows, and contextual states.

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -1,7 +1,5 @@
 # Form
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 BootstrapVueNext form component and helper components that optionally support inline form styles and
@@ -547,7 +545,6 @@ for details on the Bootstrap v5 validation states.
 <script setup lang="ts">
 import {data} from '../../data/components/form.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import NotYetImplemented from '../../components/NotYetImplemented.vue'
 import {

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -1,10 +1,6 @@
 # Form
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/grid-system.md
+++ b/apps/docs/src/docs/components/grid-system.md
@@ -1,7 +1,5 @@
 # Grid System
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Use the powerful mobile-first flexbox grid (via the `<BContainer>`, `<BRow>` and

--- a/apps/docs/src/docs/components/grid-system.md
+++ b/apps/docs/src/docs/components/grid-system.md
@@ -1,10 +1,6 @@
 # Grid System
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -1,10 +1,6 @@
 # Image
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -1,7 +1,5 @@
 # Image
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Documentation and examples for opting images (via `BImg` component) into responsive behavior (so they never become larger than their parent elements), optionally adding lightweight styles to them — all via props.

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -1,10 +1,6 @@
 # Input Group
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -1,7 +1,5 @@
 # Input Group
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Easily extend form controls by adding text, buttons, or button groups on either side of textual inputs.
@@ -470,7 +468,6 @@ input groups. However, the inputs inside the input group do support contextual s
 <script setup lang="ts">
 import {data} from '../../data/components/inputGroup.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import NotYetImplemented from '../../components/NotYetImplemented.vue'
 import {

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -1,10 +1,6 @@
 # Link
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -1,7 +1,5 @@
 # Link
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Use BootstrapVue's custom b-link component for generating a standard `<a>` link or `RouterLink`. `BLink` supports the `disabled` state and `click` event propagation.
@@ -326,7 +324,6 @@ a.disabled {
 <script setup lang="ts">
 import {data} from '../../data/components/link.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import NoteAlert from '../../components/NoteAlert.vue'
 import {BLink, BCard, BCardBody} from 'bootstrap-vue-next'

--- a/apps/docs/src/docs/components/list-group.md
+++ b/apps/docs/src/docs/components/list-group.md
@@ -1,7 +1,5 @@
 # List Group
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 List Groups are a flexible and powerful component for displaying a series of content. List Group items can be modified to support just about any content within. They can also be used as navigation via various props.

--- a/apps/docs/src/docs/components/list-group.md
+++ b/apps/docs/src/docs/components/list-group.md
@@ -1,10 +1,6 @@
 # List Group
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -1,7 +1,5 @@
 # Modal
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Modals are streamlined, but flexible dialog prompts powered by JavaScript and CSS. They support a number of use cases from user notification to completely custom content and feature a handful of helpful sub-components, sizes, variants, accessibility, and more.
@@ -226,7 +224,6 @@ If you're looking for replacements for `$bvModal.msgBoxOk` and `$bvModal.msgBoxC
 <script setup lang="ts">
 import {data} from '../../data/components/modal.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BModal, BButton, vBModal} from 'bootstrap-vue-next'
 import {ref, nextTick} from 'vue'

--- a/apps/docs/src/docs/components/modal.md
+++ b/apps/docs/src/docs/components/modal.md
@@ -1,10 +1,6 @@
 # Modal
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/nav.md
+++ b/apps/docs/src/docs/components/nav.md
@@ -1,7 +1,5 @@
 # Nav
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Navigation available in Bootstrap share general markup and styles, from the base `<BNav>` class

--- a/apps/docs/src/docs/components/nav.md
+++ b/apps/docs/src/docs/components/nav.md
@@ -1,10 +1,6 @@
 # Nav
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -1,7 +1,5 @@
 # Navbar
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 The component `BNavbar` is a wrapper that positions branding, navigation, and other elements into a concise header. It is easily extensible and thanks to the `BCollapse` component, it can easily integrate responsive behaviors.

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -1,10 +1,6 @@
 # Navbar
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/offcanvas.md
+++ b/apps/docs/src/docs/components/offcanvas.md
@@ -1,7 +1,5 @@
 # Offcanvas
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Build hidden sidebars into your project. Sidebars can aid in enhancing user interaction or preventing further interaction.
@@ -96,7 +94,6 @@ In SSR environments, the BOffcanvas component must be rendered client-side due t
 <script setup lang="ts">
 import {data} from '../../data/components/offcanvas.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BOffcanvas, BButton} from 'bootstrap-vue-next'
 import {ref, computed} from 'vue'

--- a/apps/docs/src/docs/components/offcanvas.md
+++ b/apps/docs/src/docs/components/offcanvas.md
@@ -1,10 +1,6 @@
 # Offcanvas
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -1,10 +1,6 @@
 # Overlay
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -1,7 +1,5 @@
 # Overlay
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 BootstrapVueNext's custom `BOverlay` component is used to _visually obscure_ a particular element or component and its content. It signals to the user of a state change within the element or component and can be used for creating loaders, warnings/alerts, prompts, and more.
@@ -931,7 +929,6 @@ also set the `rounded` prop on `BOverlay`.
 <script setup lang="ts">
 import {data} from '../../data/components/overlay.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BForm, BProgress, BRow, BImg, BFormInput, BFormSelect, BOverlay, BCol, BButton, BCard, BCardBody, BCardText, BAlert} from 'bootstrap-vue-next'
 import {ref, nextTick} from 'vue';

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -1,7 +1,5 @@
 # Pagination
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Quick first, previous, next, last, and page buttons for pagination control of another component

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -1,10 +1,6 @@
 # Pagination
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/placeholder.md
+++ b/apps/docs/src/docs/components/placeholder.md
@@ -1,7 +1,5 @@
 # Placeholder
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Placeholders are components that indicate that something may still be loading.
@@ -336,7 +334,6 @@ Optionally, you can manually adjust any scope of the table using slots. The foll
 <script setup lang="ts">
 import {data} from '../../data/components/placeholder.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BPlaceholderButton,

--- a/apps/docs/src/docs/components/placeholder.md
+++ b/apps/docs/src/docs/components/placeholder.md
@@ -1,10 +1,6 @@
 # Placeholder
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/popover.md
+++ b/apps/docs/src/docs/components/popover.md
@@ -1,10 +1,6 @@
 # Popover
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 ## Docs to be written
 

--- a/apps/docs/src/docs/components/popover.md
+++ b/apps/docs/src/docs/components/popover.md
@@ -1,7 +1,5 @@
 # Popover
 
-<ComponentSidebar />
-
 ## Docs to be written
 
 ## Auto close popover when hidden by `hide` middleware
@@ -72,7 +70,6 @@ import { computed, ref, onMounted } from 'vue';
 import {data} from '../../data/components/popover.data'
 import HighlightCard from '../../components/HighlightCard.vue'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 
 import {
   BCol,

--- a/apps/docs/src/docs/components/progress.md
+++ b/apps/docs/src/docs/components/progress.md
@@ -1,7 +1,5 @@
 # Progress
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Documentation and examples for using Bootstrap custom progress bars featuring support for stacked bars, animated backgrounds, and text labels.
@@ -248,7 +246,6 @@ const animate = ref(false)
 <script setup lang="ts">
 import {data} from '../../data/components/progress.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import {BButton, BProgressBar, BCard, BProgress} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
 import { ref } from 'vue';

--- a/apps/docs/src/docs/components/progress.md
+++ b/apps/docs/src/docs/components/progress.md
@@ -1,10 +1,6 @@
 # Progress
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -1,7 +1,5 @@
 # Spinners
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 The `<BSpinner>` component can be used to show the loading state in your projects. They're
@@ -109,7 +107,6 @@ As well, when no label is provided, the spinner will automatically have the attr
 <script setup lang="ts">
 import {data} from '../../data/components/spinner.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {BCard, BCardBody, BButton, BSpinner} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -1,10 +1,6 @@
 # Spinners
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -1,7 +1,5 @@
 # Tables
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 For displaying tabular data, `BTable` supports pagination, filtering, sorting, custom rendering, various style options, events, and asynchronous data. For simple display of tabular data without all the fancy features, BootstrapVueNext provides two lightweight alternative components `BTableLite` and `BTableSimple`.
@@ -1093,7 +1091,6 @@ function onAddSort() {
 <script setup lang="ts">
 import {data} from '../../data/components/table.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {
   BButton,

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -1,10 +1,6 @@
 # Tables
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -1,7 +1,5 @@
 # Tabs
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 Create a widget of tabbable panes of _local content_. The tabs component is built upon navs and
 cards internally, and provides full keyboard navigation control of the tabs.

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -1,10 +1,6 @@
 # Tabs
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 Create a widget of tabbable panes of _local content_. The tabs component is built upon navs and

--- a/apps/docs/src/docs/components/toast.md
+++ b/apps/docs/src/docs/components/toast.md
@@ -1,7 +1,5 @@
 # Toast
 
-<ComponentSidebar />
-
 <div class="lead mb-5">
 
 Push notifications to your visitors with `BToast` and `BToastOrchestrator`. These are components that are easily customizable for generating alert messages
@@ -242,7 +240,6 @@ If you just need a single simple message to appear along the bottom or top of th
 <script setup lang="ts">
 import {data} from '../../data/components/toast.data'
 import ComponentReference from '../../components/ComponentReference.vue'
-import ComponentSidebar from '../../components/ComponentSidebar.vue'
 import {BButtonGroup, BButton, BToast, useToastController} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
 import {ref, h, onMounted} from 'vue'

--- a/apps/docs/src/docs/components/toast.md
+++ b/apps/docs/src/docs/components/toast.md
@@ -1,10 +1,6 @@
 # Toast
 
-<ComponentSidebar>
-
-[[toc]]
-
-</ComponentSidebar>
+<ComponentSidebar />
 
 <div class="lead mb-5">
 

--- a/apps/docs/src/docs/composables/useBreadcrumb.md
+++ b/apps/docs/src/docs/composables/useBreadcrumb.md
@@ -1,10 +1,5 @@
 <ComposableHeader path="useBreadcrumb/index.ts" title="useBreadcrumb" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 `useBreadcrumb` is a helper utility for the `BBreadcrumb` component. It provides a **globally** changable context so you can modify a breadcrumb. It should be noted that the breacrumb component will automatically use the global context by default. `useBreadcrumb` is shared globally, one modification to the state will be recognized throughout the app. As noted in the BBreadcrumb documentation, the items prop for the component takes precedence over `useBreadcrumb`
@@ -50,7 +45,6 @@ const addItem = () => {
 <script setup lang="ts">
 import {ref} from 'vue'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {BBreadcrumb, BButton, BFormInput, BFormGroup, BCard, BCardBody, useBreadcrumb} from 'bootstrap-vue-next'
 import ComposableHeader from './ComposableHeader.vue'

--- a/apps/docs/src/docs/composables/useColorMode.md
+++ b/apps/docs/src/docs/composables/useColorMode.md
@@ -1,10 +1,5 @@
 <ComposableHeader path="useColorMode/index.ts" title="useColorMode" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 `useColorMode` provides a convenient utility to adjust the global color theme of your application. You can also use it to target specific components by using a [template ref](https://vuejs.org/guide/essentials/template-refs.html#template-refs) or a selector. Bootstrap's default behavior dictates that color modes are applied to all children in the branch. `useColorMode` is simply a wrapper for the [vueuse](https://vueuse.org/core/useColorMode/#usecolormode) utility.
@@ -53,7 +48,6 @@ import ComposableHeader from './ComposableHeader.vue'
 import {ref} from 'vue'
 import {useColorMode, BCard, BCardBody, BButton} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
 
 const target = ref<HTMLElement | null>(null)
 

--- a/apps/docs/src/docs/composables/useModal.md
+++ b/apps/docs/src/docs/composables/useModal.md
@@ -1,10 +1,5 @@
 <ComposableHeader path="useModal/index.ts" title="useModal" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 You can use `useModal` to get the closest modal in **child component** and hide it. It can also be supplied a target id to show or hide a specific modal
@@ -67,7 +62,7 @@ const {show, hide, modal} = useModal('my-modal')
 <script setup lang="ts">
 import {BButton, BModal, useModal} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import {ref, onMounted} from 'vue'
 import ComposableHeader from './ComposableHeader.vue'
 

--- a/apps/docs/src/docs/composables/useModalController.md
+++ b/apps/docs/src/docs/composables/useModalController.md
@@ -1,10 +1,5 @@
 <ComposableHeader path="useModalController/index.ts" title="useModalController" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 `useModalController` can hide modals everywhere in the app, as well as creating modals on the fly
@@ -224,7 +219,7 @@ const {hide, hideAll} = useModalController()
 <script setup lang="ts">
 import {BButton, BModal, useModalController, BButtonGroup, useModal} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {ref, computed, h, onMounted} from 'vue'
 import ComposableHeader from './ComposableHeader.vue'

--- a/apps/docs/src/docs/composables/useToastController.md
+++ b/apps/docs/src/docs/composables/useToastController.md
@@ -1,10 +1,5 @@
 <ComposableHeader path="useToastController/index.ts" title="useToastController" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Often times one may want to open a `Toast` in a global context, without the need for declaring a component, perhaps to display an error after a function threw an error. `useToastController` is used to create `Toasts` on demand. You must have initialized the `BToastOrchestrator` component once in your application. The following functionality requires the existance of that component
@@ -207,7 +202,7 @@ const hideMe = () => {
 import {data} from '../../data/components/toast.data'
 import {BButton, useToastController, BButtonGroup, BToast} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import UsePluginAlert from '../../components/UsePluginAlert.vue'
 import {ref, computed, h, onMounted} from 'vue'
 import ComposableHeader from './ComposableHeader.vue'

--- a/apps/docs/src/docs/configurations/customizing-styles.md
+++ b/apps/docs/src/docs/configurations/customizing-styles.md
@@ -1,13 +1,5 @@
 # Customizing Styles
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
-
-[[toc]]
-
-  </Teleport>
-</ClientOnly>
-
 ## Bootstrap Customization
 
 There are many ways to customize the underlying [Bootstrap](https://getbootstrap.com/) styles. See

--- a/apps/docs/src/docs/configurations/global-options.md
+++ b/apps/docs/src/docs/configurations/global-options.md
@@ -1,13 +1,5 @@
 # Global options
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
-
-[[toc]]
-
-  </Teleport>
-</ClientOnly>
-
 ## Overview
 
 Global configurations allow you to set default prop values for all Vue components in your application. This is achieved using the createBootstrap plugin. Here's an example:

--- a/apps/docs/src/docs/directives/BColorMode.md
+++ b/apps/docs/src/docs/directives/BColorMode.md
@@ -1,10 +1,5 @@
 <DirectiveHeader path="BColorMode/index.ts" title="BColorMode" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 The `BColorMode` directive is similar to [useColorMode](../composables/useColorMode.md) but provides a more low level directive for placement on individual components. It is useful when you want to make an element have one color mode, but do not want the overhead of the composable variant.
@@ -48,7 +43,7 @@ const changeColor = () => {
 import {ref} from 'vue'
 import {vBColorMode, BButton, BCard} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import DirectiveHeader from './DirectiveHeader.vue'
 
 const currentColor = ref<'light' | 'dark'>('dark')

--- a/apps/docs/src/docs/directives/BTooltip.md
+++ b/apps/docs/src/docs/directives/BTooltip.md
@@ -1,10 +1,5 @@
 <DirectiveHeader path="BTooltip/index.ts" title="BTooltip" />
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <BCard class="bg-body-tertiary">
 
 ```vue-html
@@ -186,6 +181,6 @@ We should use the value type when the component is not setting to the root compo
 
 <script setup lang="ts">
 import {BCard, BCardBody} from 'bootstrap-vue-next'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import DirectiveHeader from './DirectiveHeader.vue'
 </script>

--- a/apps/docs/src/docs/icons.md
+++ b/apps/docs/src/docs/icons.md
@@ -1,10 +1,5 @@
 # Icons
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <BAlert variant="danger" :model-value="true" class="my-5">
 
 The icon components from BootstrapVue are deprecated. While migrating to BootstrapVueNext the icon components will not be supported as there are better, more modern solutions to incorporating icon packages into your application. Continue reading BootstrapVueNext's suggestion on how to incorporate Bootstrap-icons into your application! This documentation only serves as a reference, BootstrapVueNext has no part in the mentioned libraries and some content may be out of date.
@@ -238,8 +233,6 @@ import IBiActivity from '~icons/bi/activity'
 <script setup lang="ts">
 import {BCard, BCardBody, BTab, BTabs, BAlert} from 'bootstrap-vue-next'
 import {useLocalStorage} from '@vueuse/core'
-import ContentsSidebar from '../components/ContentsSidebar.vue'
-
 
 const codePreference = useLocalStorage('code-group-preference', 0)
 </script>

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -1,13 +1,5 @@
 # Migration Guide
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
-
-[[toc]]
-
-  </Teleport>
-</ClientOnly>
-
 ## Overview
 
 `bootstrap-vue-next` is an entirely new implementation of [bootrap-vue](https://bootstrap-vue.org/) based on [Vue 3](https://vuejs.org/) and [Bootstrap 5](https://getbootstrap.com/). Therefore, you should not expect this to be a drop-in replacement. Where possible compatibility has been maintained, but providing a clean developer experience when working with `Vue 3`, `Bootstrap 5` and this library is a higher priority.

--- a/apps/docs/src/docs/reference/accessibility.md
+++ b/apps/docs/src/docs/reference/accessibility.md
@@ -1,10 +1,5 @@
 # Accessibility
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 A brief overview of BootstrapVueNext's features and limitations for the creation of accessible content.
@@ -94,5 +89,5 @@ Steps you should do for testing:
 
 <script setup lang="ts">
 import {BCard} from 'bootstrap-vue-next'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -1,10 +1,5 @@
 # Color variants and CSS class mapping
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 <p>Color variants are available when using the default Bootstrap v5 CSS and their mappings to CSS classes</p>
@@ -253,7 +248,7 @@ $dark: $gray-900;
 <script setup lang="ts">
 import {BCard} from 'bootstrap-vue-next'
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>
 
 <style lang="scss">

--- a/apps/docs/src/docs/reference/form-validation.md
+++ b/apps/docs/src/docs/reference/form-validation.md
@@ -1,10 +1,5 @@
 # Form validation
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 BootstrapVueNext does not include form validation by default; we leave that up to the many existing form validation plugins. Included here are some examples of validation plugins and how they may be integrated.
@@ -12,5 +7,5 @@ BootstrapVueNext does not include form validation by default; we leave that up t
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/images.md
+++ b/apps/docs/src/docs/reference/images.md
@@ -1,13 +1,7 @@
 # Image Support
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
-
 The `src` prop and `blank-src` prop, out of the box, works only with absolute or fully-qualified-domain-name URLs. If you are using project assets as image sources, please refer to [Asset URL handling](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue#asset-url-handling) to configure Vite to transform asset urls. If using a different build tool, you will need to find the relevant documentation to transform assets.
 
 <script setup lang="ts">
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/router-links.md
+++ b/apps/docs/src/docs/reference/router-links.md
@@ -1,10 +1,5 @@
 # Router link support
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Several BootstrapVue components support rendering `RouterLink` components compatible with Vue Router and Nuxt.js. For more information, see the official [Vue Router docs](https://router.vuejs.org) and official [Nuxt.js docs](https://nuxt.com/docs/api/components/nuxt-link#props).
@@ -187,7 +182,7 @@ router: { prefetchLinks: false }
 
 <script setup lang="ts">
 import HighlightCard from '../../components/HighlightCard.vue'
-import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 import NotYetImplemented from '../../components/NotYetImplemented.vue'
 import {BAlert} from 'bootstrap-vue-next'
 </script>

--- a/apps/docs/src/docs/reference/settings.md
+++ b/apps/docs/src/docs/reference/settings.md
@@ -1,10 +1,5 @@
 # Settings
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 BootstrapVue provides a few options for customizing component default values, and more.
@@ -12,5 +7,5 @@ BootstrapVue provides a few options for customizing component default values, an
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/size-props-and-classes.md
+++ b/apps/docs/src/docs/reference/size-props-and-classes.md
@@ -1,10 +1,5 @@
 # Size props and classes
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS provides several classes that control the sizing of elements, of which some of these have been translated into props on components.
@@ -12,5 +7,5 @@ Bootstrap v5 CSS provides several classes that control the sizing of elements, o
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/spacing-classes.md
+++ b/apps/docs/src/docs/reference/spacing-classes.md
@@ -1,10 +1,5 @@
 # Spacing classes
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS includes a wide range of shorthand responsive margin and padding utility classes to modify an element's appearance.
@@ -12,5 +7,5 @@ Bootstrap v5 CSS includes a wide range of shorthand responsive margin and paddin
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/starter-templates.md
+++ b/apps/docs/src/docs/reference/starter-templates.md
@@ -1,10 +1,5 @@
 # Starter Templates
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 There are several ways you can create your app, from basic client side HTML all the way up to using a build system and compilers.
@@ -12,5 +7,5 @@ There are several ways you can create your app, from basic client side HTML all 
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/theming-bootstrap.md
+++ b/apps/docs/src/docs/reference/theming-bootstrap.md
@@ -1,10 +1,5 @@
 # Theming Bootstrap
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Theming is accomplished by SASS variables, SASS maps, and custom CSS. There is no dedicated theme stylesheet; instead, you can enable the built-in theme to add gradients, shadows, and more.
@@ -12,5 +7,5 @@ Theming is accomplished by SASS variables, SASS maps, and custom CSS. There is n
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/third-party-libraries.md
+++ b/apps/docs/src/docs/reference/third-party-libraries.md
@@ -1,10 +1,5 @@
 # Third party libraries
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 There are several 3rd party libraries that you can use to add additional functionality and features to your BootstrapVue project.
@@ -12,5 +7,5 @@ There are several 3rd party libraries that you can use to add additional functio
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/reference/utility-classes.md
+++ b/apps/docs/src/docs/reference/utility-classes.md
@@ -1,10 +1,5 @@
 # Utility Classes
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 Bootstrap v5 CSS provides various utility classes to control color, spacing, flex-box, text alignment, floating, position, responsive display/hiding and much more.
@@ -12,5 +7,5 @@ Bootstrap v5 CSS provides various utility classes to control color, spacing, fle
 </div>
 
 <script setup lang="ts">
-    import ContentsSidebar from '../../components/ContentsSidebar.vue'
+
 </script>

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -1,10 +1,5 @@
 # Types
 
-<ContentsSidebar>
-
-[[toc]]
-
-</ContentsSidebar>
 <div class="lead mb-5">
 
 `BootstrapVueNext` is a complete rewrite that strives for full TypeScript compatibility. This is a list of types we use in this library and that you can use too.
@@ -582,5 +577,4 @@ New values can be used now and the type check will be successful:
 
 <script setup lang="ts">
 import {BCard, BCardBody} from 'bootstrap-vue-next'
-import ContentsSidebar from '../components/ContentsSidebar.vue'
 </script>

--- a/apps/docs/src/index.md
+++ b/apps/docs/src/index.md
@@ -1,13 +1,5 @@
 # Introduction
 
-<ClientOnly>
-  <Teleport to=".bd-toc">
-
-[[toc]]
-
-  </Teleport>
-</ClientOnly>
-
 <div class="lead mb-5">
 
 With BootstrapVueNext you can build fast, responsive, and ARIA accessible projects on the web using Vue.js and Bootstrap v5.


### PR DESCRIPTION
# Describe the PR

Rather than manually adding [[toc]] to every page, I've turned on the option to add the page headers into the page data and then I can just put a vue component in the Layout.vue sidebar to generate the "On the page" table of contents.

My medium term goal for this is to move to using a vertical nav for this and adding in scrollspy to keep it in sync with the core page + expand/collapse like the BSV and bootstrap TOCs do.

I believe this step is a significant enough improvement on its own to get it in before I muck with scrollspy, etc.

- This removes a lot of boilerplate code from the *.md files
- It fixes the issue that I kludged up a while ago where the component reference item in the toc is in a separate <ul>, which looks fine visually but probably messes with accessibility.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
