### PR TITLE
docs(BTable): Document custom data rendering

### DIFF
--- a/apps/docs/src/docs/components/demo/TableCustomData.vue
+++ b/apps/docs/src/docs/components/demo/TableCustomData.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <BTable small :fields="fields" :items="items" responsive="sm">
+      <!-- A virtual column -->
+      <template #cell(index)="data">
+        {{ data.index + 1 }}
+      </template>
+
+      <!-- A custom formatted column -->
+      <template #cell(name)="data">
+        <b class="text-info">{{ data.item.name.last.toUpperCase() }}</b
+        >, <b>{{ data.item.name.first }}</b>
+      </template>
+
+      <!-- A virtual composite column -->
+      <template #cell(nameage)="data">
+        {{ data.item.name.first }} is {{ data.item.age }} years old
+      </template>
+
+      <!-- Optional default data cell scoped slot -->
+      <template #cell()="data">
+        <i>{{ data.value }}</i>
+      </template>
+    </BTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Person {
+  name: {first: string; last: string}
+  sex: string
+  age: number
+}
+
+const fields = [
+  // A virtual column that doesn't exist in items
+  'index',
+  // A column that needs custom formatting
+  {key: 'name', label: 'Full Name'},
+  // A regular column
+  'age',
+  // A regular column
+  'sex',
+  // A virtual column made up from two fields
+  {key: 'nameage', label: 'First name and age'},
+]
+const items: Person[] = [
+  {name: {first: 'John', last: 'Doe'}, sex: 'Male', age: 42},
+  {name: {first: 'Jane', last: 'Doe'}, sex: 'Female', age: 36},
+  {name: {first: 'Rubin', last: 'Kincade'}, sex: 'Male', age: 73},
+  {name: {first: 'Shirley', last: 'Partridge'}, sex: 'Female', age: 62},
+]
+</script>

--- a/apps/docs/src/docs/components/demo/TableFieldObjects.vue
+++ b/apps/docs/src/docs/components/demo/TableFieldObjects.vue
@@ -15,7 +15,7 @@ interface Person {
 }
 
 // Note 'isActive' is left out and will not appear in the rendered table
-const fields: Exclude<TableFieldRaw<Person>, string>[] = [
+const fields: TableFieldRaw<Person>[] = [
   {
     key: 'last_name',
     sortable: true,

--- a/apps/docs/src/docs/components/demo/TableFormatter.vue
+++ b/apps/docs/src/docs/components/demo/TableFormatter.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <BTable :fields="fields" :items="items">
+      <template #cell(name)="data">
+        <!-- `data.value` is the value after formatted by the Formatter -->
+        <a :href="`#${(data.value as any as string).replace(/[^a-z]+/i, '-').toLowerCase()}`">{{
+          data.value
+        }}</a>
+      </template>
+    </BTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {TableFieldRaw} from 'bootstrap-vue-next'
+
+interface Name {
+  first: string
+  last: string
+}
+
+interface Person {
+  name: Name
+  sex: string
+  age: number
+}
+
+const fullName = (value: unknown) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const name = value as any as Name
+  return `${name.first} ${name.last}`
+}
+
+const fields: TableFieldRaw<Person>[] = [
+  {
+    // A column that needs custom formatting,
+    // calling formatter 'fullName' in this app
+    key: 'name',
+    label: 'Full Name',
+    formatter: fullName,
+  },
+  // A regular column
+  'age',
+  {
+    // A regular column with custom formatter
+    key: 'sex',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    formatter: (value) => (value as any as string).charAt(0).toUpperCase(),
+  },
+  {
+    // A virtual column with custom formatter
+    key: 'birthYear',
+    label: 'Calculated Birth Year',
+    formatter: (value_, key_, item: Person) => (new Date().getFullYear() - item.age).toString(),
+  },
+]
+
+const items = [
+  {name: {first: 'John', last: 'Doe'}, sex: 'Male', age: 42},
+  {name: {first: 'Jane', last: 'Doe'}, sex: 'Female', age: 36},
+  {name: {first: 'Rubin', last: 'Kincade'}, sex: 'male', age: 73},
+  {name: {first: 'Shirley', last: 'Partridge'}, sex: 'female', age: 62},
+]
+</script>

--- a/apps/docs/src/docs/components/demo/TableRawHtml.vue
+++ b/apps/docs/src/docs/components/demo/TableRawHtml.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <b-table :items="items">
+      <template #cell(html)="data">
+        <!-- eslint-disable vue/no-v-html -->
+        <span v-html="data.value" />
+      </template>
+    </b-table>
+  </div>
+</template>
+
+<script setup lang="ts">
+const items = [
+  {
+    text: 'This is <i>escaped</i> content',
+    html: 'This is <i>raw <strong>HTML</strong></i> <span style="color:red">content</span>',
+  },
+]
+</script>

--- a/apps/docs/src/docs/components/demo/TableSortBy.vue
+++ b/apps/docs/src/docs/components/demo/TableSortBy.vue
@@ -23,7 +23,7 @@ const items: TableItem<SortPerson>[] = [
   {isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney'},
 ]
 
-const fields: Exclude<TableFieldRaw<SortPerson>, string>[] = [
+const fields: TableFieldRaw<SortPerson>[] = [
   {key: 'last_name', sortable: true},
   {key: 'first_name', sortable: true},
   {key: 'age', sortable: true},

--- a/apps/docs/src/docs/components/demo/TableSortByMulti.vue
+++ b/apps/docs/src/docs/components/demo/TableSortByMulti.vue
@@ -23,7 +23,7 @@ const sortItems: TableItem<SortPerson>[] = [
   {isActive: true, age: 38, first_name: 'Jami', last_name: 'Carney'},
 ]
 
-const sortFields: Exclude<TableFieldRaw<SortPerson>, string>[] = [
+const sortFields: TableFieldRaw<SortPerson>[] = [
   {key: 'last_name', sortable: true},
   {key: 'first_name', sortable: true},
   {key: 'age', sortable: true},

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -345,7 +345,78 @@ information on the `busy` state.
 
 ## Custom data rendering
 
-To Be Completed
+Custom rendering for each data field in a row is possible using either
+[scoped slots](https://vuejs.org/guide/components/slots.html#scoped-slots) or a formatter callback
+function, or a combination of both.
+
+### Scoped field slots
+
+Scoped field slots give you greater control over how the record data appears. You can use scoped
+slots to provided custom rendering for a particular field. If you want to add an extra field which
+does not exist in the records, just add it to the [`fields`](#fields-column-definitions) array, and
+then reference the field(s) in the scoped slot(s). Scoped field slots use the following naming
+syntax: `` `'cell(${field_key})'` ``.
+
+You can use the default _fall-back_ scoped slot `'cell()'` to format any cells that do not have an
+explicit scoped slot provided.
+
+<<< DEMO ./demo/TableCustomData.vue
+
+The slot's scope variable (`data` in the above sample) will have the following properties:
+
+| Property         | Type                               | Description                                                                                                                                                               |
+| ---------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index`          | number                             | The row number (indexed from zero) relative to the _displayed_ rows                                                                                                       |
+| `item`           | Items                              | The entire raw record data (i.e. `items[index]`) for this row (before any formatter is applied)                                                                           |
+| `value`          | unknown                            | The value for this key in the record (`null` or `undefined` if a virtual column), or the output of the field's [`formatter` function](#formatter-callback)                |
+| `unformatted`    | unknown                            | The raw value for this key in the item record (`null` or `undefined` if a virtual column), before being passed to the field's [`formatter` function](#formatter-callback) |
+| `field`          | `(typeof computedFields.value)[0]` | The field's normalized field definition object                                                                                                                            |
+| `detailsShowing` | boolean                            | Will be `true` if the row's `row-details` scoped slot is visible. See section [Row details support](#row-details-support) below for additional information                |
+| `toggleDetails`  | `() => void`                       | Can be called to toggle the visibility of the rows `row-details` scoped slot. See section [Row details support](#row-details-support) below for additional information    |
+| `rowSelected`    | boolean                            | Will be `true` if the row has been selected. See section [Row select support](#row-select-support) for additional information                                             |
+| `selectRow`      | `(index?: number) => void`         | When called, selects the current row. See section [Row select support](#row-select-support) for additional information                                                    |
+| `unselectRow`    | `(index?: number) => void`         | When called, unselects the current row. See section [Row select support](#row-select-support) for additional information                                                  |
+
+**Notes:**
+
+- `index` will not always be the actual row's index number, as it is computed after filtering,
+  sorting and pagination have been applied to the original table data. The `index` value will refer
+  to the **displayed row number**. This number will align with the indexes from the optional
+  [`v-model` bound](#v-model-binding) variable.
+- When using the `v-slot` syntax, note that slot names **cannot** contain spaces, and
+  when using in-browser DOM templates the slot names will _always_ be lower cased. To get around
+  this, you can pass the slot name using Vue's
+  [dynamic slot names](https://vuejs.org/guide/components/slots.html#dynamic-slot-names)
+
+#### Displaying raw HTML
+
+By default `BTable` escapes HTML tags in items data and results of formatter functions, if you need
+to display raw HTML code in `BTable`, you should use `v-html` directive on an element in a in
+scoped field slot.
+
+<<< DEMO ./demo/TableRawHtml.vue
+
+::: danger WARNING
+Be cautious of using the <code>v-html</code> method to display user
+supplied content, as it may make your application vulnerable to
+<a class="alert-link" href="https://en.wikipedia.org/wiki/Cross-site_scripting">
+<abbr title="Cross Site Scripting Attacks">XSS attacks</abbr></a>, if you do not first
+<a class="alert-link" href="https://en.wikipedia.org/wiki/HTML_sanitization">sanitize</a> the
+user supplied string.
+:::
+
+### Formatter callback
+
+Optionally, you can customize field output by using a formatter callback function. To enable this,
+the field's `formatter` property is used. The value of this property may be String or function
+reference. In case of a String value, the function must be defined at the parent component's
+methods. When providing `formatter` as a `Function`, it must be declared at global scope (window or
+as global mixin at Vue, or as an anonymous function), unless it has been bound to a `this` context.
+
+The callback function accepts three arguments - `value`, `key`, and `item`, and should return the
+formatted value as a string (HTML strings are not supported)
+
+<<< DEMO ./demo/TableFormatter.vue
 
 ## Header and Footer custom rendering via scoped slots
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -595,8 +595,8 @@ The following properties are <NotYetImplemented/> -
 
 ### Field Definitions
 
-`formatter` Only the callback function value for this field is implemented, not adding the name
-of a method in the component.
+`formatter` Only the callback function value for this field is implemented, adding the name
+of a method in the component is deprecated.
 
 `sortKey` and `sortDirection` are deprecated, use the table's `sortBy` model as documented [here](/docs/components/table#sorting) instead.
 


### PR DESCRIPTION
# Describe the PR

- Port the docs from BSV for custom data rendering of BTables
- Update the examples
- Update migration guide
- Address #2510 in the migration guide

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
