### PR TITLE
docs: Fix typescript errors in search components

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -177,10 +177,9 @@ import MoonStarsFill from '~icons/bi/moon-stars-fill'
 import SunFill from '~icons/bi/sun-fill'
 import ChevronRight from '~icons/bi/chevron-right'
 import CircleHalf from '~icons/bi/circle-half'
-import {useData, useRoute, withBase} from 'vitepress'
+import {useData, useRoute, VPNavBarSearch, withBase} from 'vitepress'
 import {appInfoKey} from './keys'
 import {useMediaQuery} from '@vueuse/core'
-import VPNavBarSearch from 'vitepress/dist/client/theme-default/components/VPNavBarSearch.vue'
 
 // https://vitepress.dev/reference/runtime-api#usedata
 const {page} = useData()

--- a/package.json
+++ b/package.json
@@ -51,5 +51,10 @@
     "npm": ">=10.0.0",
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@9.12.2"
+  "packageManager": "pnpm@9.12.2",
+  "pnpm": {
+    "patchedDependencies": {
+      "vitepress@1.5.0": "patches/vitepress@1.5.0.patch"
+    }
+  }
 }

--- a/patches/vitepress@1.5.0.patch
+++ b/patches/vitepress@1.5.0.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/client/index.d.ts b/dist/client/index.d.ts
+index 596adb4f22286b24fb5cb694943d835afa084fc4..4fcb57e4e5999c07c8c73fdb4b3d594808d8ceb2 100644
+--- a/dist/client/index.d.ts
++++ b/dist/client/index.d.ts
+@@ -130,4 +130,6 @@ declare const Content: vue.DefineComponent<vue.ExtractPropTypes<{
+     as: string | Record<string, any>;
+ }, {}, {}, {}, string, vue.ComponentProvideOptions, true, {}, any>;
+ 
+-export { Content, type EnhanceAppContext, type Route, type Router, type Theme, type VitePressData, escapeHtml as _escapeHtml, dataSymbol, defineClientComponent, getScrollOffset, inBrowser, onContentUpdated, useData, useRoute, useRouter, withBase };
++declare const VPNavBarSearch: vue.DefineComponent;
++
++export { Content, type EnhanceAppContext, type Route, type Router, type Theme, type VitePressData, escapeHtml as _escapeHtml, dataSymbol, defineClientComponent, getScrollOffset, inBrowser, onContentUpdated, useData, useRoute, useRouter, VPNavBarSearch, withBase };
+diff --git a/dist/client/index.js b/dist/client/index.js
+index da89a51b26f1f6eefb9133126e45b4e2ba618bb2..9210138afe8f94b64153de7ee55bba381736f4e8 100644
+--- a/dist/client/index.js
++++ b/dist/client/index.js
+@@ -7,3 +7,5 @@ export { useRoute, useRouter } from './app/router';
+ export { inBrowser, onContentUpdated, defineClientComponent, withBase, getScrollOffset, _escapeHtml } from './app/utils';
+ // components
+ export { Content } from './app/components/Content';
++import VPNavBarSearch from './theme-default/components/VPNavBarSearch.vue';
++export { VPNavBarSearch };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vitepress@1.5.0:
+    hash: iraxpmbqxhubcplbfvmecu7tba
+    path: patches/vitepress@1.5.0.patch
+
 importers:
 
   .:
@@ -82,7 +87,7 @@ importers:
         version: 0.27.4(@babel/parser@7.26.2)(@nuxt/kit@3.14.159(magicast@0.3.5)(rollup@4.27.3))(rollup@4.27.3)(vue@3.5.13(typescript@5.6.3))
       vitepress:
         specifier: 1.5.0
-        version: 1.5.0(@algolia/client-search@5.14.2)(@types/node@22.9.0)(change-case@5.4.4)(postcss@8.4.49)(sass@1.81.0)(search-insights@2.17.3)(terser@5.36.0)(typescript@5.6.3)
+        version: 1.5.0(patch_hash=iraxpmbqxhubcplbfvmecu7tba)(@algolia/client-search@5.14.2)(@types/node@22.9.0)(change-case@5.4.4)(postcss@8.4.49)(sass@1.81.0)(search-insights@2.17.3)(terser@5.36.0)(typescript@5.6.3)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.6.3)
@@ -10674,7 +10679,7 @@ snapshots:
       sass: 1.81.0
       terser: 5.36.0
 
-  vitepress@1.5.0(@algolia/client-search@5.14.2)(@types/node@22.9.0)(change-case@5.4.4)(postcss@8.4.49)(sass@1.81.0)(search-insights@2.17.3)(terser@5.36.0)(typescript@5.6.3):
+  vitepress@1.5.0(patch_hash=iraxpmbqxhubcplbfvmecu7tba)(@algolia/client-search@5.14.2)(@types/node@22.9.0)(change-case@5.4.4)(postcss@8.4.49)(sass@1.81.0)(search-insights@2.17.3)(terser@5.36.0)(typescript@5.6.3):
     dependencies:
       '@docsearch/css': 3.8.0
       '@docsearch/js': 3.8.0(@algolia/client-search@5.14.2)(search-insights@2.17.3)


### PR DESCRIPTION
# Describe the PR

This is the last set of typescript errors in docs. Once this and the other PRs in flight are merged, I'll push a change to add type-check to the main build, which should prevent new errors from being checked in.

I went down a bunch of paths to try to suppress these errors, since they aren't ours. However, it appears that the typescript team is opposed to suppressing errors in the dependency tree (you can exclude top-level files, but not things that are included by a file that you're checking.  See https://github.com/microsoft/TypeScript/issues/40426 for info.

I've opened a feature request on VitePress to see if they have other ideas on how to include their search control in a custom theme https://github.com/vuejs/vitepress/issues/4476 - but I'd like to get type checking turned on sooner then they're likely to react.

The other possibility is to rework our theme to be an extended default theme so that we can use their Layout component. But that seems like it would be a mess, and one of the nice things about our doc site as it stands is that we're using BSVN for most of the styling which I'm not sure we could do if we went down this route.

## Small replication

pnpm type-check

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
