### PR TITLE
fix(BTableSimple): implement 'fixed' and 'noBorderCollapse' props

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTable/BTableSimple.vue
+++ b/packages/bootstrap-vue-next/src/components/BTable/BTableSimple.vue
@@ -73,6 +73,8 @@ const computedClasses = computed(() => [
     'table-sm': props.small,
     [`table-${props.variant}`]: props.variant !== null,
     'table-striped-columns': props.stripedColumns,
+    'b-table-fixed': props.fixed,
+    'b-table-no-border-collapse': props.noBorderCollapse,
   },
 ])
 const computedTableAttrs = computed(() => ({


### PR DESCRIPTION
# Describe the PR

Correctly handle the 'fixed' and 'noBorderCollapse' props in BTableSimple components.

Fixes #2685.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Table now supports conditional styling for fixed layout and disabling border collapse based on new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->