### PR TITLE
feat(BTable): expose table items

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -997,6 +997,7 @@ const computedLiteProps = computed(() => ({
 defineExpose({
   // The row selection methods are really for compat. Users should probably use the v-model though
   ...exposedSelectableUtilities,
+  items: computedItems,
   refresh: callItemsProvider,
 })
 </script>


### PR DESCRIPTION
# Describe the PR

This pull request exposes the items of the `BTable` component, like in `bootstrap-vue`. The main motivation behind this is compatibility. The variable used to be named `filteredItems` in `bootstrap-vue` thus could be accessed in a ref like `this.$refs.table.filteredItems` and allowed for custom entry counters and such to be made.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
