### PR TITLE
fix(BFormSelect): prevent options with label from being treated as groups

### DIFF
--- a/packages/bootstrap-vue-next/src/composables/useFormSelect.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormSelect.ts
@@ -7,7 +7,7 @@ export const useFormSelect = (
   props: MaybeRefOrGetter<Record<string, unknown>>
 ) => {
   const isComplex = (option: unknown): option is ComplexSelectOptionRaw =>
-    typeof option === 'object' && option !== null && 'label' in option
+    typeof option === 'object' && option !== null && 'options' in option
 
   const normalizeOption = (option: unknown): ComplexSelectOptionRaw | SelectOption => {
     const propsValue = toValue(props)


### PR DESCRIPTION
# Describe the PR
This fixes the issue #2661 where options that contains a `label` field were incorrectly rendered as groups instead of regular options.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(#2661)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved option type detection in form select components for more accurate rendering of complex options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->