### PR TITLE
fix(BModal): fallback focus element always present (#2604)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BModal/modal.spec.ts
@@ -382,6 +382,43 @@ describe('modal', () => {
     wrapper.unmount()
   })
 
+  it('fallback element is added when no focusable elements are present', async () => {
+    const wrapper = mount(BModal, {
+      attachTo: document.body,
+      global: {
+        stubs: {teleport: true, transition: false},
+      },
+      props: {
+        noHeader: true,
+        noFooter: true,
+      },
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('div.modal div.modal-fallback-focus').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('fallback element is not added when a focusable element is present', async () => {
+    const wrapper = mount(BModal, {
+      attachTo: document.body,
+      global: {
+        stubs: {teleport: true},
+      },
+      props: {
+        noHeader: false,
+        noFooter: false,
+      },
+    })
+    await nextTick()
+
+    expect(wrapper.find('div.modal div.modal-fallback-focus').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
   describe('button and event functionality', () => {
     it('header close button triggers modal close and is preventable', async () => {
       let cancelHide = true

--- a/packages/bootstrap-vue-next/src/composables/useActivatedFocusTrap.ts
+++ b/packages/bootstrap-vue-next/src/composables/useActivatedFocusTrap.ts
@@ -49,8 +49,9 @@ export const useActivatedFocusTrap = (
     )
     return !tabbableElements || tabbableElements.length === 0
   }
-  const needsFallback = ref(checkNeedsFocus())
+  const needsFallback = ref(false)
   onMounted(() => {
+    needsFallback.value = checkNeedsFocus()
     useMutationObserver(
       element,
       () => {


### PR DESCRIPTION
# Describe the PR

Fixes #2604. It's checking the template ref element for focusable elements before the element is mounted instead of after, and since template refs are undefined until the component is mounted (noted in the Vue docs) it never finds any.

## Small replication

Open any modal in the docs (https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/modal.html) and you'll see the fallback focus element in the DOM.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
