### PR TITLE
fix(BButton): Consume useColorVariantClasses

### DIFF
--- a/apps/docs/src/data/components/button.data.ts
+++ b/apps/docs/src/data/components/button.data.ts
@@ -55,7 +55,7 @@ export default {
                 default: 'secondary',
               },
             }),
-            ['size', 'tag', 'variant']
+            ['bgVariant', 'size', 'tag', 'textVariant', 'variant']
           ),
         } satisfies Record<
           Exclude<keyof BvnComponentProps['BButton'], keyof typeof linkProps>,

--- a/apps/docs/src/docs/reference/color-variants.md
+++ b/apps/docs/src/docs/reference/color-variants.md
@@ -245,12 +245,6 @@ $dark: $gray-900;
   </template>
 </HighlightCard>
 
-<script setup lang="ts">
-import {BCard} from 'bootstrap-vue-next'
-import HighlightCard from '../../components/HighlightCard.vue'
-
-</script>
-
 <style lang="scss">
 .bg-body-tertiary [class^="border"] {
   display: inline-block;

--- a/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
+++ b/packages/bootstrap-vue-next/src/components/BButton/BButton.vue
@@ -41,7 +41,8 @@ import {useLinkClasses} from '../../composables/useLinkClasses'
 import {onKeyStroke} from '@vueuse/core'
 import type {BButtonProps} from '../../types/ComponentProps'
 import {useDefaults} from '../../composables/useDefaults'
-import type {ColorVariant} from '../../types/ColorTypes'
+import type {BorderColorVariant, ColorExtendables, ColorVariant} from '../../types/ColorTypes'
+import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
 
 defineSlots<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,10 +142,14 @@ const linkValueClasses = useLinkClasses(
       : undefined),
   }))
 )
+const colorClasses = useColorVariantClasses(
+  props as ColorExtendables & {borderVariant?: BorderColorVariant | null}
+)
+
 const computedClasses = computed(() => [
   variantIsLinkType.value === true && computedLink.value === false
     ? linkValueClasses.value
-    : undefined,
+    : colorClasses.value,
   [`btn-${props.size}`],
   {
     [`btn-${props.variant}`]: props.variant !== null && variantIsLinkTypeSubset.value === false,

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -837,7 +837,9 @@ type CustomLinkVariant = {
   [K in ColorVariant as `link-${K}`]: unknown
 }
 
-export interface BButtonProps extends Omit<BLinkProps, 'variant'> {
+export interface BButtonProps
+  extends Omit<BLinkProps, 'variant'>,
+    Omit<ColorExtendables, 'variant'> {
   loading?: boolean
   loadingFill?: boolean
   loadingText?: string


### PR DESCRIPTION
# Describe the PR

When I was documenting and fixing up `useColorVariantClasses`, I missed the fact that BButton didn't actually consume that composible. This fixes that oversight.

Fixes #2637

## Small replication

```
<template>
  <BRow
    ><BCol>Set 'variant': <BButton variant="success"> testing </BButton></BCol></BRow
  >
  <BRow
    ><BCol>Set 'bg-variant': <BButton bg-variant="info"> testing </BButton></BCol></BRow
  >
  <BRow
    ><BCol
      >Set 'text-variant' (background is 'secondary' since 'variant' defaults to 'secondary'):
      <BButton text-variant="info"> testing </BButton></BCol
    ></BRow
  >
  <BRow
    ><BCol
      >Set 'text-variant' and 'bg-variant':
      <BButton text-variant="primary" bg-variant="danger"> testing </BButton></BCol
    ></BRow
  >
  <BRow
    ><BCol
      >Set all three - 'variant' is overridden by 'bg-variant' and 'text-variant':
      <BButton text-variant="primary" bg-variant="danger" variant="success">
        testing
      </BButton></BCol
    ></BRow
  >
</template>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
