### PR TITLE
feat(BTableLite): add `table-colgroup` slot

### DIFF
--- a/apps/docs/src/components/NotYetDocumented.vue
+++ b/apps/docs/src/components/NotYetDocumented.vue
@@ -1,25 +1,27 @@
 <template>
-  <span v-if="!helpOnly">
-    This {{ type }} is either not documented or has not been through full parity review. Please use
-    with caution and refer to the code to find differences in behavior. We are working to bring the
-    migration guide and documenation up-to-date with the code.
-  </span>
-  If you would like to help, please refer to the
-  <a
-    href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#improving-the-documentation"
-  >
-    improving the documentation</a
-  >
-  and
-  <a
-    href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#help-verify-bootstrapvue-and-bootstrap-v5-parity"
-    >help verify parity</a
-  >
-  sections of our
-  <a
-    href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#developing"
-    >contribution guide.<slot
-  /></a>
+  <p>
+    <span v-if="!helpOnly">
+      This {{ type }} is either not documented or has not been through full parity review. Please
+      use with caution and refer to the code to find differences in behavior. We are working to
+      bring the migration guide and documenation up-to-date with the code.
+    </span>
+    If you would like to help, please refer to the
+    <a
+      href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#improving-the-documentation"
+    >
+      improving the documentation</a
+    >
+    and
+    <a
+      href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#help-verify-bootstrapvue-and-bootstrap-v5-parity"
+      >help verify parity</a
+    >
+    sections of our
+    <a
+      href="https://github.com/bootstrap-vue-next/bootstrap-vue-next/blob/main/CONTRIBUTING.md#developing"
+      >contribution guide.<slot
+    /></a>
+  </p>
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/data/components/table.data.ts
+++ b/apps/docs/src/data/components/table.data.ts
@@ -517,6 +517,17 @@ export default {
         ],
       },
       {
+        name: 'table-colgroup',
+        description: 'Slot for user supplied `<colgroup>` element',
+        scope: [
+          {
+            prop: 'fields',
+            type: 'TableField<Items>[]',
+            description: 'The normalized fields definition array (in the array of objects format)',
+          },
+        ],
+      },
+      {
         name: 'top-row',
         description: 'Fixed top row slot for user supplied B-TD cells. Optionally scoped',
         scope: endRowScope,

--- a/apps/docs/src/docs/components/demo/TableColgroup.vue
+++ b/apps/docs/src/docs/components/demo/TableColgroup.vue
@@ -1,0 +1,20 @@
+<template>
+  <div>
+    <BTable :items="items" :fields="fields">
+      <template #table-colgroup>
+        <col style="width: 30%" />
+        <col style="width: 45%" />
+        <col style="width: 25%" />
+      </template>
+    </BTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+const fields = ['first_name', 'last_name', 'age']
+const items = [
+  {age: 40, first_name: 'Dickerson', last_name: 'Macdonald'},
+  {age: 21, first_name: 'Larsen', last_name: 'Shaw'},
+  {age: 89, first_name: 'Geneva', last_name: 'Wilson'},
+]
+</script>

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -311,7 +311,10 @@ control the caption positioning.
 
 ### Table colgroup
 
-<NotYetImplemented /> The `table-colgroup` slot is not yet implemented.
+The `table-colgroup` slot allows you to include a `<colgroup>` element in your table. You can use
+this slot to specify widths for columns using the `<col>` element.
+
+<<< DEMO ./demo/TableColgroup.vue
 
 ### Table busy state
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -27,7 +27,10 @@ Bootstrap-vue-next will commit to breaking changes whenever Bootstrap marks some
 ### Status
 
 This migration guide is a work in progress. We're adding to this guide as we complete the documentation and parity pass and doing
-our best to note each component or directive that hasn't been through the full process. <NotYetDocumented :help-only="true" />
+our best to note each component or directive that hasn't been through the full process.
+
+<NotYetDocumented :help-only="true" />
+
 For section of this guide that are not marked as in progress, we're still interested in examples of migrations that you
 have found tricky or clarifcation if the details in the guide weren't sufficent.
 
@@ -626,7 +629,6 @@ The following are <NotYetImplemented/> -
 
 - The `filter-debounce`, `fixed`, `no-border-collapse`, `selected-variant`, and `table-footer-sorting` props
 - The `filter` prop does not yet support a RegEx object, only a string.
-- The `table-colgroup` slot
 - The `context-changed` and `refreshed` events
 
 `filter-included-fields` have been replaced by a single `filterable` prop. `filter-ignored-fields`
@@ -641,6 +643,8 @@ is deprecated.
 Similarly, the `sort-changed` event is replaced by the `update:sortBy` event
 
 `table-variant` is replaced with `variant` for consistency.
+
+The slot scope for `table-colgroup` slot now only contains the `fields` prop, with the `columns` prop removed.
 
 BootstrapVue used the main v-model binding to expose a readonly version of the displayed items. This is deprecated. Instead,
 used the exposed function `displayedItems` as demonstrated in [the documentation](/docs/components/table#complete-example).
@@ -688,6 +692,8 @@ of a method in the component is deprecated.
 <NotYetDocumented type="component"/>
 
 See the [v-html](#v-html) section for information on deprecation of the `html` prop.
+
+The slot scope for `table-colgroup` slot now only contains the `fields` prop, with the `columns` prop removed.
 
 ### BTableSimple
 
@@ -737,7 +743,6 @@ See [Show and Hide](#show-and-hide) shared properties.
 See the [v-html](#v-html) section for information on deprecation of the `html` prop.
 
 `content` prop has been renamed to `body` for consistency with other components.
-
 
 ## Directives
 

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -30,6 +30,9 @@
       }
     "
   >
+    <template v-if="slots['table-colgroup']" #table-colgroup="scope">
+      <slot name="table-colgroup" v-bind="scope" />
+    </template>
     <!-- eslint-enable prettier/prettier -->
     <template v-if="slots['thead-top']" #thead-top="scope">
       <slot
@@ -344,6 +347,8 @@ type SortSlotScope = {
 
 const slots = defineSlots<{
   // BTableLite
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'table-colgroup'?: (props: {fields: typeof computedFields.value}) => any
   'thead-top'?: (props: {
     columns: number
     fields: typeof computedFields.value

--- a/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableLite.vue
@@ -1,5 +1,8 @@
 <template>
   <BTableSimple v-bind="computedSimpleProps">
+    <colgroup v-if="slots['table-colgroup']">
+      <slot name="table-colgroup" :fields="computedFields" />
+    </colgroup>
     <BThead v-show="showComputedHeaders" :variant="props.headVariant" :class="props.theadClass">
       <slot name="thead-top" :columns="computedFieldsTotal" :fields="computedFields" />
       <BTr :variant="props.headRowVariant" :class="props.theadTrClass">
@@ -294,6 +297,8 @@ const emit = defineEmits<{
 }>()
 
 const slots = defineSlots<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  'table-colgroup'?: (props: {fields: typeof computedFields.value}) => any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   'thead-top'?: (props: {columns: number; fields: typeof computedFields.value}) => any
   [key: `head(${string})`]: (props: {


### PR DESCRIPTION
# Describe the PR

Add table-colgroup slot to BTableLite component for custom column width definitions.

Fixes #2520.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [X] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for a new named slot, `table-colgroup`, in tables, allowing users to specify custom column widths.
  - Introduced a demo component showcasing how to use the new `table-colgroup` slot for column width customization.

- **Documentation**
  - Updated documentation to describe the new `table-colgroup` slot and provide a usage example.
  - Revised the migration guide to remove outdated references to the slot's availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->