### PR TITLE
feat(BDropdownItemButton): fix and optimize `role`

### DIFF
--- a/apps/docs/src/data/components/dropdown.data.ts
+++ b/apps/docs/src/data/components/dropdown.data.ts
@@ -121,6 +121,11 @@ export default {
       sourcePath: '/BDropdown/BDropdownItem.vue',
       props: {
         '': {
+          itemRole: {
+            type: `'menuitem' | 'menuitemradio' | 'menuitemcheckbox'`,
+            default: 'menuitem',
+            description: 'ARIA role of the inner link element',
+          },
           ...pick(buildCommonProps({}), ['linkClass', 'wrapperAttrs']),
         } satisfies Record<
           Exclude<keyof BvnComponentProps['BDropdownItem'], keyof typeof linkProps>,
@@ -162,6 +167,11 @@ export default {
             type: 'ClassValue',
             default: undefined,
             description: 'Class or classes to apply to the inner button element',
+          },
+          buttonRole: {
+            type: `'menuitem' | 'menuitemradio' | 'menuitemcheckbox'`,
+            default: 'menuitem',
+            description: 'ARIA role of the inner button element',
           },
           ...pick(buildCommonProps({}), [
             'active',

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
@@ -9,7 +9,7 @@
       :aria-current="props.active ? true : null"
       :href="computedTag === 'a' ? props.href : null"
       :rel="props.rel"
-      role="menuitem"
+      :role="props.itemRole"
       :type="computedTag === 'button' ? 'button' : null"
       :target="props.target"
       v-bind="{...computedLinkProps, ...attrs}"
@@ -35,6 +35,7 @@ defineOptions({
 
 const _props = withDefaults(defineProps<BDropdownItemProps>(), {
   wrapperAttrs: undefined,
+  itemRole: 'menuitem',
   // Link props
   linkClass: undefined,
   variant: null,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -1,7 +1,7 @@
 <template>
   <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
     <button
-      role="menuitem"
+      :role="props.buttonRole"
       type="button"
       class="dropdown-item"
       :class="computedClasses"
@@ -28,6 +28,7 @@ const _props = withDefaults(defineProps<BDropdownItemButtonProps>(), {
   active: false,
   activeClass: 'active',
   buttonClass: undefined,
+  buttonRole: 'menuitem',
   disabled: false,
   variant: null,
   wrapperAttrs: undefined,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -1,7 +1,7 @@
 <template>
   <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
     <button
-      role="menu"
+      role="menuitem"
       type="button"
       class="dropdown-item"
       :class="computedClasses"

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -155,12 +155,14 @@ export interface BDropdownHeaderProps {
 export interface BDropdownItemProps extends Omit<BLinkProps, 'routerTag'> {
   linkClass?: ClassValue
   wrapperAttrs?: Readonly<AttrsValue>
+  itemRole: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox'
 }
 
 export interface BDropdownItemButtonProps {
   active?: boolean
   activeClass?: ClassValue
   buttonClass?: ClassValue
+  buttonRole: 'menuitem' | 'menuitemradio' | 'menuitemcheckbox'
   wrapperAttrs?: Readonly<AttrsValue>
   disabled?: boolean
   variant?: ColorVariant | null


### PR DESCRIPTION
# Describe the PR

Found that the current `BDropdownItemButton` is having a wrong ARIA role `menu`. This PR aims to fix it from `menu` to `menuitem`.
Additionally, trying to make it into a prop which allows developers to change the role of the inner element of `BDropdownItem` and `BDropdownItemButton` to `menuitem`, `menuitemradio` or `menuitemcheckbox` base on their needs (default `menuitem`).

Document is also updated accordingly

## Small replication

Not a UI change, not available to provide a demo video.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
