### PR TITLE
fix(OpenCollective): Make AvatarCard currency default to USD if not specified

### DIFF
--- a/apps/docs/src/components/OpenCollectiveMemberDisplayAvatarCard.vue
+++ b/apps/docs/src/components/OpenCollectiveMemberDisplayAvatarCard.vue
@@ -20,7 +20,7 @@
           {{
             new Intl.NumberFormat('en-US', {
               style: 'currency',
-              currency: member.currency,
+              currency: member.currency ?? 'USD',
               maximumFractionDigits: 0,
             }).format(member.totalAmountDonated)
           }}</small


### PR DESCRIPTION
# Describe the PR

When building the docs locally, it pulled in a new contributor who had contributed $10, but the API isn't specifying the currency for some reason:

```
		"MemberId": 0000,
		"createdAt": "2025-02-01 13:18",
		"type": "USER",
		"role": "FOLLOWER",
		"isActive": true,
		"totalAmountDonated": 10,
		"currency": "USD",
		"lastTransactionAt": "2025-02-01 13:24",
		"lastTransactionAmount": 10,
		"profile": "https://opencollective.com/xxxxx",
		"name": "XXXX XXXX",
		"company": null,
		"description": null,
		"image": "https://opencollective-production.s3.us-west-1.amazonaws.com/deadf960-e768-11ea-9f8b-49726fcd5851.jpg",
		"email": null,
		"newsletterOptIn": null,
		"twitter": null,
		"github": "https://github.com/xxxx",
		"website": null
```

Defaulting to `USD` in this case seems reasonable.

## Small replication

Build and run the docs

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
