### PR TITLE
fix(BLink): Allow  "0" as a value for UnderlineLinkOpacity

### DIFF
--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -280,7 +280,7 @@ type InputType =
 
 ```ts
 type LinkOpacity = 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
-type UnderlineOpacity = 0 | LinkOpacity
+type UnderlineOpacity = 0 | '0' | LinkOpacity
 type UnderlineOffset = 1 | 2 | 3 | '1' | '2' | '3'
 ```
 

--- a/packages/bootstrap-vue-next/src/types/LinkDecorators.ts
+++ b/packages/bootstrap-vue-next/src/types/LinkDecorators.ts
@@ -1,3 +1,3 @@
 export type LinkOpacity = 10 | 25 | 50 | 75 | 100 | '10' | '25' | '50' | '75' | '100'
-export type UnderlineOpacity = 0 | LinkOpacity
+export type UnderlineOpacity = 0 | '0' | LinkOpacity
 export type UnderlineOffset = 1 | 2 | 3 | '1' | '2' | '3'


### PR DESCRIPTION
# Describe the PR

I missed this when adding explicit types for the link properties and now that I've got type checking on the docs build working, this prevented me from doing an `pnpm install` on main.

## Small replication

N/A

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
