### PR TITLE
feat(BFormTags): added feedbackAriaLive prop 

### DIFF
--- a/apps/docs/src/data/components/formTags.data.ts
+++ b/apps/docs/src/data/components/formTags.data.ts
@@ -90,6 +90,11 @@ export default {
             description:
               'The message when duplicate tags are detected. Set to an empty string to disable the message',
           },
+          feedbackAriaLive: {
+            type: 'string',
+            default: "'assertive'",
+            description: 'Value to use for the `aria-live` attribute on the feedback text',
+          },
           inputAttrs: {
             type: 'Readonly<AttrsValue>',
             default: undefined,

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -1,65 +1,12 @@
 <template>
-  <div class="p-4">
-    <h2 class="text-2xl font-bold mb-4">Test BFormTags feedbackAriaLive</h2>
-
-    <!-- Assertive (default) -->
-    <div class="mb-6">
-      <h3 class="text-lg font-semibold">feedbackAriaLive: assertive (default)</h3>
-      <BFormTags
-        v-model="assertiveTags"
-        :tag-validator="validateTag"
-        invalid-tag-text="Tags must be longer than 3 characters"
-        duplicate-tag-text="Tag already exists"
-        limit="3"
-        limit-tags-text="Maximum 3 tags allowed"
-      />
-      <div class="mt-2"><strong>Tags:</strong> {{ assertiveTags }}</div>
-    </div>
-
-    <!-- Polite -->
-    <div class="mb-6">
-      <h3 class="text-lg font-semibold">feedbackAriaLive: polite</h3>
-      <BFormTags
-        v-model="politeTags"
-        feedback-aria-live="polite"
-        :tag-validator="validateTag"
-        invalid-tag-text="Tags must be longer than 3 characters"
-        duplicate-tag-text="Tag already exists"
-        limit="3"
-        limit-tags-text="Maximum 3 tags allowed"
-      />
-      <div class="mt-2"><strong>Tags:</strong> {{ politeTags }}</div>
-    </div>
-
-    <!-- Off -->
-    <div class="mb-6">
-      <h3 class="text-lg font-semibold">feedbackAriaLive: off</h3>
-      <BFormTags
-        v-model="offTags"
-        feedback-aria-live="off"
-        :tag-validator="validateTag"
-        invalid-tag-text="Tags must be longer than 3 characters"
-        duplicate-tag-text="Tag already exists"
-        limit="3"
-        limit-tags-text="Maximum 3 tags allowed"
-      />
-      <div class="mt-2"><strong>Tags:</strong> {{ offTags }}</div>
-    </div>
-  </div>
+  <BContainer>
+    <BRow>
+      <BCol> Hello World! </BCol>
+    </BRow>
+  </BContainer>
 </template>
 
 <script setup lang="ts">
-import {BFormTags} from './components'
-import {ref} from 'vue'
-
-const validateTag = (tag: string) => tag.length > 3
-
-// Tags for assertive (default)
-const assertiveTags = ref(['hello', 'world'])
-
-// Tags for polite
-const politeTags = ref(['hello', 'world'])
-
-// Tags for off
-const offTags = ref(['hello', 'world'])
+// You can use this file as a development spot to test your changes
+// Please do not commit this file
 </script>

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -9,4 +9,5 @@
 <script setup lang="ts">
 // You can use this file as a development spot to test your changes
 // Please do not commit this file
+import {BCol, BContainer, BRow} from './components'
 </script>

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -2,28 +2,6 @@
   <div class="p-4">
     <h2 class="text-2xl font-bold mb-4">Test BFormTags feedbackAriaLive</h2>
 
-    <!-- Dynamic feedbackAriaLive -->
-    <div class="mb-6">
-      <h3 class="text-lg font-semibold">Dynamic feedbackAriaLive</h3>
-      <label for="ariaLiveSelect" class="mr-2">Select feedbackAriaLive:</label>
-      <select id="ariaLiveSelect" v-model="dynamicAriaLive" class="border rounded px-2 py-1">
-        <option value="assertive">assertive</option>
-        <option value="polite">polite</option>
-        <option value="off">off</option>
-      </select>
-      <BFormTags
-        v-model="dynamicTags"
-        :feedback-aria-live="dynamicAriaLive"
-        :tag-validator="validateTag"
-        invalid-tag-text="Tags must be longer than 3 characters"
-        duplicate-tag-text="Tag already exists"
-        limit="3"
-        limit-tags-text="Maximum 3 tags allowed"
-        class="mt-2"
-      />
-      <div class="mt-2"><strong>Tags:</strong> {{ dynamicTags }}</div>
-    </div>
-
     <!-- Assertive (default) -->
     <div class="mb-6">
       <h3 class="text-lg font-semibold">feedbackAriaLive: assertive (default)</h3>
@@ -67,38 +45,6 @@
       />
       <div class="mt-2"><strong>Tags:</strong> {{ offTags }}</div>
     </div>
-
-    <div class="mt-4">
-      <h3 class="text-lg font-semibold">Test Instructions</h3>
-      <p>Use a screen reader (e.g., NVDA, VoiceOver) to test feedback announcements:</p>
-      <ul class="list-disc pl-5">
-        <li>
-          <strong>Invalid Tag</strong>: Enter "abc" (too short). Expected:
-          <ul class="list-circle pl-5">
-            <li>Assertive: Interrupts with "Invalid tag(s): abc"</li>
-            <li>Polite: Announces "Invalid tag(s): abc" without interrupting</li>
-            <li>Off: No announcement</li>
-          </ul>
-        </li>
-        <li>
-          <strong>Duplicate Tag</strong>: Enter "hello" (already in tags). Expected:
-          <ul class="list-circle pl-5">
-            <li>Assertive: Interrupts with "Duplicate tag(s): hello"</li>
-            <li>Polite: Announces "Duplicate tag(s): hello" without interrupting</li>
-            <li>Off: No announcement</li>
-          </ul>
-        </li>
-        <li>
-          <strong>Limit Reached</strong>: Add three valid tags (e.g., "valid1", "valid2", "valid3").
-          Expected:
-          <ul class="list-circle pl-5">
-            <li>Assertive: Interrupts with "Maximum 3 tags allowed"</li>
-            <li>Polite: Announces "Maximum 3 tags allowed" without interrupting</li>
-            <li>Off: No announcement</li>
-          </ul>
-        </li>
-      </ul>
-    </div>
   </div>
 </template>
 
@@ -107,10 +53,6 @@ import {BFormTags} from './components'
 import {ref} from 'vue'
 
 const validateTag = (tag: string) => tag.length > 3
-
-// Tags for dynamic feedbackAriaLive
-const dynamicTags = ref(['hello', 'world'])
-const dynamicAriaLive = ref<'assertive' | 'polite' | 'off'>('assertive')
 
 // Tags for assertive (default)
 const assertiveTags = ref(['hello', 'world'])

--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -1,13 +1,123 @@
 <template>
-  <BContainer>
-    <BRow>
-      <BCol> Hello World! </BCol>
-    </BRow>
-  </BContainer>
+  <div class="p-4">
+    <h2 class="text-2xl font-bold mb-4">Test BFormTags feedbackAriaLive</h2>
+
+    <!-- Dynamic feedbackAriaLive -->
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold">Dynamic feedbackAriaLive</h3>
+      <label for="ariaLiveSelect" class="mr-2">Select feedbackAriaLive:</label>
+      <select id="ariaLiveSelect" v-model="dynamicAriaLive" class="border rounded px-2 py-1">
+        <option value="assertive">assertive</option>
+        <option value="polite">polite</option>
+        <option value="off">off</option>
+      </select>
+      <BFormTags
+        v-model="dynamicTags"
+        :feedback-aria-live="dynamicAriaLive"
+        :tag-validator="validateTag"
+        invalid-tag-text="Tags must be longer than 3 characters"
+        duplicate-tag-text="Tag already exists"
+        limit="3"
+        limit-tags-text="Maximum 3 tags allowed"
+        class="mt-2"
+      />
+      <div class="mt-2"><strong>Tags:</strong> {{ dynamicTags }}</div>
+    </div>
+
+    <!-- Assertive (default) -->
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold">feedbackAriaLive: assertive (default)</h3>
+      <BFormTags
+        v-model="assertiveTags"
+        :tag-validator="validateTag"
+        invalid-tag-text="Tags must be longer than 3 characters"
+        duplicate-tag-text="Tag already exists"
+        limit="3"
+        limit-tags-text="Maximum 3 tags allowed"
+      />
+      <div class="mt-2"><strong>Tags:</strong> {{ assertiveTags }}</div>
+    </div>
+
+    <!-- Polite -->
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold">feedbackAriaLive: polite</h3>
+      <BFormTags
+        v-model="politeTags"
+        feedback-aria-live="polite"
+        :tag-validator="validateTag"
+        invalid-tag-text="Tags must be longer than 3 characters"
+        duplicate-tag-text="Tag already exists"
+        limit="3"
+        limit-tags-text="Maximum 3 tags allowed"
+      />
+      <div class="mt-2"><strong>Tags:</strong> {{ politeTags }}</div>
+    </div>
+
+    <!-- Off -->
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold">feedbackAriaLive: off</h3>
+      <BFormTags
+        v-model="offTags"
+        feedback-aria-live="off"
+        :tag-validator="validateTag"
+        invalid-tag-text="Tags must be longer than 3 characters"
+        duplicate-tag-text="Tag already exists"
+        limit="3"
+        limit-tags-text="Maximum 3 tags allowed"
+      />
+      <div class="mt-2"><strong>Tags:</strong> {{ offTags }}</div>
+    </div>
+
+    <div class="mt-4">
+      <h3 class="text-lg font-semibold">Test Instructions</h3>
+      <p>Use a screen reader (e.g., NVDA, VoiceOver) to test feedback announcements:</p>
+      <ul class="list-disc pl-5">
+        <li>
+          <strong>Invalid Tag</strong>: Enter "abc" (too short). Expected:
+          <ul class="list-circle pl-5">
+            <li>Assertive: Interrupts with "Invalid tag(s): abc"</li>
+            <li>Polite: Announces "Invalid tag(s): abc" without interrupting</li>
+            <li>Off: No announcement</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Duplicate Tag</strong>: Enter "hello" (already in tags). Expected:
+          <ul class="list-circle pl-5">
+            <li>Assertive: Interrupts with "Duplicate tag(s): hello"</li>
+            <li>Polite: Announces "Duplicate tag(s): hello" without interrupting</li>
+            <li>Off: No announcement</li>
+          </ul>
+        </li>
+        <li>
+          <strong>Limit Reached</strong>: Add three valid tags (e.g., "valid1", "valid2", "valid3").
+          Expected:
+          <ul class="list-circle pl-5">
+            <li>Assertive: Interrupts with "Maximum 3 tags allowed"</li>
+            <li>Polite: Announces "Maximum 3 tags allowed" without interrupting</li>
+            <li>Off: No announcement</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-// You can use this file as a development spot to test your changes
-// Please do not commit this file
-import {BCol, BContainer, BRow} from './components'
+import {BFormTags} from './components'
+import {ref} from 'vue'
+
+const validateTag = (tag: string) => tag.length > 3
+
+// Tags for dynamic feedbackAriaLive
+const dynamicTags = ref(['hello', 'world'])
+const dynamicAriaLive = ref<'assertive' | 'polite' | 'off'>('assertive')
+
+// Tags for assertive (default)
+const assertiveTags = ref(['hello', 'world'])
+
+// Tags for polite
+const politeTags = ref(['hello', 'world'])
+
+// Tags for off
+const offTags = ref(['hello', 'world'])
 </script>

--- a/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
@@ -97,7 +97,7 @@
           </div>
         </li>
       </ul>
-      <div aria-live="polite" aria-atomic="true">
+      <div :aria-live="props.feedbackAriaLive" aria-atomic="true">
         <div v-if="isInvalid" class="d-block invalid-feedback">
           {{ props.invalidTagText }}: {{ inputValue }}
         </div>
@@ -123,7 +123,7 @@
 
 <script setup lang="ts">
 import {onKeyStroke, syncRef, useFocus, useToNumber} from '@vueuse/core'
-import {computed, ref, useTemplateRef} from 'vue'
+import {computed, ref, useTemplateRef, watch} from 'vue'
 import {useDefaults} from '../../composables/useDefaults'
 import type {BFormTagsProps} from '../../types/ComponentProps'
 import {escapeRegExpChars} from '../../utils/stringUtils'
@@ -164,8 +164,26 @@ const _props = withDefaults(defineProps<Omit<BFormTagsProps, 'modelValue'>>(), {
   tagRemovedLabel: 'Tag removed',
   tagValidator: () => true,
   tagVariant: 'secondary',
+  feedbackAriaLive: 'assertive', // New prop
 })
 const props = useDefaults(_props, 'BFormTags')
+
+// Runtime validation for feedbackAriaLive
+watch(
+  () => props.feedbackAriaLive,
+  (value) => {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      value &&
+      !['polite', 'assertive', 'off'].includes(value)
+    ) {
+      console.warn(
+        `BFormTags: feedbackAriaLive must be 'polite', 'assertive', or 'off', received: ${value}`
+      )
+    }
+  },
+  {immediate: true}
+)
 
 const emit = defineEmits<{
   'blur': [value: FocusEvent]

--- a/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
@@ -177,7 +177,8 @@ watch(
       value &&
       !['polite', 'assertive', 'off'].includes(value)
     ) {
-      console.warn(
+      emit(
+        'warning',
         `BFormTags: feedbackAriaLive must be 'polite', 'assertive', or 'off', received: ${value}`
       )
     }

--- a/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
@@ -140,6 +140,7 @@ const _props = withDefaults(defineProps<Omit<BFormTagsProps, 'modelValue'>>(), {
   autofocus: false,
   disabled: false,
   duplicateTagText: 'Duplicate tag(s)',
+  feedbackAriaLive: 'assertive',
   form: undefined,
   inputAttrs: undefined,
   inputClass: undefined,
@@ -164,7 +165,6 @@ const _props = withDefaults(defineProps<Omit<BFormTagsProps, 'modelValue'>>(), {
   tagRemovedLabel: 'Tag removed',
   tagValidator: () => true,
   tagVariant: 'secondary',
-  feedbackAriaLive: 'assertive',
 })
 const props = useDefaults(_props, 'BFormTags')
 

--- a/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/BFormTags.vue
@@ -123,7 +123,7 @@
 
 <script setup lang="ts">
 import {onKeyStroke, syncRef, useFocus, useToNumber} from '@vueuse/core'
-import {computed, ref, useTemplateRef, watch} from 'vue'
+import {computed, ref, useTemplateRef} from 'vue'
 import {useDefaults} from '../../composables/useDefaults'
 import type {BFormTagsProps} from '../../types/ComponentProps'
 import {escapeRegExpChars} from '../../utils/stringUtils'
@@ -164,27 +164,9 @@ const _props = withDefaults(defineProps<Omit<BFormTagsProps, 'modelValue'>>(), {
   tagRemovedLabel: 'Tag removed',
   tagValidator: () => true,
   tagVariant: 'secondary',
-  feedbackAriaLive: 'assertive', // New prop
+  feedbackAriaLive: 'assertive',
 })
 const props = useDefaults(_props, 'BFormTags')
-
-// Runtime validation for feedbackAriaLive
-watch(
-  () => props.feedbackAriaLive,
-  (value) => {
-    if (
-      process.env.NODE_ENV === 'development' &&
-      value &&
-      !['polite', 'assertive', 'off'].includes(value)
-    ) {
-      emit(
-        'warning',
-        `BFormTags: feedbackAriaLive must be 'polite', 'assertive', or 'off', received: ${value}`
-      )
-    }
-  },
-  {immediate: true}
-)
 
 const emit = defineEmits<{
   'blur': [value: FocusEvent]

--- a/packages/bootstrap-vue-next/src/components/BFormTags/form-tags.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormTags/form-tags.spec.ts
@@ -25,4 +25,31 @@ describe('form-tags', () => {
       expect($smallElement.text()).toBe('Foo')
     })
   })
+
+  describe('feedbackAriaLive behavior', () => {
+    it('sets aria-live to assertive by default', () => {
+      const wrapper = mount(BFormTags)
+      const feedbackDiv = wrapper.find('.b-form-tags > div[aria-atomic="true"]:last-child')
+      expect(feedbackDiv.exists()).toBe(true)
+      expect(feedbackDiv.attributes('aria-live')).toBe('assertive')
+    })
+
+    it('sets aria-live to polite when feedbackAriaLive is polite', () => {
+      const wrapper = mount(BFormTags, {
+        props: {feedbackAriaLive: 'polite'},
+      })
+      const feedbackDiv = wrapper.find('.b-form-tags > div[aria-atomic="true"]:last-child')
+      expect(feedbackDiv.exists()).toBe(true)
+      expect(feedbackDiv.attributes('aria-live')).toBe('polite')
+    })
+
+    it('sets aria-live to off when feedbackAriaLive is off', () => {
+      const wrapper = mount(BFormTags, {
+        props: {feedbackAriaLive: 'off'},
+      })
+      const feedbackDiv = wrapper.find('.b-form-tags > div[aria-atomic="true"]:last-child')
+      expect(feedbackDiv.exists()).toBe(true)
+      expect(feedbackDiv.attributes('aria-live')).toBe('off')
+    })
+  })
 })

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -460,7 +460,7 @@ export interface BFormTagsProps {
   tagRemovedLabel?: string
   tagValidator?: (t: string) => boolean
   tagVariant?: ColorVariant | null
-  feedbackAriaLive?: 'polite' | 'assertive' | 'off' // New prop
+  feedbackAriaLive?: 'polite' | 'assertive' | 'off'
 }
 
 export interface BFormTextareaProps extends CommonInputProps {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -6,7 +6,7 @@ import type {
   RootBoundary,
   Strategy,
 } from '@floating-ui/vue'
-import type {ComponentPublicInstance, TransitionProps} from 'vue'
+import type {AriaAttributes, ComponentPublicInstance, TransitionProps} from 'vue'
 import type {RouteLocationRaw} from 'vue-router'
 import type {LinkTarget} from './LinkTarget'
 import type {
@@ -435,6 +435,7 @@ export interface BFormTagsProps {
   autofocus?: boolean
   disabled?: boolean
   duplicateTagText?: string
+  feedbackAriaLive?: AriaAttributes['aria-live']
   form?: string
   inputAttrs?: Readonly<AttrsValue>
   inputClass?: ClassValue
@@ -460,7 +461,6 @@ export interface BFormTagsProps {
   tagRemovedLabel?: string
   tagValidator?: (t: string) => boolean
   tagVariant?: ColorVariant | null
-  feedbackAriaLive?: 'polite' | 'assertive' | 'off'
 }
 
 export interface BFormTextareaProps extends CommonInputProps {

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -460,6 +460,7 @@ export interface BFormTagsProps {
   tagRemovedLabel?: string
   tagValidator?: (t: string) => boolean
   tagVariant?: ColorVariant | null
+  feedbackAriaLive?: 'polite' | 'assertive' | 'off' // New prop
 }
 
 export interface BFormTextareaProps extends CommonInputProps {


### PR DESCRIPTION
# Describe the PR

Created feedbackAriaLive prop for BFormTags to configure aria-live attribute on feedback text and added unit tests. Fixes #2674.  

Contributor: Noah Lanctot - https://github.com/InfiniteGmng
## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to customize the ARIA live region politeness for feedback messages in the tag input component, improving accessibility for screen reader users.

- **Tests**
  - Introduced new test cases to verify the correct behavior of the ARIA live region setting in the tag input component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->