### PR TITLE
chore: remove blur from boverlay in cases where its not allowed by br…

### DIFF
--- a/apps/docs/src/docs/components/overlay.md
+++ b/apps/docs/src/docs/components/overlay.md
@@ -95,7 +95,7 @@ Control the opacity of the backdrop via the `opacity` prop (opacity values can r
       </div>
       {{ opacity.toFixed(2) }}
       <div>
-        <label for="bg-blur">Blur</label>
+        <label for="bg-blur">Blur (does not work if variant is anything other than 'transparent' or 'white' or if bgColor is defined)</label>
         <BFormSelect id="bg-blur" v-model="blur" :options="blurs" />
       </div>
     </div>
@@ -144,7 +144,10 @@ Control the opacity of the backdrop via the `opacity` prop (opacity values can r
       {{ opacity.toFixed(2) }}
 
       <div>
-        <label for="bg-blur">Blur</label>
+        <label for="bg-blur"
+          >Blur (does not work if variant is anything other than 'transparent' or 'white' or if
+          bgColor is defined)</label
+        >
         <BFormSelect id="bg-blur" v-model="blur" :options="blurs" />
       </div>
     </div>
@@ -183,10 +186,10 @@ const variants = [
   'danger',
   'warning',
   'info',
-]
+] as const
 const blurs = [{text: 'None', value: ''}, '1px', '2px', '5px', '0.5em', '1rem']
 
-const variant = ref('light')
+const variant = ref<(typeof variants)[number]>('light')
 const opacity = ref(0.85)
 const blur = ref('2px')
 </script>
@@ -934,7 +937,6 @@ import {ref, nextTick} from 'vue';
 const showOverlayEx1 = ref(false)
 const showRoundedEx = ref(false)
 
-const variant = ref('light')
 const opacity = ref(0.85)
 const blur = ref('2px')
 const variants = [
@@ -948,7 +950,8 @@ const variants = [
   'danger',
   'warning',
   'info',
-]
+] as const
+const variant = ref('light')
 const blurs = [
   { text: 'None', value: '' },
   '1px',

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -591,7 +591,7 @@ See [Show and Hide](#show-and-hide) shared properties.
 
 <NotYetDocumented type="component"/>
 
-prop `blur` does not work when prop `bgColor` is defined. It also will not work if prop `variant` is anything other than `white` or `transparent`. This overcomes a browser change.
+prop `blur` does not work when the prop `bgColor` is defined. It also will not work if the prop `variant` is anything other than `white` or `transparent`. This overcomes a browser change.
 
 ### BPagination
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -587,6 +587,12 @@ The `type` prop is deprecated. Use the the `v-b-color-mode` directive or `useCol
 
 See [Show and Hide](#show-and-hide) shared properties.
 
+### BOverlay
+
+<NotYetDocumented type="component"/>
+
+prop `blur` does not work when prop `bgColor` is defined. It also will not work if prop `variant` is anything other than `white` or `transparent`. This overcomes a browser change.
+
 ### BPagination
 
 See [Show and Hide](#show-and-hide) shared properties.

--- a/packages/bootstrap-vue-next/src/components/BOverlay/BOverlay.vue
+++ b/packages/bootstrap-vue-next/src/components/BOverlay/BOverlay.vue
@@ -125,7 +125,10 @@ const blurStyles = computed(() => ({
   ...positionStyles,
   opacity: props.opacity,
   backgroundColor: props.bgColor || undefined,
-  backdropFilter: props.blur ? `blur(${props.blur})` : undefined,
+  backdropFilter:
+    props.blur && !props.bgColor && (props.variant === 'white' || props.variant === 'transparent')
+      ? `blur(${props.blur})`
+      : undefined,
 }))
 
 const spinWrapperStyles = computed(() =>


### PR DESCRIPTION
…owser

# Describe the PR

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new section for the BOverlay component in the migration guide, including details about blur limitations.
- **Documentation**
  - Clarified in the documentation that the blur effect for overlays only works when the variant is 'transparent' or 'white' and no background color is set.
- **Bug Fixes**
  - Updated overlay behavior so the blur effect is only applied when compatible with the selected variant and background color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->