### PR TITLE
feat(BTable): custom filter functions

### DIFF
--- a/apps/docs/src/data/components/table.data.ts
+++ b/apps/docs/src/data/components/table.data.ts
@@ -197,7 +197,7 @@ export default {
               default: undefined,
             },
             filterFunction: {
-              type: '(item: Items) => boolean',
+              type: '(item: Readonly<Items>, filter: string | undefined) => boolean',
               default: undefined,
               description:
                 'Function called during filtering of items, gets passed the current item being filtered',

--- a/apps/docs/src/data/components/table.data.ts
+++ b/apps/docs/src/data/components/table.data.ts
@@ -196,6 +196,12 @@ export default {
               type: 'string',
               default: undefined,
             },
+            filterFunction: {
+              type: '(item: Items) => boolean',
+              default: undefined,
+              description:
+                'Function called during filtering of items, gets passed the current item being filtered',
+            },
             filterable: {
               type: 'string[]',
               default: undefined,

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -661,7 +661,7 @@ const computedItems = computed<Items[]>(() => {
               return false
 
             if (props.filterFunction && typeof props.filterFunction === 'function') {
-              return props.filterFunction(item)
+              return props.filterFunction(item, props.filter)
             }
 
             const realVal = (): string => {

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -242,6 +242,7 @@ const _props = withDefaults(
     noSortableIcon: false,
     perPage: Number.POSITIVE_INFINITY,
     filter: undefined,
+    filterFunction: undefined,
     mustSort: false,
     filterable: undefined,
     provider: undefined,
@@ -658,6 +659,11 @@ const computedItems = computed<Items[]>(() => {
               (!props.filterable?.includes(key) && !!props.filterable?.length)
             )
               return false
+
+            if (props.filterFunction && typeof props.filterFunction === 'function') {
+              return props.filterFunction(item)
+            }
+
             const realVal = (): string => {
               const filterField = computedFields.value.find((el) => {
                 if (isTableField<Items>(el)) return el.key === key

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1092,7 +1092,7 @@ export interface BTableProps<Items> extends Omit<BTableLiteProps<Items>, 'tableC
   perPage?: Numberish
   currentPage?: Numberish
   filter?: string
-  filterFunction?: (item: Items) => boolean
+  filterFunction?: (item: Readonly<Items>, filter: string | undefined) => boolean
   filterable?: readonly string[]
   // TODO
   // apiUrl?: string

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1092,10 +1092,10 @@ export interface BTableProps<Items> extends Omit<BTableLiteProps<Items>, 'tableC
   perPage?: Numberish
   currentPage?: Numberish
   filter?: string
+  filterFunction?: (item: Items) => boolean
   filterable?: readonly string[]
   // TODO
   // apiUrl?: string
-  // filterFunction?: () => any
   // filterIgnoredFields?: any[]
   // filterIncludedFields?: any[]
   // headRowVariant?: ColorVariant | null


### PR DESCRIPTION
# Describe the PR
This PR aims to bring over the ability to pass a custom filter function to the `BTable` component as seen in `bootstrap-vue`. This gives developers more control over how exactly they want to filter their data inside tables.

## Small replication
Hard to properly convey in a video, but here is a small replication of what this could do. Code is displayed underneath the table.

https://github.com/user-attachments/assets/232fbd06-ed5b-4087-9f37-17081af03b2c


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
