### PR TITLE
docs(otp): Track on this page with scrollspy

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -196,8 +196,6 @@ import PageContents from '../../src/components/PageContents.vue'
 const {page} = useData()
 const route = useRoute()
 
-//debugger
-
 const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
 const target = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_target')
 

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -137,11 +137,12 @@
                 header-class="pb-0 d-flex offcanvas-hidden-width"
                 body-class="py-2"
               >
-                <PageContents />
+                <PageContents ref="_target" />
+                <div>Current: {{ current }}</div>
               </BOffcanvas>
             </ClientOnly>
           </aside>
-          <Content class="doc-content" />
+          <Content ref="_content" style="height: 100%" class="doc-content" />
         </div>
       </BRow>
     </main>
@@ -166,10 +167,19 @@ import {
   BRow,
   BToastOrchestrator,
   useColorMode,
+  useScrollspy,
   vBColorMode,
   vBToggle,
 } from 'bootstrap-vue-next'
-import {computed, inject, onMounted, ref, watch} from 'vue'
+import {
+  type ComponentPublicInstance,
+  computed,
+  inject,
+  onMounted,
+  ref,
+  useTemplateRef,
+  watch,
+} from 'vue'
 import GithubIcon from '~icons/bi/github'
 import OpencollectiveIcon from '~icons/logos/opencollective'
 import DiscordIcon from '~icons/bi/discord'
@@ -181,10 +191,18 @@ import {useData, useRoute, withBase} from 'vitepress'
 import {VPNavBarSearch} from 'vitepress/theme'
 import {appInfoKey} from './keys'
 import {useMediaQuery} from '@vueuse/core'
+import PageContents from '../../src/components/PageContents.vue'
 
 // https://vitepress.dev/reference/runtime-api#usedata
 const {page} = useData()
 const route = useRoute()
+
+//debugger
+
+const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
+const target = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_target')
+
+const {current} = useScrollspy(content, target)
 
 const globalData = inject(appInfoKey, {
   discordUrl: '',

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -125,7 +125,7 @@
       </BRow>
       <BRow v-else>
         <div class="bd-content">
-          <aside class="otp-sidebar">
+          <aside ref="_target" class="otp-sidebar">
             <ClientOnly>
               <BOffcanvas
                 id="otp-menu"
@@ -137,8 +137,7 @@
                 header-class="pb-0 d-flex offcanvas-hidden-width"
                 body-class="py-2"
               >
-                <PageContents ref="_target" />
-                <div>Current: {{ current }}</div>
+                <PageContents />
               </BOffcanvas>
             </ClientOnly>
           </aside>
@@ -202,7 +201,10 @@ const route = useRoute()
 const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
 const target = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_target')
 
-const {current} = useScrollspy(content, target)
+useScrollspy(content, target, {
+  contentQuery: ':scope > div > [id], #component-reference',
+  targetQuery: ':scope [href]',
+})
 
 const globalData = inject(appInfoKey, {
   discordUrl: '',

--- a/apps/docs/src/components/PageContents.vue
+++ b/apps/docs/src/components/PageContents.vue
@@ -31,12 +31,9 @@ a.nav-link.otp-link {
   &.active {
     color: var(--bs-primary-text-emphasis);
     border-left-color: var(--bs-primary-text-emphasis);
-    font-weight: bold;
   }
 
   &:hover {
-    color: var(--bs-primary-text-emphasis);
-    border-left-color: var(--bs-primary-text-emphasis);
     font-weight: bold;
   }
 }

--- a/apps/docs/src/components/PageContents.vue
+++ b/apps/docs/src/components/PageContents.vue
@@ -1,5 +1,5 @@
 <template>
-  <BNav v-if="headers.length > 0" vertical small class="otp-nav">
+  <BNav vertical small class="otp-nav">
     <PageContentsItem v-for="header in headers" :key="header.slug" :item="header" />
     <BNavItem v-if="isComponentPage" href="#component-reference" link-class="otp-link"
       >Component Reference</BNavItem

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -1,13 +1,20 @@
 <template>
-  <BContainer>
-    <BRow>
-      <BCol> Hello World! </BCol>
-    </BRow>
-  </BContainer>
+  <div>
+    <BOffcanvas ref="off-canvas" v-model="showOffcanvas" title="Title"
+      ><div ref="_content">Testing some content</div>
+    </BOffcanvas>
+
+    <BButton @click="showOffcanvas = !showOffcanvas">Toggle Offcanvas</BButton>
+  </div>
 </template>
 
 <script setup lang="ts">
-// You can use this file as a development spot to test your changes
-// Please do not commit this file
-import {BCol, BContainer, BRow} from './components'
+import {type ComponentPublicInstance, ref, useTemplateRef} from 'vue'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const offCanvas = useTemplateRef<ComponentPublicInstance<HTMLElement>>('off-canvas')
+
+const showOffcanvas = ref(false)
 </script>

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -1,20 +1,13 @@
 <template>
-  <div>
-    <BOffcanvas ref="off-canvas" v-model="showOffcanvas" title="Title"
-      ><div ref="_content">Testing some content</div>
-    </BOffcanvas>
-
-    <BButton @click="showOffcanvas = !showOffcanvas">Toggle Offcanvas</BButton>
-  </div>
+  <BContainer>
+    <BRow>
+      <BCol> Hello World! </BCol>
+    </BRow>
+  </BContainer>
 </template>
 
 <script setup lang="ts">
-import {type ComponentPublicInstance, ref, useTemplateRef} from 'vue'
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const offCanvas = useTemplateRef<ComponentPublicInstance<HTMLElement>>('off-canvas')
-
-const showOffcanvas = ref(false)
+// You can use this file as a development spot to test your changes
+// Please do not commit this file
+import {BCol, BContainer, BRow} from './components'
 </script>


### PR DESCRIPTION
# Describe the PR

Use the `useScrollSpy` composable to track the position of the main document in the "On this page" contents.

## Small replication

See the docs

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
