### PR TITLE
fix(BLink): Create and export Opacity and Offset types

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -738,6 +738,10 @@ watch(
   }
 }
 
+.custom-block {
+  margin-bottom: 1rem;
+}
+
 @media (min-width: 992px) {
   .offcanvas-header.offcanvas-hidden-width .btn-close {
     display: none !important;

--- a/apps/docs/src/docs/components/demo/LinkColors.vue
+++ b/apps/docs/src/docs/components/demo/LinkColors.vue
@@ -1,0 +1,19 @@
+<template>
+  <p v-for="color in variants" :key="color">
+    <BLink :variant="color"> {{ color }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BaseColorVariant} from 'bootstrap-vue-next'
+const variants: (keyof BaseColorVariant)[] = [
+  'primary',
+  'secondary',
+  'success',
+  'danger',
+  'warning',
+  'info',
+  'light',
+  'dark',
+]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkDisabled.css
+++ b/apps/docs/src/docs/components/demo/LinkDisabled.css
@@ -1,0 +1,3 @@
+a.disabled {
+  pointer-events: none;
+}

--- a/apps/docs/src/docs/components/demo/LinkDisabled.vue
+++ b/apps/docs/src/docs/components/demo/LinkDisabled.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- #region template -->
+  <BLink href="#foo" disabled>Disabled Link</BLink>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/LinkExternal.vue
+++ b/apps/docs/src/docs/components/demo/LinkExternal.vue
@@ -1,0 +1,9 @@
+<template>
+  <!-- #region template -->
+  <BLink href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener" class="me-2">
+    External Link to Bootstrap
+  </BLink>
+  <BLink to="sample" class="me-2"> To page sample </BLink>
+  <BLink href="#comp-ref--props"> Jump to Properties </BLink>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/LinkHoverVariants.vue
+++ b/apps/docs/src/docs/components/demo/LinkHoverVariants.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- #region template -->
+  <BLink
+    :underline-offset="3"
+    underline-opacity="25"
+    underline-offset-hover="1"
+    underline-opacity-hover="100"
+  >
+    Mutliple variants
+  </BLink>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/LinkOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacity.vue
@@ -5,6 +5,6 @@
 </template>
 
 <script setup lang="ts">
-import {type BvnComponentProps} from 'bootstrap-vue-next'
-const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+import {type LinkOpacity} from 'bootstrap-vue-next'
+const opacities: LinkOpacity[] = [10, 25, 50, 75, 100]
 </script>

--- a/apps/docs/src/docs/components/demo/LinkOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacity.vue
@@ -1,0 +1,10 @@
+<template>
+  <p v-for="opacity in opacities" :key="opacity">
+    <BLink :opacity="opacity"> {{ opacity }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BvnComponentProps} from 'bootstrap-vue-next'
+const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
@@ -5,6 +5,6 @@
 </template>
 
 <script setup lang="ts">
-import {type BvnComponentProps} from 'bootstrap-vue-next'
-const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+import {type LinkOpacity} from 'bootstrap-vue-next'
+const opacities: LinkOpacity[] = [10, 25, 50, 75, 100]
 </script>

--- a/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
@@ -1,0 +1,10 @@
+<template>
+  <p v-for="opacity in opacities" :key="opacity">
+    <BLink :opacity-hover="opacity"> {{ opacity }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BvnComponentProps} from 'bootstrap-vue-next'
+const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkSimple.vue
+++ b/apps/docs/src/docs/components/demo/LinkSimple.vue
@@ -1,0 +1,5 @@
+<template>
+  <!-- #region template -->
+  <BLink>Link</BLink>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/LinkStyles.vue
+++ b/apps/docs/src/docs/components/demo/LinkStyles.vue
@@ -1,0 +1,20 @@
+<template>
+  <!-- #region template -->
+  <BLink
+    class="btn btn-primary me-2"
+    href="https://getbootstrap.com/docs/5.3"
+    target="_blank"
+    rel="noopener"
+  >
+    External Link to Bootstrap
+  </BLink>
+  <BLink
+    class="btn btn-primary disabled"
+    href="https://getbootstrap.com/docs/5.3"
+    target="_blank"
+    rel="noopener"
+  >
+    Disabled Link
+  </BLink>
+  <!-- #endregion template -->
+</template>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineColors.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineColors.vue
@@ -1,0 +1,19 @@
+<template>
+  <p v-for="color in variants" :key="color">
+    <BLink :underline-variant="color"> {{ color }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BaseColorVariant} from 'bootstrap-vue-next'
+const variants: (keyof BaseColorVariant)[] = [
+  'primary',
+  'secondary',
+  'success',
+  'danger',
+  'warning',
+  'info',
+  'light',
+  'dark',
+]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
@@ -5,6 +5,6 @@
 </template>
 
 <script setup lang="ts">
-import {type BvnComponentProps} from 'bootstrap-vue-next'
-const offsets: BvnComponentProps['BLink']['underlineOffset'][] = [1, 2, 3]
+import {type UnderlineOffset} from 'bootstrap-vue-next'
+const offsets: UnderlineOffset[] = [1, 2, 3]
 </script>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
@@ -1,0 +1,10 @@
+<template>
+  <p v-for="offset in offsets" :key="offset">
+    <BLink :underline-offset="offset"> {{ offset }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BvnComponentProps} from 'bootstrap-vue-next'
+const offsets: BvnComponentProps['BLink']['underlineOffset'][] = [1, 2, 3]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
@@ -1,0 +1,10 @@
+<template>
+  <p v-for="opacity in opacities" :key="opacity">
+    <BLink :underline-opacity="opacity"> {{ opacity }} link </BLink>
+  </p>
+</template>
+
+<script setup lang="ts">
+import {type BvnComponentProps} from 'bootstrap-vue-next'
+const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+</script>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
@@ -5,6 +5,6 @@
 </template>
 
 <script setup lang="ts">
-import {type BvnComponentProps} from 'bootstrap-vue-next'
-const opacities: BvnComponentProps['BLink']['opacity'][] = [10, 25, 50, 75, 100]
+import {type UnderlineOpacity} from 'bootstrap-vue-next'
+const opacities: UnderlineOpacity[] = [10, 25, 50, 75, 100]
 </script>

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -13,7 +13,7 @@ Easily extend form controls by adding text, buttons, or button groups on either 
 You can attach addons using either props, named slots and/or sub-components.
 
 ::: info NOTE
-Bootstrap 5 dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups. The sub-components are added for compatibility reasons.
+Bootstrap 5 dropped `.input-group-append` and `.input-group-prepend`. You can now just add buttons and `.input-group-text` as direct children of the input groups.
 :::
 
 ### Using `prepend` and `append` props

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -10,16 +10,7 @@ Use BootstrapVue's custom b-link component for generating a standard `<a>` link 
 
 By defaut links with no options will default to # location.
 
-<HighlightCard>
-  <BLink>Link</BLink>
-  <template #html>
-
-```vue-html
-  <BLink>Link</BLink>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkSimple.vue#template{vue-html}
 
 ## Links with Router and External Links
 
@@ -34,96 +25,23 @@ If your app is running under [Nuxt.js](https://nuxtjs.org), the
 `<router-link>`. The `<nuxt-link>` component supports all the same features as `<router-link>` (as
 it is a wrapper component for `<router-link>`) and more.
 
-<HighlightCard>
-  <BLink href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-    External Link to Bootstrap
-  </BLink>
-  <BLink to="sample">
-    To page sample
-  </BLink>
-  <BLink href="#comp-ref--props">
-    Jump to Properties
-  </BLink>
-  <template #html>
-
-```vue-html
-<BLink href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-  External Link to Bootstrap
-</BLink>
-
-<BLink to="sample">
-  To page sample
-</BLink>
-
-<BLink href="#comp-ref--props">
-  Jump to Properties
-</BLink>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkExternal.vue#template{vue-html}
 
 ## Styling Links
 
 External Links can be specified with the `href` prop.
 
-<HighlightCard>
-  <BLink class="btn btn-primary me-2" href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-      External Link to Bootstrap
-  </BLink>
-  <BLink class="btn btn-primary disabled" href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-      Disabled Link
-  </BLink>
-  <template #html>
-
-```vue-html
-<BLink class="btn btn-primary m-2" href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-  External Link to Bootstrap
-</BLink>
-
-<BLink class="btn btn-primary disabled m-2" href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener">
-  Disabled Link
-</BLink>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkStyles.vue#template{vue-html}
 
 ## Link opacity
 
 Change the alpha opacity of the link `rgba()` color value. Please be aware that changes to a color’s opacity can lead to links with [insufficient contrast](https://getbootstrap.com/docs/5.3/getting-started/accessibility/#color-contrast).
 
-<HighlightCard>
-  <p v-for="opacity in [10, 25, 50, 75, 100]" :key="opacity">
-    <BLink :opacity="opacity"> {{ opacity }} link </BLink>
-  </p>
-  <template #html>
-
-```vue-html
-<p v-for="opacity in [10, 25, 50, 75, 100]" :key="opacity">
-  <BLink :opacity="opacity"> {{ opacity }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkOpacity.vue
 
 You can even change the opacity level on hover.
 
-<HighlightCard>
-  <p v-for="opacity in [10, 25, 50, 75, 100]" :key="opacity">
-    <BLink :opacity-hover="opacity"> {{ opacity }} link </BLink>
-  </p>
-  <template #html>
-
-```vue-html
-<p v-for="opacity in [10, 25, 50, 75, 100]" :key="opacity">
-  <BLink :opacity-hover="opacity"> {{ opacity }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkOpacityHover.vue
 
 ## Link underlines
 
@@ -131,200 +49,59 @@ You can even change the opacity level on hover.
 
 Change the underline’s color independent of the link text color.
 
-<HighlightCard>
-  <p
-    v-for="color in [
-      'primary',
-      'secondary',
-      'success',
-      'danger',
-      'warning',
-      'info',
-      'light',
-      'dark',
-    ]"
-    :key="color"
-  >
-    <BLink :underline-variant="color"> {{ color }} link </BLink>
-  </p>
-  <template #html>
-
-```vue-html
-<p
-  v-for="color in [
-    'primary',
-    'secondary',
-    'success',
-    'danger',
-    'warning',
-    'info',
-    'light',
-    'dark',
-  ]"
-  :key="color"
->
-  <BLink :underline-variant="color"> {{ color }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkUnderlineColors.vue
 
 ### Underline offset
 
 Change the underline’s distance from your text. Offset is set in `em` units to automatically scale with the element’s current `font-size`.
 
-<HighlightCard>
-  <p v-for="offset in [1, 2, 3]" :key="offset">
-    <BLink :underline-offset="offset"> {{ offset }} link </BLink>
-  </p>
-
-<template #html>
-
-```vue-html
-<p v-for="offset in [1, 2, 3]" :key="offset">
-  <BLink :underline-offset="offset"> {{ offset }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkUnderlineOffsets.vue
 
 ### Underline opacity
 
 Change the underline’s opacity.
 
-<HighlightCard>
-  <p v-for="opacity in [0, 10, 25, 50, 75, 100]" :key="opacity">
-    <BLink :underline-opacity="opacity"> {{ opacity }} link </BLink>
-  </p>
-  <template #html>
-
-```vue-html
-<p v-for="opacity in [0, 10, 25, 50, 75, 100]" :key="opacity">
-  <BLink :underline-opacity="opacity"> {{ opacity }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkUnderlineOpacity.vue
 
 ### Hover variants
 
 Just like the setting `opacity` has a matching `opacity-hover` prop, `underline-offset` and `underline-opacity` have matching
 `underline-offset-hover` and `underline-opacity-hover` props. Mix and match to create unique link styles.
 
-<HighlightCard>
-  <BLink
-    :underline-offset="3"
-    underline-opacity="25"
-    underline-offset-hover="1"
-    underline-opacity-hover="100"
-  >
-    Mutliple variants
-  </BLink>
-  <template #html>
-
-```vue-html
-<BLink
-  :underline-offset="3"
-  underline-opacity="25"
-  underline-offset-hover="1"
-  underline-opacity-hover="100"
->
-  Mutliple variants
-</BLink>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkHoverVariants.vue#template{vue-html}
 
 ## Colored Links
 
 You can use the `variant` prop to colorize links. Some of the link styles use a relatively light foreground color, and should only be used on a dark background in order to have sufficient contrast.
 
-<HighlightCard>
-  <p
-    v-for="color in [
-      'primary',
-      'secondary',
-      'success',
-      'danger',
-      'warning',
-      'info',
-      'light',
-      'dark',
-    ]"
-    :key="color"
-  >
-    <BLink :variant="color"> {{ color }} link </BLink>
-  </p>
-  <template #html>
-
-```vue-html
-<p
-  v-for="color in [
-    'primary',
-    'secondary',
-    'success',
-    'danger',
-    'warning',
-    'info',
-    'light',
-    'dark',
-  ]"
-  :key="color"
->
-  <BLink :variant="color"> {{ color }} link </BLink>
-</p>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkColors.vue
 
 ## Link disabled state
 
 Disable link functionality by setting the `disabled` prop to true.
 
-<HighlightCard>
-  <BLink href="#foo" disabled>Disabled Link</BLink>
-  <template #html>
-
-```vue-html
-  <BLink href="#foo" disabled>Disabled Link</BLink>
-```
-
-  </template>
-</HighlightCard>
+<<< DEMO ./demo/LinkDisabled.vue#template{vue-html}
 
 Disabling a link will set the Bootstrap v5 `.disabled` class on the link as well as handles stopping
 event propagation, preventing the default action from occurring, and removing the link from the
 document tab sequence (`tabindex="-1"`).
 
-<NoteAlert> Bootstrap v5 CSS currently does not style disabled links differently than non-disabled
+::: info NOTE
+Bootstrap v5 CSS currently does not style disabled links differently than non-disabled
 links. You can use the following custom CSS to style disabled links (by preventing hover style
-changes):
-</NoteAlert>
+changes).
+:::
 
-<HighlightCard>
-
-<template #html>
-
-```css
-a.disabled {
-  pointer-events: none;
-}
-```
-
-</template>
-</HighlightCard>
+<<< FRAGMENT ./demo/LinkDisabled.css
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
-import {data} from '../../data/components/link.data'
-import ComponentReference from '../../components/ComponentReference.vue'
-import HighlightCard from '../../components/HighlightCard.vue'
-import NoteAlert from '../../components/NoteAlert.vue'
-import {BLink, BCard, BCardBody} from 'bootstrap-vue-next'
+<script lang="ts">
+import {data} from '../../data/components/inputGroup.data'
+
+export default {
+  setup() {
+    return {data}
+  }
+}
 </script>

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -274,6 +274,18 @@ type InputType =
 
 </BCard>
 
+## LinkDecorators
+
+<BCard class="bg-body-tertiary">
+
+```ts
+type LinkOpacity = 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
+type UnderlineOpacity = 0 | LinkOpacity
+type UnderlineOffset = 1 | 2 | 3 | '1' | '2' | '3'
+```
+
+</BCard>
+
 ## LinkTarget
 
 <BCard class="bg-body-tertiary">

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -52,6 +52,7 @@ import type {RadiusElementExtendables} from './RadiusElement'
 import type {SpinnerType} from './SpinnerType'
 import type {PlaceholderAnimation, PlaceholderSize} from './PlaceholderTypes'
 import type {ButtonType} from './ButtonType'
+import type {LinkOpacity, UnderlineOffset, UnderlineOpacity} from './LinkDecorators'
 import type {LiteralUnion} from './LiteralUnion'
 import type {BreadcrumbItemRaw} from './BreadcrumbTypes'
 import type {TransitionMode} from './TransitionMode'
@@ -75,8 +76,8 @@ export interface BLinkProps {
   href?: string
   icon?: boolean
   noRel?: boolean
-  opacity?: 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
-  opacityHover?: 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
+  opacity?: LinkOpacity
+  opacityHover?: LinkOpacity
   prefetch?: boolean
   prefetchOn?: Partial<{
     visibility: boolean
@@ -91,10 +92,10 @@ export interface BLinkProps {
   stretched?: boolean
   target?: LinkTarget
   to?: RouteLocationRaw
-  underlineOffset?: 1 | 2 | 3 | '1' | '2' | '3'
-  underlineOffsetHover?: 1 | 2 | 3 | '1' | '2' | '3'
-  underlineOpacity?: 0 | 10 | 25 | 50 | 75 | 100 | '0' | '10' | '25' | '50' | '75' | '100'
-  underlineOpacityHover?: 0 | 10 | 25 | 50 | 75 | 100 | '0' | '10' | '25' | '50' | '75' | '100'
+  underlineOffset?: UnderlineOffset
+  underlineOffsetHover?: UnderlineOffset
+  underlineOpacity?: UnderlineOpacity
+  underlineOpacityHover?: UnderlineOpacity
   underlineVariant?: ColorVariant | null
   variant?: ColorVariant | null
 }

--- a/packages/bootstrap-vue-next/src/types/LinkDecorators.ts
+++ b/packages/bootstrap-vue-next/src/types/LinkDecorators.ts
@@ -1,0 +1,3 @@
+export type LinkOpacity = 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
+export type UnderlineOpacity = 0 | LinkOpacity
+export type UnderlineOffset = 1 | 2 | 3 | '1' | '2' | '3'

--- a/packages/bootstrap-vue-next/src/types/index.ts
+++ b/packages/bootstrap-vue-next/src/types/index.ts
@@ -48,6 +48,7 @@ export type {
 } from './SelectTypes'
 export type {InputType} from './InputType'
 export type {LinkTarget} from './LinkTarget'
+export type {LinkOpacity, UnderlineOffset, UnderlineOpacity} from './LinkDecorators'
 export type {LiteralUnion} from './LiteralUnion'
 export type {PaginationPage} from './PaginationPage'
 export type {PlaceholderAnimation, PlaceholderSize} from './PlaceholderTypes'


### PR DESCRIPTION
# Describe the PR

- Create and export types used by examples (and possibly useful elsewhere) - addresses #2537
    - `LinkOpacity`
    - `UnderlineOpacity`
    - `UnderlineOffset`
- Add the above types to `types.md`
- Refactor the examples for BLink into their own files
- Fix linting/typescript issues uncovered by the refactor
- Add some space below custom notes

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
