### PR TITLE
fix(BTable): Export additional types

### DIFF
--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1098,8 +1098,6 @@ export interface BTableProps<Items> extends Omit<BTableLiteProps<Items>, 'tableC
   // apiUrl?: string
   // filterIgnoredFields?: any[]
   // filterIncludedFields?: any[]
-  // headRowVariant?: ColorVariant | null
-  // headVariant?: ColorVariant | null
   // labelSortAsc?: string
   // labelSortClear?: string
   // labelSortDesc?: string
@@ -1108,7 +1106,6 @@ export interface BTableProps<Items> extends Omit<BTableLiteProps<Items>, 'tableC
   noSelectOnClick?: boolean
   // selectedVariant?: ColorVariant | null
   // showEmpty?: boolean
-  // sortDirection?: 'asc' | 'desc' | 'last'
   // sortIconLeft?: boolean
   // sortNullLast?: boolean
   selectedItems?: readonly Items[]

--- a/packages/bootstrap-vue-next/src/types/TableTypes.ts
+++ b/packages/bootstrap-vue-next/src/types/TableTypes.ts
@@ -51,7 +51,6 @@ export type TableField<T = any> = {
   class?: ClassValue
   formatter?: TableFieldFormatter<T>
   sortable?: boolean
-  sortKey?: string
   sortDirection?: string
   sortByFormatted?: boolean | TableFieldFormatter<T>
   filterByFormatted?: boolean | TableFieldFormatter<T>

--- a/packages/bootstrap-vue-next/src/types/index.ts
+++ b/packages/bootstrap-vue-next/src/types/index.ts
@@ -20,6 +20,9 @@ export type {
   TableFieldFormatter,
   TableFieldRaw,
   TableItem,
+  TableRowThead,
+  TableRowType,
+  TableStrictClassValue,
 } from './TableTypes'
 export type {
   BaseButtonVariant,


### PR DESCRIPTION
# Describe the PR

- Export several types that are needed to implement the examples in the docs
- Remove `headRowVarian`t and `headVariant` which were commented out in BTable, since they're implemented in BTableLite
- Remove the `sortDirectionProp` from `BTable`, since it is superseded by `sortBy`
- Remove `sortKey` from `TableField` since its functionality is superseded by `sortBy`

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
