### PR TITLE
docs:(BTable): Extend documentation and migration guide for sorting

### DIFF
--- a/apps/docs/src/docs/components/demo/TableSortBy.vue
+++ b/apps/docs/src/docs/components/demo/TableSortBy.vue
@@ -1,11 +1,12 @@
 <template>
   <BTable v-model:sort-by="sortBy" :items="items" :fields="fields" />
   <div>sortBy = {{ JSON.stringify(sortBy) }}</div>
+  <div>singleSortBy = {{ JSON.stringify(singleSortBy) }}</div>
 </template>
 
 <script setup lang="ts">
 import {type BTableSortBy, type TableFieldRaw, type TableItem} from 'bootstrap-vue-next'
-import {ref} from 'vue'
+import {computed, ref} from 'vue'
 
 interface SortPerson {
   first_name: string
@@ -31,4 +32,6 @@ const fields: TableFieldRaw<SortPerson>[] = [
 ]
 
 const sortBy = ref<BTableSortBy[]>([{key: 'first_name', order: 'desc'}])
+
+const singleSortBy = computed(() => sortBy.value.find((sb) => sb.order !== undefined))
 </script>

--- a/apps/docs/src/docs/components/demo/TableSortCompareCustom.ts
+++ b/apps/docs/src/docs/components/demo/TableSortCompareCustom.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+type T = {
+  titleField: string
+}
+/* #region snippet */
+const removeArticles = (str: string) => str.replace(/^(a |the )/i, '')
+const sortBy = [
+  {
+    key: 'titleField',
+    comparer: (a: T, b: T, key: string) =>
+      removeArticles(a.titleField).localeCompare(removeArticles(b.titleField)),
+  },
+]
+/* #endregion snippet */

--- a/apps/docs/src/docs/components/demo/TableSortCompareDefault.ts
+++ b/apps/docs/src/docs/components/demo/TableSortCompareDefault.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const getStringValue = (value: unknown): string => 'dummy string'
+/* #region snippet */
+const defaultComparer = (a: unknown, b: unknown): number =>
+  getStringValue(a).localeCompare(getStringValue(b), undefined, {numeric: true})
+/* #endregion snippet */

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -381,8 +381,7 @@ The slot's scope variable (`data` in the above sample) will have the following p
 
 - `index` will not always be the actual row's index number, as it is computed after filtering,
   sorting and pagination have been applied to the original table data. The `index` value will refer
-  to the **displayed row number**. This number will align with the indexes from the optional
-  [`v-model` bound](#v-model-binding) variable.
+  to the **displayed row number**.
 - When using the `v-slot` syntax, note that slot names **cannot** contain spaces, and
   when using in-browser DOM templates the slot names will _always_ be lower cased. To get around
   this, you can pass the slot name using Vue's
@@ -685,11 +684,11 @@ selected, such as a virtual column as shown in the example below.
 
 ### Table body transition support
 
-### `v-model` binding
+<NotYetImplemented />
 
 ## Sorting
 
-As mentioned in the [Fields](#fields) section above, you can make columns
+As mentioned in the [Fields](#fields-column-definitions) section above, you can make columns
 sortable in `<BTable>`. Clicking on a sortable column header will sort the column in ascending
 direction (smallest first), while clicking on it again will switch the direction of sorting to
 descending (largest first). Clicking on it a third time will stop sorting on the column. For
@@ -698,7 +697,7 @@ sort that column in ascending order and clear the sort order for the previously 
 
 You can control which column is pre-sorted and the order of sorting (ascending or descending). To
 pre-specify the column to be sorted use the `sortBy` model. For single column sorting (e.g. `multisort===false`)
-`sortBy` should be an array containing a single `BTableSortBy` object.
+`sortBy` should be an array containing a single `BTableSortBy` object with a defined `order` field.
 
 <<< FRAGMENT ./demo/TableSortBy.ts#snippet{ts}
 
@@ -709,7 +708,8 @@ pre-specify the column to be sorted use the `sortBy` model. For single column so
 
 By default the comparer function does a `numeric localeCompare`. If one wishes to change this, use a custom comparer function with that `BTableSortBy` element.
 
-To prevent the table from wiping out the comparer function, internally it will set the `order` key to `undefined`, instead of just removing the element from the `sortBy` array. i.e. `:sort-by="[]"` & `:sort-by="[key: 'someKey', order: undefined]"` behave identically. Naturally if this value is given to a server, orders of undefined should be handled.
+To prevent the table from wiping out the comparer function, internally it will set the `order` key to `undefined`, instead of just removing the element from the `sortBy` array. i.e. `:sort-by="[]"` & `:sort-by="[key: 'someKey', order: undefined]"` behave identically. Naturally if this value is given to a server, orders of undefined should be handled. See the computed `singleSortBy` function below as a simple means of retrieving the single sortded column reference from a table
+that is in single sort mode.
 
 <<< DEMO ./demo/TableSort.vue
 
@@ -728,7 +728,18 @@ to the `sortBy` array. From the user inteface, multi-sort works as follows:
 
 <<< DEMO ./demo/TableSortByMulti.vue
 
-### Change initial sort direction
+### Custom Sort Comparer(s)
+
+Each item in the `BSortBy` model may include a `comparer` field of the type `BTableSortByComparerFunction<T = any> = (a: T, b: T, key: string) => number`. This function takes the items to be compared and the key to compare on. Since the key is passed in, you may use the same function for multiple fields or you can craft a different comparer function for each fied. Leaving the `comparer` field undefined (or not defining a field in the `sortBy` array at all) will fall back to using hte default comparer, which looks like this:
+
+<<< FRAGMENT ./demo/TableSortCompareDefault.ts#snippet{ts}
+
+where `getStringValue` retrieves the field value as a string.
+
+If you have a particular field that you want to sort by, you can set up a record of the `sortBy` model
+with a custom comparer:
+
+<<< FRAGMENT ./demo/TableSortCompareCustom.ts#snippet{ts}
 
 ## Filtering
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -609,7 +609,7 @@ The following properties are <NotYetImplemented/> -
 
 <NotYetImplemented /> The `table-colgroup` slot is not yet implemented.
 
-`sort-direction` is deprecated, use the `sortBy` prop (or model) instead.
+`sort-compare` and `sort-direction` are deprecated, use the `sortBy` prop (or model) as documented [here](/docs/components/table#sorting) instead.
 
 The semantics of the `row-selected` event have changed. `row-selected` is now emitted for each selected
 row and sends the single row's item as it's parameter. There is a new matching event called `row-unselected`

--- a/apps/docs/src/docs/types.md
+++ b/apps/docs/src/docs/types.md
@@ -495,6 +495,22 @@ type TableItem<T = Record<string, unknown>> = T & {
 
 </BCard>
 
+## TableSortBy
+
+<BCard class="bg-body-tertiary">
+
+```ts
+type BTableSortByOrder = 'desc' | 'asc' | undefined
+type BTableSortByComparerFunction<T = any> = (a: T, b: T, key: string) => number
+type BTableSortBy<T = any> = {
+  order: BTableSortByOrder
+  key: string
+  comparer?: BTableSortByComparerFunction<T>
+}
+```
+
+</BCard>
+
 ## TextColorVariant
 
 <BCard class="bg-body-tertiary">


### PR DESCRIPTION
# Describe the PR

- Attempt to clarify the use of `sortBy` model.
- Add a deprecation warning to `v-model` binding section
- Add documentation for sort compare functions
- Updater migration guide

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
