### PR TITLE
fix(BDdropdown)!: Replace click event on split button with split-click

### DIFF
--- a/apps/docs/src/data/components/carousel.data.ts
+++ b/apps/docs/src/data/components/carousel.data.ts
@@ -151,7 +151,7 @@ export default {
           ],
         },
         {
-          event: 'click:prev',
+          event: 'prev-click',
           description: '',
           args: [
             {
@@ -162,7 +162,7 @@ export default {
           ],
         },
         {
-          event: 'click:next',
+          event: 'next-click',
           description: '',
           args: [
             {

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -97,7 +97,7 @@ You can view the [Floating-ui docs](https://floating-ui.com/docs/middleware) to 
 
 ## Split button support
 
-Create a split dropdown button, where the left button provides a `click:split` event and link support, while the right-hand side is the dropdown menu toggle button.
+Create a split dropdown button, where the left button provides a `split-click` event and link support, while the right-hand side is the dropdown menu toggle button.
 
 <<< DEMO ./demo/DropdownSplitButton.vue#template{vue-html}
 

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -97,7 +97,7 @@ You can view the [Floating-ui docs](https://floating-ui.com/docs/middleware) to 
 
 ## Split button support
 
-Create a split dropdown button, where the left button provides a `split-click` event and link support, while the right-hand side is the dropdown menu toggle button.
+Create a split dropdown button, where the left button provides a `click:split` event and link support, while the right-hand side is the dropdown menu toggle button.
 
 <<< DEMO ./demo/DropdownSplitButton.vue#template{vue-html}
 

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -97,7 +97,7 @@ You can view the [Floating-ui docs](https://floating-ui.com/docs/middleware) to 
 
 ## Split button support
 
-Create a split dropdown button, where the left button provides standard `click` event and link support, while the right-hand side is the dropdown menu toggle button.
+Create a split dropdown button, where the left button provides a `split-click` event and link support, while the right-hand side is the dropdown menu toggle button.
 
 <<< DEMO ./demo/DropdownSplitButton.vue#template{vue-html}
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -278,7 +278,7 @@ See [Show and Hide](#show-and-hide) shared properties.
 See the [v-html](#v-html) section for information on deprecation of the `html` prop.
 
 The `click` event that was emitted when clicking on the left or button side of a `split` dropdown
-has been replaced by a `click:split` which provides the native mouse event. This is because
+has been replaced by a `split-click` which provides the native mouse event. This is because
 naming the event 'click' was hiding the native `click` event so supressing the that event for
 parents that might have unexpected actions (such as a link navigating to a new page) was difficult.
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -278,7 +278,7 @@ See [Show and Hide](#show-and-hide) shared properties.
 See the [v-html](#v-html) section for information on deprecation of the `html` prop.
 
 The `click` event that was emitted when clicking on the left or button side of a `split` dropdown
-has been replaced by a `split-click` which provides the native mouse event. This is because
+has been replaced by a `click:split` which provides the native mouse event. This is because
 naming the event 'click' was hiding the native `click` event so supressing the that event for
 parents that might have unexpected actions (such as a link navigating to a new page) was difficult.
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -277,6 +277,11 @@ See [Show and Hide](#show-and-hide) shared properties.
 
 See the [v-html](#v-html) section for information on deprecation of the `html` prop.
 
+The `click` event that was emitted when clicking on the left or button side of a `split` dropdown
+has been replaced by a `split-click` which provides the native mouse event. This is because
+naming the event 'click' was hiding the native `click` event so supressing the that event for
+parents that might have unexpected actions (such as a link navigating to a new page) was difficult.
+
 <NotYetImplemented>`toggleAttrs`</NotYetImplemented>
 
 #### Dropdown sub-components

--- a/apps/docs/src/utils/dropdown-common.ts
+++ b/apps/docs/src/utils/dropdown-common.ts
@@ -191,7 +191,7 @@ export const dropdownEmits: ComponentReference['emits'] = [
     description: 'Emitted when the dropdown tried to open, but was prevented from doing so.',
   },
   {
-    event: 'click:split',
+    event: 'split-click',
     description: 'Emitted when split button is clicked in split mode',
     args: [
       {

--- a/apps/docs/src/utils/dropdown-common.ts
+++ b/apps/docs/src/utils/dropdown-common.ts
@@ -154,7 +154,7 @@ export const dropdownProps = {
 export const dropdownEmits: ComponentReference['emits'] = [
   {
     event: 'click',
-    description: 'Emitted when button is clicked',
+    description: 'Emitted when the main button is clicked only when in split mode.',
     args: [
       {
         arg: 'event',
@@ -200,17 +200,6 @@ export const dropdownEmits: ComponentReference['emits'] = [
   {
     event: 'show-prevented',
     description: 'Emitted when the dropdown tried to open, but was prevented from doing so.',
-  },
-  {
-    event: 'split-click',
-    description: 'Emitted when split button is clicked in split mode',
-    args: [
-      {
-        arg: 'event',
-        type: 'MouseEvent',
-        description: 'Native click event object',
-      },
-    ],
   },
   {
     event: 'toggle',

--- a/apps/docs/src/utils/dropdown-common.ts
+++ b/apps/docs/src/utils/dropdown-common.ts
@@ -153,17 +153,6 @@ export const dropdownProps = {
 
 export const dropdownEmits: ComponentReference['emits'] = [
   {
-    event: 'click',
-    description: 'Emitted when button is clicked',
-    args: [
-      {
-        arg: 'event',
-        type: 'MouseEvent',
-        description: 'Native click event object',
-      },
-    ],
-  },
-  {
     event: 'hide',
     description: 'Emitted just before dropdown is hidden. Cancelable',
     args: [

--- a/apps/docs/src/utils/dropdown-common.ts
+++ b/apps/docs/src/utils/dropdown-common.ts
@@ -191,7 +191,7 @@ export const dropdownEmits: ComponentReference['emits'] = [
     description: 'Emitted when the dropdown tried to open, but was prevented from doing so.',
   },
   {
-    event: 'split-click',
+    event: 'click:split',
     description: 'Emitted when split button is clicked in split mode',
     args: [
       {

--- a/apps/docs/src/utils/dropdown-common.ts
+++ b/apps/docs/src/utils/dropdown-common.ts
@@ -154,7 +154,7 @@ export const dropdownProps = {
 export const dropdownEmits: ComponentReference['emits'] = [
   {
     event: 'click',
-    description: 'Emitted when the main button is clicked only when in split mode.',
+    description: 'Emitted when button is clicked',
     args: [
       {
         arg: 'event',
@@ -200,6 +200,17 @@ export const dropdownEmits: ComponentReference['emits'] = [
   {
     event: 'show-prevented',
     description: 'Emitted when the dropdown tried to open, but was prevented from doing so.',
+  },
+  {
+    event: 'split-click',
+    description: 'Emitted when split button is clicked in split mode',
+    args: [
+      {
+        arg: 'event',
+        type: 'MouseEvent',
+        description: 'Native click event object',
+      },
+    ],
   },
   {
     event: 'toggle',

--- a/apps/playground/src/components/Comps/TDropdown.vue
+++ b/apps/playground/src/components/Comps/TDropdown.vue
@@ -200,7 +200,7 @@
             <BDropdown
               text="click me"
               split
-              @split-click="consoleLog('split button clicked')"
+              @click:split="consoleLog('split button clicked')"
               @click.stop.prevent="consoleLog('button clicked')"
             >
               <BDropdownItem>First Action</BDropdownItem>

--- a/apps/playground/src/components/Comps/TDropdown.vue
+++ b/apps/playground/src/components/Comps/TDropdown.vue
@@ -189,6 +189,32 @@
     </BRow>
     <BRow>
       <BCol>
+        <h4 class="m-2">Split embeded in link</h4>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol>
+        <BListGroup>
+          <BListGroupItem href="https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs">
+            Some link
+            <BDropdown
+              text="click me"
+              split
+              @split-click="consoleLog('split button clicked')"
+              @click.stop.prevent="consoleLog('button clicked')"
+            >
+              <BDropdownItem>First Action</BDropdownItem>
+              <BDropdownItem variant="primary">Second Action</BDropdownItem>
+              <BDropdownItem active>Active action</BDropdownItem>
+              <BDropdownItem disabled>Disabled action</BDropdownItem>
+              <BDropdownItem to="/docs/components/badge">Badge</BDropdownItem></BDropdown
+            >
+          </BListGroupItem>
+        </BListGroup>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol>
         <h4 class="m-2">Custom popper config</h4>
       </BCol>
     </BRow>

--- a/apps/playground/src/components/Comps/TDropdown.vue
+++ b/apps/playground/src/components/Comps/TDropdown.vue
@@ -200,7 +200,7 @@
             <BDropdown
               text="click me"
               split
-              @click:split="consoleLog('split button clicked')"
+              @split-click="consoleLog('split button clicked')"
               @click.stop.prevent="consoleLog('button clicked')"
             >
               <BDropdownItem>First Action</BDropdownItem>

--- a/apps/playground/src/components/Comps/TNav.vue
+++ b/apps/playground/src/components/Comps/TNav.vue
@@ -16,7 +16,7 @@
             text="Dropdown"
             toggle-class="nav-link-custom"
             right
-            @click:split="consoleLog('split button clicked')"
+            @split-click="consoleLog('split button clicked')"
             @click.stop.prevent="consoleLog('button clicked')"
           >
             <BDropdownItem>One</BDropdownItem>

--- a/apps/playground/src/components/Comps/TNav.vue
+++ b/apps/playground/src/components/Comps/TNav.vue
@@ -16,7 +16,7 @@
             text="Dropdown"
             toggle-class="nav-link-custom"
             right
-            @split-click="consoleLog('split button clicked')"
+            @click:split="consoleLog('split button clicked')"
             @click.stop.prevent="consoleLog('button clicked')"
           >
             <BDropdownItem>One</BDropdownItem>

--- a/apps/playground/src/components/Comps/TNav.vue
+++ b/apps/playground/src/components/Comps/TNav.vue
@@ -12,9 +12,12 @@
           <BNavItem>Link</BNavItem>
           <BNavItemDropdown
             id="my-nav-dropdown"
+            split
             text="Dropdown"
             toggle-class="nav-link-custom"
             right
+            @split-click="consoleLog('split button clicked')"
+            @click.stop.prevent="consoleLog('button clicked')"
           >
             <BDropdownItem>One</BDropdownItem>
             <BDropdownItem>Two</BDropdownItem>
@@ -45,3 +48,7 @@
     </BRow>
   </BContainer>
 </template>
+
+<script setup lang="ts">
+const consoleLog = (...args: unknown[]) => console.log(...args)
+</script>

--- a/packages/bootstrap-vue-next/src/components/BCarousel/BCarousel.vue
+++ b/packages/bootstrap-vue-next/src/components/BCarousel/BCarousel.vue
@@ -103,8 +103,8 @@ const props = useDefaults(_props, 'BCarousel')
 const emit = defineEmits<{
   'slide': [value: BvCarouselEvent]
   'slid': [value: BvCarouselEvent]
-  'click:prev': [value: MouseEvent]
-  'click:next': [value: MouseEvent]
+  'prev-click': [value: MouseEvent]
+  'next-click': [value: MouseEvent]
 }>()
 
 const slots = defineSlots<{
@@ -300,12 +300,12 @@ watch(isHovering, (newValue) => {
 })
 
 const onClickPrev = (event: MouseEvent) => {
-  emit('click:prev', event)
+  emit('prev-click', event)
   if (event.defaultPrevented) return
   prev()
 }
 const onClickNext = (event: MouseEvent) => {
-  emit('click:next', event)
+  emit('next-click', event)
   if (event.defaultPrevented) return
   next()
 }

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -149,7 +149,7 @@ const props = useDefaults(_props, 'BDropdown')
 
 const emit = defineEmits<
   {
-    'split-click': [event: MouseEvent]
+    'click:split': [event: MouseEvent]
   } & showHideEmits
 >()
 
@@ -348,7 +348,7 @@ const onButtonClick = () => {
 
 const onSplitClick = (event: Readonly<MouseEvent>) => {
   if (props.split) {
-    emit('split-click', event)
+    emit('click:split', event)
     return
   }
   onButtonClick()

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -17,7 +17,7 @@
       :aria-haspopup="props.split ? undefined : 'menu'"
       :href="props.split ? props.splitHref : undefined"
       :to="props.split && props.splitTo ? props.splitTo : undefined"
-      @click.stop.prevent="onSplitClick"
+      @click="onSplitClick"
     >
       <slot name="button-content"> {{ props.text }} </slot>
     </BButton>
@@ -32,7 +32,7 @@
       class="dropdown-toggle-split dropdown-toggle"
       :aria-expanded="showRef"
       aria-haspopup="menu"
-      @click.stop.prevent="onButtonClick"
+      @click="onButtonClick"
     >
       <span class="visually-hidden">
         <slot name="toggle-text">
@@ -58,7 +58,7 @@
           :class="[props.menuClass, computedMenuClasses]"
           :aria-labelledby="computedId"
           :role="props.role"
-          @click.stop.prevent="onClickInside"
+          @click="onClickInside"
         >
           <slot v-if="contentShowing" :hide="hide" :show="show" :visible="showRef" />
         </ul>
@@ -364,7 +364,6 @@ onClickOutside(
   {ignore: [button, splitButton]}
 )
 const onClickInside = () => {
-  console.log('click inside')
   if (showRef.value && (props.autoClose === true || props.autoClose === 'inside')) {
     hide()
   }

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -149,7 +149,7 @@ const props = useDefaults(_props, 'BDropdown')
 
 const emit = defineEmits<
   {
-    'click:split': [event: MouseEvent]
+    'split-click': [event: MouseEvent]
   } & showHideEmits
 >()
 
@@ -348,7 +348,7 @@ const onButtonClick = () => {
 
 const onSplitClick = (event: Readonly<MouseEvent>) => {
   if (props.split) {
-    emit('click:split', event)
+    emit('split-click', event)
     return
   }
   onButtonClick()

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -149,7 +149,7 @@ const props = useDefaults(_props, 'BDropdown')
 
 const emit = defineEmits<
   {
-    click: [event: MouseEvent]
+    'split-click': [event: MouseEvent]
   } & showHideEmits
 >()
 
@@ -348,7 +348,7 @@ const onButtonClick = () => {
 
 const onSplitClick = (event: Readonly<MouseEvent>) => {
   if (props.split) {
-    emit('click', event)
+    emit('split-click', event)
     return
   }
   onButtonClick()

--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -17,7 +17,7 @@
       :aria-haspopup="props.split ? undefined : 'menu'"
       :href="props.split ? props.splitHref : undefined"
       :to="props.split && props.splitTo ? props.splitTo : undefined"
-      @click="onSplitClick"
+      @click.stop.prevent="onSplitClick"
     >
       <slot name="button-content"> {{ props.text }} </slot>
     </BButton>
@@ -32,7 +32,7 @@
       class="dropdown-toggle-split dropdown-toggle"
       :aria-expanded="showRef"
       aria-haspopup="menu"
-      @click="onButtonClick"
+      @click.stop.prevent="onButtonClick"
     >
       <span class="visually-hidden">
         <slot name="toggle-text">
@@ -58,7 +58,7 @@
           :class="[props.menuClass, computedMenuClasses]"
           :aria-labelledby="computedId"
           :role="props.role"
-          @click="onClickInside"
+          @click.stop.prevent="onClickInside"
         >
           <slot v-if="contentShowing" :hide="hide" :show="show" :visible="showRef" />
         </ul>
@@ -364,6 +364,7 @@ onClickOutside(
   {ignore: [button, splitButton]}
 )
 const onClickInside = () => {
+  console.log('click inside')
   if (showRef.value && (props.autoClose === true || props.autoClose === 'inside')) {
     hide()
   }

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
@@ -279,22 +279,22 @@ describe('dropdown', () => {
     expect($bbutton.text()).toBe('slots')
   })
 
-  it('first child BButton emits click when prop split', async () => {
+  it('first child BButton does emits click:split when prop split', async () => {
     const wrapper = mount(BDropdown, {
       props: {split: true},
     })
     const $bbutton = wrapper.getComponent(BButton)
     await $bbutton.trigger('click')
-    expect($bbutton.emitted()).toHaveProperty('click')
+    expect(wrapper.emitted()).toHaveProperty('click:split')
   })
 
-  it('first child BButton does not emit click when not prop split', async () => {
+  it('first child BButton does not emit click:split when not prop split', async () => {
     const wrapper = mount(BDropdown, {
       props: {split: false},
     })
     const $bbutton = wrapper.getComponent(BButton)
     await $bbutton.trigger('click')
-    expect(wrapper.emitted()).not.toHaveProperty('click')
+    expect(wrapper.emitted()).not.toHaveProperty('click:split')
   })
 
   it('wrapper emits click when prop split', async () => {

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
@@ -279,22 +279,22 @@ describe('dropdown', () => {
     expect($bbutton.text()).toBe('slots')
   })
 
-  it('first child BButton does emits click:split when prop split', async () => {
+  it('first child BButton does emits split-click when prop split', async () => {
     const wrapper = mount(BDropdown, {
       props: {split: true},
     })
     const $bbutton = wrapper.getComponent(BButton)
     await $bbutton.trigger('click')
-    expect(wrapper.emitted()).toHaveProperty('click:split')
+    expect(wrapper.emitted()).toHaveProperty('split-click')
   })
 
-  it('first child BButton does not emit click:split when not prop split', async () => {
+  it('first child BButton does not emit split-click when not prop split', async () => {
     const wrapper = mount(BDropdown, {
       props: {split: false},
     })
     const $bbutton = wrapper.getComponent(BButton)
     await $bbutton.trigger('click')
-    expect(wrapper.emitted()).not.toHaveProperty('click:split')
+    expect(wrapper.emitted()).not.toHaveProperty('split-click')
   })
 
   it('wrapper emits click when prop split', async () => {

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
@@ -13,7 +13,7 @@
       @show-prevented="emit('show-prevented', $event)"
       @toggle-prevented="emit('toggle-prevented', $event)"
       @toggle="emit('toggle', $event)"
-      @split-click="emit('split-click', $event)"
+      @click:split="emit('click:split', $event)"
     >
       <template #button-content>
         <slot name="button-content" />
@@ -77,7 +77,7 @@ const props = useDefaults(_props, 'BNavItemDropdown')
 
 const emit = defineEmits<
   {
-    'split-click': [event: MouseEvent]
+    'click:split': [event: MouseEvent]
   } & showHideEmits
 >()
 

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
@@ -13,7 +13,7 @@
       @show-prevented="emit('show-prevented', $event)"
       @toggle-prevented="emit('toggle-prevented', $event)"
       @toggle="emit('toggle', $event)"
-      @click:split="emit('click:split', $event)"
+      @split-click="emit('split-click', $event)"
     >
       <template #button-content>
         <slot name="button-content" />
@@ -77,7 +77,7 @@ const props = useDefaults(_props, 'BNavItemDropdown')
 
 const emit = defineEmits<
   {
-    'click:split': [event: MouseEvent]
+    'split-click': [event: MouseEvent]
   } & showHideEmits
 >()
 

--- a/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BNav/BNavItemDropdown.vue
@@ -13,7 +13,7 @@
       @show-prevented="emit('show-prevented', $event)"
       @toggle-prevented="emit('toggle-prevented', $event)"
       @toggle="emit('toggle', $event)"
-      @click="emit('click', $event)"
+      @split-click="emit('split-click', $event)"
     >
       <template #button-content>
         <slot name="button-content" />
@@ -77,7 +77,7 @@ const props = useDefaults(_props, 'BNavItemDropdown')
 
 const emit = defineEmits<
   {
-    click: [event: MouseEvent]
+    'split-click': [event: MouseEvent]
   } & showHideEmits
 >()
 


### PR DESCRIPTION
# Describe the PR

Addresses #2571 

- replace the `click` event with `split-click` when the dropdown is in split mode. This prevent it from hiding the native click event and allows the user to access the native event to stop propagation
- replace the `click:prev` and `click:next` events on `BCarousel` with `prev-click` and `next-click` for consistency
- make this work for NavItemdropdown as well
- remove the documentation for `click`
- update the migration guide
- Add test cases to `TDropdown` and `TNav`
- fix up the main documentation for `BDropdown`

## Small replication

See #2571 

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
