### PR TITLE
fix(svg): use em instead of rem for height to avoid Safari error

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -55,7 +55,7 @@
             rel="noopener"
             link-classes="py-1 px-0"
           >
-            <component :is="link.icon()" height="1.1rem" aria-hidden />
+            <component :is="link.icon()" height="1.1em" aria-hidden />
           </BNavItem>
           <div class="border border-secondary ms-2 me-3" />
           <ClientOnly>
@@ -64,7 +64,7 @@
               <template #button-content>
                 <component
                   :is="currentIcon"
-                  height="1.1rem"
+                  height="1.1em"
                   :aria-label="`Toggle theme (${colorMode})`"
                   class="d-inline-block"
                 />


### PR DESCRIPTION
# Describe the PR

Replace `rem` with `em` in svg height attribute for Safari compatibility.

Related to #2611

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
