### PR TITLE
fix(BModal): ensure clicking inside and releasing outside does not close modal (#2703)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
+++ b/packages/bootstrap-vue-next/src/components/BModal/BModal.vue
@@ -24,9 +24,8 @@
         v-bind="$attrs"
         :style="computedZIndex"
         style="display: block"
-        @click.self="hide('backdrop')"
       >
-        <div class="modal-dialog" :class="modalDialogClasses">
+        <div ref="_modalDialog" class="modal-dialog" :class="modalDialogClasses">
           <div v-if="contentShowing" class="modal-content" :class="props.contentClass">
             <div v-if="!props.noHeader" class="modal-header" :class="headerClasses">
               <slot name="header" v-bind="sharedSlots">
@@ -125,7 +124,7 @@
 </template>
 
 <script setup lang="ts">
-import {onKeyStroke, unrefElement} from '@vueuse/core'
+import {onClickOutside, onKeyStroke, unrefElement} from '@vueuse/core'
 import {useActivatedFocusTrap} from '../../composables/useActivatedFocusTrap'
 import {computed, type CSSProperties, type EmitFn, useTemplateRef, watch} from 'vue'
 import type {BModalProps} from '../../types/ComponentProps'
@@ -223,6 +222,7 @@ const computedId = useId(() => props.id, 'modal')
 const modelValue = defineModel<Exclude<BModalProps['modelValue'], undefined>>({default: false})
 
 const element = useTemplateRef<HTMLElement>('_element')
+const modalDialog = useTemplateRef<HTMLElement>('_modalDialog')
 const fallbackFocusElement = useTemplateRef<HTMLElement>('_fallbackFocusElement')
 const okButton = useTemplateRef<HTMLElement>('_okButton')
 const cancelButton = useTemplateRef<HTMLElement>('_cancelButton')
@@ -314,6 +314,8 @@ onKeyStroke(
   {target: element}
 )
 useSafeScrollLock(showRef, () => props.bodyScrolling)
+
+onClickOutside(modalDialog, () => hide('backdrop'))
 
 const hasHeaderCloseSlot = computed(() => !isEmptySlot(slots['header-close']))
 


### PR DESCRIPTION
# Describe the PR
Uses the VueUse onClickOutside function similar to BDropdown and BPopover so that when a user begins clicking inside the modal and releases outside, it does not close the modal.
This behaviour matches the Bootstrap V5 modal behaviour.

## Small replication

As described in the issue, the behaviour now falls in-line with Bootstrap V5.
With the following App.vue:
```vue
<template>
  <BContainer>
    <BModal v-model="isModalVisible" title="My Modal">Hello world</BModal>
    <BButton @click="isModalVisible = true">Show Modal</BButton>
  </BContainer>
</template>

<script setup lang="ts">
// You can use this file as a development spot to test your changes
// Please do not commit this file
import {BButton, BContainer, BModal} from './components'
import {ref} from 'vue'
const isModalVisible = ref(false)
</script>
```

**Behaviour before changes**
![2025-05-19-170116-firefox](https://github.com/user-attachments/assets/160e3df7-9ec2-4975-a1d3-5e2ec5f18a83)

**Behaviour after changes**
![2025-05-19-170032-firefox](https://github.com/user-attachments/assets/34d22dfe-451a-4161-a6fb-251dd26ceb34)

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
