### PR TITLE
feat: implement BAvatar badge-offset

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
@@ -60,6 +60,7 @@ import {isEmptySlot} from '../../utils/dom'
 import {useNumberishToStyle} from '../../composables/useNumberishToStyle'
 import {useRadiusElementClasses} from '../../composables/useRadiusElementClasses'
 import {useColorVariantClasses} from '../../composables/useColorVariantClasses'
+import {useRtl} from '../../composables/useRtl'
 import type {Size} from '../../types'
 
 const props = withDefaults(defineProps<BAvatarProps>(), {
@@ -136,6 +137,7 @@ const slots = defineSlots<{
 const {computedLink, computedLinkProps} = useBLinkHelper(props)
 
 const parentData = inject(avatarGroupInjectionKey, null)
+const {isRtl} = useRtl()
 
 const SIZES = Object.freeze([
   null,
@@ -221,6 +223,7 @@ const textFontStyle = computed<StyleValue>(() => {
 const badgeOffsetStyle = computed<StyleValue>(() => {
   const offset = props.badgeOffset
   const placement = props.badgePlacement
+  const rtlEnabled = isRtl?.value ?? false
 
   let x = `-50%`
   let y = `-50%`
@@ -232,9 +235,13 @@ const badgeOffsetStyle = computed<StyleValue>(() => {
   }
 
   if (placement.includes('end')) {
-    x = `calc(-50% - ${offset})`
+    // In LTR: “end” = push left  (calc(-50% - offset))
+    // In RTL: “end” = push right (calc(-50% + offset))
+    x = rtlEnabled ? `calc(-50% + ${offset})` : `calc(-50% - ${offset})`
   } else if (placement.includes('start')) {
-    x = `calc(-50% + ${offset})`
+    // In LTR: “start” = push right (calc(-50% + offset))
+    // In RTL: “start” = push left  (calc(-50% - offset))
+    x = rtlEnabled ? `calc(-50% - ${offset})` : `calc(-50% + ${offset})`
   }
 
   return {

--- a/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
+++ b/packages/bootstrap-vue-next/src/components/BAvatar/BAvatar.vue
@@ -37,8 +37,9 @@
       :dot-indicator="props.badgeDotIndicator || badgeImplicitlyDot"
       :variant="props.badgeVariant"
       :bg-variant="props.badgeBgVariant"
+      :badge-offset="props.badgeOffset"
       :text-variant="props.badgeTextVariant"
-      :style="badgeStyle"
+      :style="[badgeStyle, badgeOffsetStyle]"
       :placement="props.badgePlacement"
     >
       <slot name="badge">
@@ -69,6 +70,7 @@ const props = withDefaults(defineProps<BAvatarProps>(), {
   badgeVariant: 'primary',
   badgePlacement: 'bottom-end',
   badgeDotIndicator: false,
+  badgeOffset: null,
   badgePill: false,
   button: false,
   buttonType: 'button',
@@ -214,6 +216,30 @@ const textFontStyle = computed<StyleValue>(() => {
     ? `calc(${computedSize.value} * ${FONT_SIZE_SCALE})`
     : null
   return fontSize ? {fontSize} : {}
+})
+
+const badgeOffsetStyle = computed<StyleValue>(() => {
+  const offset = props.badgeOffset
+  const placement = props.badgePlacement
+
+  let x = `-50%`
+  let y = `-50%`
+
+  if (placement.includes('top')) {
+    y = `calc(-50% + ${offset})`
+  } else if (placement.includes('bottom')) {
+    y = `calc(-50% - ${offset})`
+  }
+
+  if (placement.includes('end')) {
+    x = `calc(-50% - ${offset})`
+  } else if (placement.includes('start')) {
+    x = `calc(-50% + ${offset})`
+  }
+
+  return {
+    transform: `translate(${x}, ${y}) !important`,
+  }
 })
 
 const marginStyle = computed(() => {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -814,6 +814,7 @@ export interface BAvatarProps
   alt?: string
   badge?: boolean | string
   badgeBgVariant?: BgColorVariant | null
+  badgeOffset?: string | null
   badgePlacement?: CombinedPlacement
   badgeTextVariant?: TextColorVariant | null
   badgeVariant?: ColorVariant | null


### PR DESCRIPTION
Contributor: 
Huy Le - https://github.com/jackle500

Add Badge-offset prop to component BBadge component.

Revise BBadge style prop to allow style changes for badge offset.

Create badgeOffsetStyle function.

GitHub Issue: #2347: BAvatar badge-offset isn't implemented.

# Describe the PR

The badge-offset property provides the ability to control the offset of the badge, from any placement. When given a positive value, the badge moves inward. A negative value moves it outward. 

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to adjust the badge position on the avatar component using the `badgeOffset` property, supporting both horizontal and vertical offsets and accommodating right-to-left layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->