### PR TITLE
docs(BTable): Add the header/footer slot docs and examples

### DIFF
--- a/apps/docs/src/docs/components/demo/TableHeadSlot.vue
+++ b/apps/docs/src/docs/components/demo/TableHeadSlot.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <BTable :fields="fields" :items="items" foot-clone>
+      <!-- A custom formatted data column cell -->
+      <template #cell(name)="data">
+        {{ (data.value as any as Name).first }} {{ (data.value as any as Name).last }}
+      </template>
+
+      <!-- A custom formatted header cell for field 'name' -->
+      <template #head(name)="data">
+        <span class="text-info">{{ data.label!.toUpperCase() }}</span>
+      </template>
+
+      <!-- A custom formatted footer cell for field 'name' -->
+      <template #foot(name)="data">
+        <span class="text-danger">{{ data.label }}</span>
+      </template>
+
+      <!-- Default fall-back custom formatted footer cell -->
+      <template #foot()="data">
+        <i>{{ data.label }}</i>
+      </template>
+    </BTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+type Name = {first: string; last: string}
+
+const fields = [
+  // A column that needs custom formatting
+  {key: 'name', label: 'Full Name'},
+  // A regular column
+  'age',
+  // A regular column
+  'sex',
+]
+const items = [
+  {name: {first: 'John', last: 'Doe'}, sex: 'Male', age: 42},
+  {name: {first: 'Jane', last: 'Doe'}, sex: 'Female', age: 36},
+  {name: {first: 'Rubin', last: 'Kincade'}, sex: 'Male', age: 73},
+  {name: {first: 'Shirley', last: 'Partridge'}, sex: 'Female', age: 62},
+]
+</script>

--- a/apps/docs/src/docs/components/demo/TableHeaderRows.vue
+++ b/apps/docs/src/docs/components/demo/TableHeaderRows.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <BTable :items="items" :fields="fields" responsive="sm">
+      <template #thead-top>
+        <BTr>
+          <BTh colspan="2"><span class="visually-hidden">Name and ID</span></BTh>
+          <BTh variant="secondary">Type 1</BTh>
+          <BTh variant="primary" colspan="3">Type 2</BTh>
+          <BTh variant="danger">Type 3</BTh>
+        </BTr>
+      </template>
+    </BTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+const items = [
+  {
+    name: 'Stephen Hawking',
+    id: 1,
+    type1: false,
+    type2a: true,
+    type2b: false,
+    type2c: false,
+    type3: false,
+  },
+  {
+    name: 'Johnny Appleseed',
+    id: 2,
+    type1: false,
+    type2a: true,
+    type2b: true,
+    type2c: false,
+    type3: false,
+  },
+  {
+    name: 'George Washington',
+    id: 3,
+    type1: false,
+    type2a: false,
+    type2b: false,
+    type2c: false,
+    type3: true,
+  },
+  {
+    name: 'Albert Einstein',
+    id: 4,
+    type1: true,
+    type2a: false,
+    type2b: false,
+    type2c: true,
+    type3: false,
+  },
+  {
+    name: 'Isaac Newton',
+    id: 5,
+    type1: true,
+    type2a: true,
+    type2b: false,
+    type2c: true,
+    type3: false,
+  },
+]
+const fields = [
+  'name',
+  {key: 'id', label: 'ID'},
+  {key: 'type1', label: 'Type 1'},
+  {key: 'type2a', label: 'Type 2A'},
+  {key: 'type2b', label: 'Type 2B'},
+  {key: 'type2c', label: 'Type 2C'},
+  {key: 'type3', label: 'Type 3'},
+]
+</script>

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -420,11 +420,83 @@ formatted value as a string (HTML strings are not supported)
 
 ## Header and Footer custom rendering via scoped slots
 
-To Be Completed
+It is also possible to provide custom rendering for the table's `thead` and `tfoot` elements. Note by
+default the table footer is not rendered unless `foot-clone` is set to `true`.
+
+Scoped slots for the header and footer cells uses a special naming convention of
+`'head(<fieldkey>)'` and `'foot(<fieldkey>)'` respectively. if a `'foot(...)'` slot for a field is
+not provided, but a `'head(...)'` slot is provided, then the footer will use the `'head(...)'` slot
+content.
+
+You can use a default _fall-back_ scoped slot `'head()'` or `'foot()'` to format any header or
+footer cells that do not have an explicit scoped slot provided.
+
+<<< DEMO ./demo/TableHeadSlot.vue
+
+The slots can be optionally scoped (`data` in the above example), and will have the following
+properties:
+
+| Property        | Type                        | Description                                                                               |
+| --------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| `column`        | `LiteralUnion<keyof Items>` | The fields's `key` value                                                                  |
+| `field`         | `TableField<Items>`         | the field's object (from the `fields` prop)                                               |
+| `label`         | `string \| undefined`       | The fields label value (also available as `data.field.label`)                             |
+| `isFoot`        | `boolean`                   | Currently rending the foot if `true`                                                      |
+| `selectAllRows` | `() => void`                | Select all rows (applicable if the table is in [`selectable`](#row-select-support) mode   |
+| `clearSelected` | `() => void`                | Unselect all rows (applicable if the table is in [`selectable`](#row-select-support) mode |
+
+When placing inputs, buttons, selects or links within a `head(...)` or `foot(...)` slot, note that
+`head-clicked` event will not be emitted when the input, select, textarea is clicked (unless they
+are disabled). `head-clicked` will never be emitted when clicking on links or buttons inside the
+scoped slots (even when disabled)
+
+**Notes:**
+
+- Slot names **cannot** contain spaces, and when using in-browser DOM templates the slot names will _always_
+- be lower cased. To get around this, you can pass the slot name using Vue's
+  [dynamic slot names](https://vuejs.org/guide/components/slots.html#dynamic-slot-names)
+
+### Adding additional rows to the header
+
+If you wish to add additional rows to the header you may do so via the `thead-top` slot. This slot
+is inserted before the header cells row, and is not automatically encapsulated by `<tr>..</tr>`
+tags. It is recommended to use the BootstrapVue [table helper components](#table-helper-components),
+rather than native browser table child elements.
+
+<<< DEMO ./demo/TableHeaderRows.vue
+
+Slot `thead-top` can be optionally scoped, receiving an object with the following properties:
+
+| Property        | Type                  | Description                                                                               |
+| --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
+| `columns`       | `number`              | The number of columns in the rendered table                                               |
+| `fields`        | `TableField<Items>[]` | Array of field definition objects (normalized to the array of objects format)             |
+| `selectAllRows` | `() => void`          | Select all rows (applicable if the table is in [`selectable`](#row-select-support) mode   |
+| `clearSelected` | `() => void`          | Unselect all rows (applicable if the table is in [`selectable`](#row-select-support) mode |
+
+### Creating a custom footer
+
+If you need greater layout control of the content of the `<tfoot>`, you can use the optionally
+scoped slot `custom-foot` to provide your own rows and cells. Use BootstrapVue's
+[table helper sub-components](#table-helper-components) `<BTr>`, `<BTh>`, and `<BTd>` to generate
+your custom footer layout.
+
+Slot `custom-foot` can be optionally scoped, receiving an object with the following properties:
+
+| Property  | Type                  | Description                                                                                |
+| --------- | --------------------- | ------------------------------------------------------------------------------------------ |
+| `columns` | `number`              | The number of columns in the rendered table                                                |
+| `fields`  | `TableField<Items>[]` | Array of field definition objects (normalized to the array of objects format)              |
+| `items`   | `readonly Items[]`    | Array of the currently _displayed_ items records - after filtering, sorting and pagination |
+
+**Notes:**
+
+- The `custom-foot` slot will **not** be rendered if the `foot-clone` prop has been set.
+- `head-clicked` events are not be emitted when clicking on `custom-foot` cells.
+- Sorting and sorting icons are not available for cells in the `custom-foot` slot.
+- The custom footer will not be shown when the table is in visually stacked mode.
 
 ## Custom empty and emptyfiltered rendering via slots
-
-To Be Completed
 
 ## Advanced Features
 


### PR DESCRIPTION
# Describe the PR

- Add the header/footer slot section to the Table documentation
- Port the examples from BSV
- Create bugs for missing compatibility

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
