### PR TITLE
feat(BTable): implement 'fixed' and 'noBorderCollapse' props

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -579,6 +579,7 @@ const tableClasses = computed(() => ({
   'b-table-busy': busyModel.value,
   'b-table-selectable': props.selectable,
   'user-select-none': props.selectable && isSelecting.value,
+  'b-table-fixed': props.fixed,
 }))
 
 const getBusyRowClasses = computed(() => [

--- a/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTable.vue
@@ -580,6 +580,7 @@ const tableClasses = computed(() => ({
   'b-table-selectable': props.selectable,
   'user-select-none': props.selectable && isSelecting.value,
   'b-table-fixed': props.fixed,
+  'b-table-no-border-collapse': props.noBorderCollapse,
 }))
 
 const getBusyRowClasses = computed(() => [

--- a/packages/bootstrap-vue-next/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-next/src/components/BTable/_table.scss
@@ -171,4 +171,8 @@
       }
     }
   }
+
+  &.b-table-fixed {
+    table-layout: fixed;
+  }
 }

--- a/packages/bootstrap-vue-next/src/components/BTable/_table.scss
+++ b/packages/bootstrap-vue-next/src/components/BTable/_table.scss
@@ -175,4 +175,9 @@
   &.b-table-fixed {
     table-layout: fixed;
   }
+
+  &.b-table-no-border-collapse {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
 }


### PR DESCRIPTION
# Describe the PR

Implement BTable (actually BTableSimple) `fixed` and `noBorderCollapse` props

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**

**Other:**

This is related to: https://github.com/bootstrap-vue-next/bootstrap-vue-next/issues/2521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fixed table layout and separate border collapse options in tables, allowing for enhanced table styling through new properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->