### PR TITLE
docs: fix incorrect references and missed script sections

### DIFF
--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -214,97 +214,12 @@ Note `<BFormTag>` requires BootstrapVueNext's custom CSS/SCSS for proper styling
 
 <ComponentReference :data="data" />
 
-<script setup lang="ts">
-  import {data} from '../../data/components/formTags.data'
-  import ComponentReference from '../../components/ComponentReference.vue'
-  import HighlightCard from '../../components/HighlightCard.vue'
-  import {BFormTags, BFormText, BFormGroup, BInputGroupText, BButton, BCard, BInputGroup, BFormTag, BFormInput, BFormSelect, BFormCheckbox, BFormInvalidFeedback, BDropdownForm, BDropdownDivider, BDropdownItemButton, BDropdownText, BDropdown} from 'bootstrap-vue-next'
-  import {ref, computed, watch} from 'vue'
+<script lang="ts">
+import {data} from '../../data/components/formTags.data'
 
-  const basicUsageTags = ref<string[]>([])
-  const usingSeparators = ref<string[]>(['apple', 'orange'])
-  const tagRemoval = ref<string[]>(['apple', 'orange', 'grape'])
-  const stylingOptions = ref<string[]>(['apple', 'orange', 'grape'])
-
-  const tagsValidator = ref<string[]>([])
-  const dirty = ref<boolean>(false)
-  const stateTagValidator = computed(() => {
-    // Overall component validation state
-    return dirty.value ? (tagsValidator.value.length > 2 && tagsValidator.value.length < 9) : null
-  })
-
-  watch(tagsValidator, () => {
-    // Set the dirty flag on first change to the tags array
-    dirty.value = true
-  })
-  const tagValidator = (tag) => {
-    // Individual tag validator function
-    return tag === tag.toLowerCase() && tag.length > 2 && tag.length < 6
+export default {
+  setup() {
+    return {data}
   }
-
-  const detectingTags = ref<string[]>([])
-  const validTags = ref<string[]>([])
-  const invalidTags = ref<string[]>([])
-  const duplicateTags = ref<string[]>([])
-  const onTagState = (valid, invalid, duplicate) => {
-    validTags.value = valid
-    invalidTags.value = invalid
-    duplicateTags.value = duplicate
-  }
-  const detectTagValidator = (tag) => {
-    return tag.length > 2 && tag.length < 6
-  }
-
-  const limitTagsModel = ref<string[]>([])
-  const limitTag = ref<number>(5)
-
-  const nativeTags = ref<string[]>(['apple', 'orange', 'banana', 'pear', 'peach'])
-
-  const customComponentTags = ref<string[]>(['apple', 'orange', 'banana'])
-
-  const customPredefinedTags = ref<string[]>([])
-  const options = ref<string[]>(['Apple', 'Orange', 'Banana', 'Lime', 'Peach', 'Chocolate', 'Strawberry'])
-  const availableOptions = computed(() => {
-    return options.value.filter(opt => customPredefinedTags.value.indexOf(opt) === -1)
-  })
-
-  const advancedDisabled = ref<boolean>(false)
-  const advancedTags = ref<string[]>([])
-  const newTag = ref<string>('')
-  const advancedState = computed(() => advancedTags.value.indexOf(newTag.value.trim()) > -1 ? false : null)
-  const resetInputValue = () => {
-        newTag.value = ''
-  }
-  const formatter = (value) => {
-    return value.toUpperCase()
-  }
-
-  const customDropdownOptions = ref<string[]>(['Apple', 'Orange', 'Banana', 'Lime', 'Peach', 'Chocolate', 'Strawberry'])
-  const customDropdownSearch = ref<string>('')
-  const customDropdownTags = ref<string[]>([])
-
-  const criteria = computed(() => customDropdownSearch.value.trim().toLowerCase())
-  const customDropdownAvailableOptions = computed(() => {
-  const searchCriteria = criteria.value
-
-  // Filter out already selected options
-  const optionsFiltered = customDropdownOptions.value.filter(opt => customDropdownTags.value.indexOf(opt) === -1)
-    if (searchCriteria) {
-      // Show only options that match criteria
-      return optionsFiltered.filter(opt => opt.toLowerCase().indexOf(searchCriteria) > -1);
-    }
-    // Show all options available
-    return optionsFiltered
-  })
-  const searchDesc = computed(() => {
-    if (criteria.value && customDropdownAvailableOptions.value.length === 0) {
-      return 'There are no tags matching your search criteria'
-    }
-    return ''
-  })
-  const onOptionClick = ({ option, addTag }) => {
-    addTag(option)
-    searchCriteria.value = ''
-  }
-
+}
 </script>

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -97,7 +97,7 @@ changes).
 <ComponentReference :data="data" />
 
 <script lang="ts">
-import {data} from '../../data/components/inputGroup.data'
+import {data} from '../../data/components/link.data'
 
 export default {
   setup() {

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -106,9 +106,6 @@ As well, when no label is provided, the spinner will automatically have the attr
 
 <script lang="ts">
 import {data} from '../../data/components/spinner.data'
-import ComponentReference from '../../components/ComponentReference.vue'
-import HighlightCard from '../../components/HighlightCard.vue'
-import {BCard, BCardBody, BButton, BSpinner} from 'bootstrap-vue-next'
 
 export default {
   setup() {


### PR DESCRIPTION
# Describe the PR

I ran across one of these while working on something else, so did yet another pass through all the component documentation to make sure that we weren't using script setup in places that I've refactored already and that we're pulling in the correct component reference file.

## Small replication

https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/form-tags.html

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified tag management documentation component by removing all reactive logic, validation, and event handling, leaving only basic data export.
  - Updated the link documentation to reference the correct data source for improved clarity.
  - Cleaned up the spinner documentation by removing unused component imports for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->