### PR TITLE
fix: make attributes reactive in Accordion, Tab, Dropdown*, etc.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BAccordion/BAccordionItem.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="accordion-item" v-bind="props.wrapperAttrs" :class="wrapperClass">
+  <div class="accordion-item" v-bind="props.wrapperAttrs" :class="processedAttrs.wrapperClass">
     <BCollapse
       :id="computedId"
       v-model="modelValue"
       class="accordion-collapse"
       :class="props.collapseClass"
       :aria-labelledby="`${computedId}-heading`"
-      v-bind="collapseAttrs"
+      v-bind="processedAttrs.collapseAttrs"
       :tag="props.tag"
       :show="props.show"
       :horizontal="props.horizontal"
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import {inject, nextTick, onMounted, useAttrs, watch} from 'vue'
+import {computed, inject, nextTick, onMounted, useAttrs, watch} from 'vue'
 import BCollapse from '../BCollapse/BCollapse.vue'
 import {accordionInjectionKey} from '../../utils/keys'
 import {useDefaults} from '../../composables/useDefaults'
@@ -63,7 +63,11 @@ import type {showHideEmits} from '../../composables/useShowHide'
 defineOptions({
   inheritAttrs: false,
 })
-const {class: wrapperClass, ...collapseAttrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...collapseAttrs} = attrs
+  return {wrapperClass, collapseAttrs}
+})
 
 const _props = withDefaults(defineProps<Omit<BAccordionItemProps, 'modelValue'>>(), {
   bodyAttrs: undefined,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownDivider.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownDivider.vue
@@ -1,18 +1,18 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="wrapperAttrs">
     <component
       :is="props.tag"
       class="dropdown-divider"
       :class="props.dividerClass"
       role="separator"
       aria-orientation="horizontal"
-      v-bind="attrs"
+      v-bind="processedAttrs.dividerAttrs"
     />
   </li>
 </template>
 
 <script setup lang="ts">
-import {useAttrs} from 'vue'
+import {computed, useAttrs} from 'vue'
 import {useDefaults} from '../../composables/useDefaults'
 import type {BDropdownDividerProps} from '../../types/ComponentProps'
 
@@ -20,7 +20,11 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...dividerAttrs} = attrs
+  return {wrapperClass, dividerAttrs}
+})
 
 const _props = withDefaults(defineProps<BDropdownDividerProps>(), {
   dividerClass: undefined,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownForm.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownForm.vue
@@ -1,10 +1,10 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="props.wrapperAttrs">
     <form
       class="dropdown-item-text"
       :class="computedClasses"
       :novalidate="props.novalidate"
-      v-bind="attrs"
+      v-bind="processedAttrs.formAttrs"
     >
       <slot />
     </form>
@@ -19,7 +19,11 @@ import type {BDropdownFormProps} from '../../types/ComponentProps'
 defineOptions({
   inheritAttrs: false,
 })
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...formAttrs} = attrs
+  return {wrapperClass, formAttrs}
+})
 
 const _props = withDefaults(defineProps<BDropdownFormProps>(), {
   formClass: undefined,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownHeader.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownHeader.vue
@@ -1,10 +1,10 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="wrapperAttrs">
     <component
       :is="props.tag"
       class="dropdown-header"
       :class="[colorClasses, props.headerClass]"
-      v-bind="attrs"
+      v-bind="processedAttrs.headerAttrs"
     >
       <slot>
         {{ props.text }}
@@ -22,7 +22,11 @@ import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
 defineOptions({
   inheritAttrs: false,
 })
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...headerAttrs} = attrs
+  return {wrapperClass, headerAttrs}
+})
 
 const _props = withDefaults(defineProps<BDropdownHeaderProps>(), {
   headerClass: undefined,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="props.wrapperAttrs">
     <component
       :is="computedTag"
       class="dropdown-item"
@@ -12,7 +12,7 @@
       role="menuitem"
       :type="computedTag === 'button' ? 'button' : null"
       :target="props.target"
-      v-bind="{...computedLinkProps, ...attrs}"
+      v-bind="{...computedLinkProps, ...processedAttrs.dropdownItemAttrs}"
       @click="clicked"
     >
       <slot />
@@ -66,7 +66,11 @@ const emit = defineEmits<{
   click: [value: MouseEvent]
 }>()
 
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...dropdownItemAttrs} = attrs
+  return {wrapperClass, dropdownItemAttrs}
+})
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownItemButton.vue
@@ -1,12 +1,12 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="props.wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="props.wrapperAttrs">
     <button
       role="menu"
       type="button"
       class="dropdown-item"
       :class="computedClasses"
       :disabled="props.disabled"
-      v-bind="attrs"
+      v-bind="processedAttrs.buttonAttrs"
       @click="clicked"
     >
       <slot />
@@ -38,7 +38,11 @@ const emit = defineEmits<{
   click: [value: MouseEvent]
 }>()
 
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...buttonAttrs} = attrs
+  return {wrapperClass, buttonAttrs}
+})
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownText.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdownText.vue
@@ -1,10 +1,10 @@
 <template>
-  <li role="presentation" :class="wrapperClass" v-bind="wrapperAttrs">
+  <li role="presentation" :class="processedAttrs.wrapperClass" v-bind="wrapperAttrs">
     <component
       :is="props.tag"
       class="dropdown-item-text"
       :class="[colorClasses, props.textClass]"
-      v-bind="attrs"
+      v-bind="processedAttrs.textAttrs"
     >
       <slot>
         {{ props.text }}
@@ -22,7 +22,11 @@ import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
 defineOptions({
   inheritAttrs: false,
 })
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...textAttrs} = attrs
+  return {wrapperClass, textAttrs}
+})
 
 const _props = withDefaults(defineProps<BDropdownTextProps>(), {
   textClass: undefined,

--- a/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormCheckbox/BFormCheckbox.vue
@@ -21,7 +21,7 @@
       :true-value="props.value"
       :false-value="props.uncheckedValue"
       :indeterminate="indeterminate || undefined"
-      v-bind="inputAttrs"
+      v-bind="processedAttrs.inputAttrs"
     />
     <label v-if="hasDefaultSlot || props.plain === false" :for="computedId" :class="labelClasses">
       <slot />
@@ -45,7 +45,11 @@ defineOptions({
   inheritAttrs: false,
 })
 
-const {class: wrapperClass, ...inputAttrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...inputAttrs} = attrs
+  return {wrapperClass, inputAttrs}
+})
 
 const _props = withDefaults(
   defineProps<Omit<BFormCheckboxProps, 'modelValue' | 'indeterminate'>>(),
@@ -140,7 +144,10 @@ const classesObject = computed(() => ({
   hasDefaultSlot: hasDefaultSlot.value,
 }))
 const wrapperClasses = getClasses(classesObject)
-const computedWrapperClasses = computed(() => [wrapperClasses.value, wrapperClass])
+const computedWrapperClasses = computed(() => [
+  wrapperClasses.value,
+  processedAttrs.value.wrapperClass,
+])
 const inputClasses = getInputClasses(classesObject)
 const computedInputClasses = computed(() => [inputClasses.value, props.inputClass])
 const labelClasses = getLabelClasses(classesObject)

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavForm.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavForm.vue
@@ -1,7 +1,7 @@
 <template>
   <li :class="liClasses" v-bind="wrapperAttrs">
     <BForm
-      v-bind="attrs"
+      v-bind="processedAttrs.formAttrs"
       :id="props.id"
       :floating="props.floating"
       :role="props.role"
@@ -43,7 +43,11 @@ const emit = defineEmits<{
   submit: [value: Event]
 }>()
 
-const {class: wrapperClass, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {class: wrapperClass, ...formAttrs} = attrs
+  return {wrapperClass, formAttrs}
+})
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +63,6 @@ const liClasses = computed(() => [
   'flex-row',
   'align-items-center',
   'flex-wrap',
-  wrapperClass,
+  processedAttrs.value.wrapperClass,
 ])
 </script>

--- a/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTab.vue
@@ -7,7 +7,7 @@
     :class="computedClasses"
     role="tabpanel"
     :aria-labelledby="computedButtonId"
-    v-bind="attrs"
+    v-bind="processedAttrs.tabAttrs"
   >
     <slot v-if="showSlot" />
   </component>
@@ -58,7 +58,11 @@ const computedButtonId = useId(() => props.buttonId, 'tab')
 const lazyRenderCompleted = ref(false)
 const el = useTemplateRef<HTMLElement>('_el')
 
-const {onClick, ...attrs} = useAttrs()
+const attrs = useAttrs()
+const processedAttrs = computed(() => {
+  const {onClick, ...tabAttrs} = attrs
+  return {onClick, tabAttrs}
+})
 
 const tab = computed(
   () =>
@@ -71,7 +75,7 @@ const tab = computed(
       titleItemClass: () => props.titleItemClass,
       titleLinkAttrs: () => props.titleLinkAttrs,
       titleLinkClass: () => props.titleLinkClass,
-      onClick,
+      onClick: processedAttrs.value.onClick,
       el: el.value,
     }) as TabType
 )


### PR DESCRIPTION
# Describe the PR

This is a direct copy of @VividLemon's changes that remove the use of the spread operator on the results of useAttrs, which should resolve #2541 

## Small replication

See the bug

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
