### PR TITLE
fix(BDropdown): don't calculate the position when dropdown is not shown.

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -74,6 +74,7 @@ import {
   flip,
   type Middleware,
   offset as offsetMiddleware,
+  type ReferenceElement,
   type RootBoundary,
   shift,
   size as sizeMiddleware,
@@ -174,7 +175,7 @@ const computedOffset = computed(() =>
 )
 const offsetToNumber = useToNumber(computedOffset)
 
-const floating = useTemplateRef<HTMLElement>('_floating')
+const floatingElement = useTemplateRef<HTMLElement>('_floating')
 const button = useTemplateRef<HTMLElement>('_button')
 const splitButton = useTemplateRef<HTMLElement>('_splitButton')
 
@@ -185,7 +186,8 @@ const rootBoundary = computed<RootBoundary | undefined>(() =>
   isRootBoundary(props.boundary) ? props.boundary : undefined
 )
 
-const referencePlacement = computed(() => (!props.split ? splitButton.value : button.value))
+const referenceElement = computed(() => (!props.split ? splitButton.value : button.value))
+let cleanup: ReturnType<typeof autoUpdate> | undefined
 
 const {
   showRef,
@@ -197,7 +199,27 @@ const {
   transitionProps,
   contentShowing,
   isVisible,
-} = useShowHide(modelValue, props, emit as EmitFn, referencePlacement, computedId)
+} = useShowHide(modelValue, props, emit as EmitFn, referenceElement, computedId, {
+  showFn: () => {
+    update()
+    nextTick(() => {
+      cleanup = autoUpdate(
+        referenceElement.value as ReferenceElement,
+        floatingElement.value as HTMLElement,
+        update,
+        {
+          animationFrame: false,
+        }
+      )
+    })
+  },
+  hideFn: () => {
+    if (cleanup) {
+      cleanup()
+      cleanup = undefined
+    }
+  },
+})
 
 const computedMenuClasses = computed(() => [
   {
@@ -210,21 +232,21 @@ onKeyStroke(
   'Escape',
   () => {
     hide()
-    getElement(referencePlacement.value)?.focus()
+    getElement(referenceElement.value)?.focus()
   },
-  {target: referencePlacement}
+  {target: referenceElement}
 )
 onKeyStroke(
   'Escape',
   () => {
     hide()
-    getElement(referencePlacement.value)?.focus()
+    getElement(referenceElement.value)?.focus()
   },
-  {target: floating}
+  {target: floatingElement}
 )
 
 const keynav = (e: Readonly<Event>, v: number) => {
-  if (floating.value?.contains((e.target as HTMLElement)?.closest('form'))) return
+  if (floatingElement.value?.contains((e.target as HTMLElement)?.closest('form'))) return
   if (/input|select|option|textarea|form/i.test((e.target as HTMLElement)?.tagName)) return
   e.preventDefault()
   if (!showRef.value) {
@@ -237,10 +259,12 @@ const keynav = (e: Readonly<Event>, v: number) => {
     }, 16)
     return
   }
-  const list = floating.value?.querySelectorAll('.dropdown-item:not(.disabled):not(:disabled)')
+  const list = floatingElement.value?.querySelectorAll(
+    '.dropdown-item:not(.disabled):not(:disabled)'
+  )
   if (!list) return
-  if (floating.value?.contains(document.activeElement)) {
-    const active = floating.value.querySelector('.dropdown-item:focus')
+  if (floatingElement.value?.contains(document.activeElement)) {
+    const active = floatingElement.value.querySelector('.dropdown-item:focus')
     const index = Array.prototype.indexOf.call(list, active) + v
     if (index >= 0 && index < list?.length) (list[index] as HTMLElement)?.focus()
   } else {
@@ -248,10 +272,10 @@ const keynav = (e: Readonly<Event>, v: number) => {
   }
 }
 
-onKeyStroke('ArrowUp', (e) => keynav(e, -1), {target: referencePlacement})
-onKeyStroke('ArrowDown', (e) => keynav(e, 1), {target: referencePlacement})
-onKeyStroke('ArrowUp', (e) => keynav(e, -1), {target: floating})
-onKeyStroke('ArrowDown', (e) => keynav(e, 1), {target: floating})
+onKeyStroke('ArrowUp', (e) => keynav(e, -1), {target: referenceElement})
+onKeyStroke('ArrowDown', (e) => keynav(e, 1), {target: referenceElement})
+onKeyStroke('ArrowUp', (e) => keynav(e, -1), {target: floatingElement})
+onKeyStroke('ArrowDown', (e) => keynav(e, 1), {target: floatingElement})
 
 const sizeStyles = ref<CSSProperties>({})
 const floatingMiddleware = computed<Middleware[]>(() => {
@@ -290,13 +314,13 @@ const floatingMiddleware = computed<Middleware[]>(() => {
         apply({availableWidth, availableHeight}) {
           sizeStyles.value = {
             maxHeight:
-              availableHeight >= (floating.value?.scrollHeight ?? 0)
+              availableHeight >= (floatingElement.value?.scrollHeight ?? 0)
                 ? undefined
                 : availableHeight
                   ? `${Math.max(0, availableHeight)}px`
                   : undefined,
             maxWidth:
-              availableWidth >= (floating.value?.scrollWidth ?? 0)
+              availableWidth >= (floatingElement.value?.scrollWidth ?? 0)
                 ? undefined
                 : availableWidth
                   ? `${Math.max(0, availableWidth)}px`
@@ -308,11 +332,10 @@ const floatingMiddleware = computed<Middleware[]>(() => {
   }
   return arr
 })
-const {update, floatingStyles} = useFloating(referencePlacement, floating, {
+const {update, floatingStyles} = useFloating(referenceElement, floatingElement, {
   placement: () => props.placement,
   middleware: floatingMiddleware,
   strategy: toRef(() => props.strategy),
-  whileElementsMounted: autoUpdate,
 })
 
 const inButtonGroupAttributes = inButtonGroup
@@ -355,7 +378,7 @@ const onSplitClick = (event: Readonly<MouseEvent>) => {
 }
 
 onClickOutside(
-  floating,
+  floatingElement,
   () => {
     if (showRef.value && (props.autoClose === true || props.autoClose === 'outside')) {
       hide()

--- a/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
+++ b/packages/bootstrap-vue-next/src/components/BPopover/BPopover.vue
@@ -168,13 +168,13 @@ const computedId = useId(() => props.id, 'popover')
 
 const hidden = ref(false)
 
-const element = useTemplateRef<HTMLElement>('_element')
+const floatingElement = useTemplateRef<HTMLElement>('_element')
 const content = useTemplateRef<HTMLElement>('_content')
 const arrow = useTemplateRef<HTMLElement>('_arrow')
 const placeholder = useTemplateRef<HTMLElement>('_placeholder')
 
-const floatingTarget = ref<HTMLElement | null>(null)
-const trigger = ref<HTMLElement | null>(null)
+const referenceElement = ref<HTMLElement | null>(null)
+const triggerElement = ref<HTMLElement | null>(null)
 
 const isAutoPlacement = computed(() => props.placement.startsWith('auto'))
 const offsetNumber = useToNumber(() => props.offset ?? NaN)
@@ -266,11 +266,15 @@ const placementRef = computed(() =>
   isAutoPlacement.value ? undefined : (props.placement as FloatingPlacement)
 )
 
-const {floatingStyles, middlewareData, placement, update} = useFloating(floatingTarget, element, {
-  placement: placementRef,
-  middleware: floatingMiddleware,
-  strategy: toRef(() => props.strategy),
-})
+const {floatingStyles, middlewareData, placement, update} = useFloating(
+  referenceElement,
+  floatingElement,
+  {
+    placement: placementRef,
+    middleware: floatingMiddleware,
+    strategy: toRef(() => props.strategy),
+  }
+)
 
 const arrowStyle = ref<CSSProperties>({position: 'absolute'})
 
@@ -311,13 +315,13 @@ const {
   isVisible,
   renderRef,
   localTemporaryHide,
-} = useShowHide(modelValue, props, emit as EmitFn, element, computedId, {
+} = useShowHide(modelValue, props, emit as EmitFn, floatingElement, computedId, {
   showFn: () => {
     update()
     nextTick(() => {
       cleanup = autoUpdate(
-        floatingTarget.value as ReferenceElement,
-        element.value as HTMLElement,
+        referenceElement.value as ReferenceElement,
+        floatingElement.value as HTMLElement,
         update,
         {animationFrame: props.realtime}
       )
@@ -349,8 +353,8 @@ const computedClasses = computed(() => {
 const {x, y} = useMouse()
 
 const isElementAndTriggerOutside = () => {
-  const triggerRect = trigger.value?.getBoundingClientRect()
-  const elementRect = element.value?.getBoundingClientRect()
+  const triggerRect = triggerElement.value?.getBoundingClientRect()
+  const elementRect = floatingElement.value?.getBoundingClientRect()
   const margin = parseInt(props.hideMargin as unknown as string, 10) || 0
   const offsetX = window?.scrollX || 0
   const offsetY = window?.scrollY || 0
@@ -378,8 +382,8 @@ const tryHide = (e?: Readonly<Event>) => {
     (!props.noninteractive &&
       isOutside &&
       triggerIsOutside &&
-      !element.value?.contains(document?.activeElement) &&
-      !trigger.value?.contains(document?.activeElement)) ||
+      !floatingElement.value?.contains(document?.activeElement) &&
+      !triggerElement.value?.contains(document?.activeElement)) ||
     (props.noninteractive && triggerIsOutside)
   ) {
     hide(e?.type)
@@ -415,54 +419,54 @@ const bind = () => {
   if (props.target) {
     const elem = getElement(toValue(props.target))
     if (elem) {
-      trigger.value = elem
+      triggerElement.value = elem
     } else {
       // eslint-disable-next-line no-console
       console.warn('Target element not found', props.target)
     }
   } else {
-    trigger.value = placeholder.value?.nextElementSibling as HTMLElement
+    triggerElement.value = placeholder.value?.nextElementSibling as HTMLElement
   }
   if (props.reference) {
     const elem = getElement(toValue(props.reference))
     if (elem) {
-      floatingTarget.value = elem
+      referenceElement.value = elem
     } else {
       // eslint-disable-next-line no-console
       console.warn('Reference element not found', props.reference)
     }
   } else {
-    floatingTarget.value = trigger.value
+    referenceElement.value = triggerElement.value
   }
-  if (!trigger.value || props.manual) {
+  if (!triggerElement.value || props.manual) {
     return
   }
   if (props.click) {
-    trigger.value.addEventListener('click', localToggle)
+    triggerElement.value.addEventListener('click', localToggle)
     return
   }
-  trigger.value.addEventListener('pointerenter', show)
-  trigger.value.addEventListener('pointerleave', tryHide)
-  trigger.value.addEventListener('focus', show)
-  trigger.value.addEventListener('blur', tryHide)
+  triggerElement.value.addEventListener('pointerenter', show)
+  triggerElement.value.addEventListener('pointerleave', tryHide)
+  triggerElement.value.addEventListener('focus', show)
+  triggerElement.value.addEventListener('blur', tryHide)
 }
 
 const unbind = () => {
-  if (trigger.value) {
-    trigger.value.removeEventListener('click', localToggle)
-    trigger.value.removeEventListener('pointerenter', show)
-    trigger.value.removeEventListener('pointerleave', tryHide)
-    trigger.value.removeEventListener('focus', show)
-    trigger.value.removeEventListener('blur', tryHide)
+  if (triggerElement.value) {
+    triggerElement.value.removeEventListener('click', localToggle)
+    triggerElement.value.removeEventListener('pointerenter', show)
+    triggerElement.value.removeEventListener('pointerleave', tryHide)
+    triggerElement.value.removeEventListener('focus', show)
+    triggerElement.value.removeEventListener('blur', tryHide)
   }
 }
 
 onClickOutside(
-  element,
+  floatingElement,
   () => {
     if (showRef.value && props.click && !props.noAutoClose && !props.manual) hide('click-outside')
   },
-  {ignore: [trigger]}
+  {ignore: [triggerElement]}
 )
 
 watch([() => props.click, () => props.target, () => props.reference], () => {


### PR DESCRIPTION
fixes #2668

# Describe the PR

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved clarity and consistency by renaming internal variables related to dropdown and popover positioning and triggers.
	- Updated lifecycle management for dropdown floating UI updates, ensuring more explicit control when showing or hiding dropdowns.
	- Streamlined event handling and keyboard navigation by using clearer variable names throughout dropdown and popover components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->