### PR TITLE
docs: use BNav for "on this page" contents

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -711,38 +711,6 @@ watch(
   }
 }
 
-.table-of-contents {
-  font-size: 0.875rem;
-
-  ul {
-    padding-left: 0;
-    margin-bottom: 0;
-    list-style: none;
-
-    a {
-      display: block;
-      padding: 0.125rem 0 0.125rem 0.75rem;
-      color: inherit;
-      text-decoration: none;
-      border-left: 0.125rem solid transparent;
-
-      &.active {
-        color: var(--bd-toc-color);
-        border-left-color: var(--bd-toc-color);
-      }
-
-      &:hover {
-        color: var(--bd-toc-color);
-        border-left-color: var(--bd-toc-color);
-      }
-    }
-
-    ul {
-      padding-left: 1rem;
-    }
-  }
-}
-
 // Search
 .DocSearch-Button .DocSearch-Search-Icon {
   @media (max-width: 767px) {

--- a/apps/docs/src/components/PageContents.vue
+++ b/apps/docs/src/components/PageContents.vue
@@ -1,14 +1,10 @@
 <template>
-  <nav v-if="headers.length > 0" class="table-of-contents">
-    <ul>
-      <li v-for="header in headers" :key="header.slug">
-        <PageContentsItem :item="header" />
-      </li>
-      <li v-if="isComponentPage">
-        <a href="#component-reference">Component Reference</a>
-      </li>
-    </ul>
-  </nav>
+  <BNav v-if="headers.length > 0" vertical small class="otp-nav">
+    <PageContentsItem v-for="header in headers" :key="header.slug" :item="header" />
+    <BNavItem v-if="isComponentPage" href="#component-reference" link-class="otp-link"
+      >Component Reference</BNavItem
+    >
+  </BNav>
 </template>
 
 <script setup lang="ts">
@@ -19,3 +15,29 @@ const data = useData()
 const headers = computed(() => data.page.value.headers)
 const isComponentPage = computed(() => data.page.value.relativePath.includes('/components/'))
 </script>
+
+<style lang="scss">
+.nav.otp-nav {
+  padding-left: 0.5rem;
+}
+
+a.nav-link.otp-link {
+  padding: 0;
+  padding-left: 0.25rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.75rem;
+  border-left: 0.125rem solid transparent;
+
+  &.active {
+    color: var(--bs-primary-text-emphasis);
+    border-left-color: var(--bs-primary-text-emphasis);
+    font-weight: bold;
+  }
+
+  &:hover {
+    color: var(--bs-primary-text-emphasis);
+    border-left-color: var(--bs-primary-text-emphasis);
+    font-weight: bold;
+  }
+}
+</style>

--- a/apps/docs/src/components/PageContentsItem.vue
+++ b/apps/docs/src/components/PageContentsItem.vue
@@ -1,10 +1,12 @@
 <template>
-  <li>
-    <a :href="item.link">{{ item.title }}</a>
-    <ul v-if="item.children?.length > 0">
-      <PageContentsItem v-for="child in item.children" :key="child.slug" :item="child" />
-    </ul>
-  </li>
+  <BNavItem :href="item.link" link-class="otp-link">
+    <template #default>{{ item.title }}</template>
+    <template #after>
+      <BNav v-if="item.children?.length > 0" vertical small class="otp-nav">
+        <PageContentsItem v-for="child in item.children" :key="child.slug" :item="child" />
+      </BNav>
+    </template>
+  </BNavItem>
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/data/components/nav.data.ts
+++ b/apps/docs/src/data/components/nav.data.ts
@@ -163,6 +163,10 @@ export default {
       ],
       slots: [
         {
+          name: 'after',
+          description: 'Content to place after the nav item link (useful for nested navs)',
+        },
+        {
           name: 'default',
           description: 'Content to place in the nav item',
         },

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItem.vue
@@ -10,6 +10,7 @@
     >
       <slot />
     </BLink>
+    <slot name="after" />
   </li>
 </template>
 
@@ -23,6 +24,8 @@ import {useDefaults} from '../../composables/useDefaults'
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default?: (props: Record<string, never>) => any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  after?: (props: Record<string, never>) => any
 }>()
 
 const _props = withDefaults(defineProps<BNavItemProps>(), {


### PR DESCRIPTION
# Describe the PR

This is another incremental step towards getting the "On the Page" contents working like in the BSV documentation.
- I've converted the raw `<ul>` `<li>` styling to use <BNav> and <BNavItem> and update the CSS to work correctly.
- In order to allow for nested navs I've added a slot after the link in the <BNavItem>
- With this is place we should be able to start using ScrollSpy to keep the nav and the body in sync (but an initial attempt failed, so I'll need to dig into ScrollSpy a bit deeper before I get that working)

## Small replication

See the docs On this Page sidebar

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
