### PR TITLE
docs: fix unplugin-vue-components issue

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -31,7 +31,7 @@ export default defineConfig({
       Components({
         globs: ['components/*.vue', 'docs/**/demo/*.vue'],
         dts: true,
-        include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
+        include: [/\.vue$/, /\.vue\?vue/, /\.md$/, /\.ts$/],
         resolvers: [BootstrapVueNextResolver()],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any,

--- a/apps/docs/src/docs/components/accordion.md
+++ b/apps/docs/src/docs/components/accordion.md
@@ -36,12 +36,6 @@ Add `free` property to make accordion items stay open when another item is opene
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/accordion.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/alert.md
+++ b/apps/docs/src/docs/components/alert.md
@@ -79,12 +79,6 @@ The BAlert exposes four functions to manipulate the state of an active timer: `p
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/alert.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/avatar.md
+++ b/apps/docs/src/docs/components/avatar.md
@@ -249,12 +249,6 @@ Avatars are based upon `BBadge` and `BButton` components, and as such, rely upon
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/avatar.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/badge.md
+++ b/apps/docs/src/docs/components/badge.md
@@ -68,12 +68,6 @@ Quickly provide actionable badges by specifying either the `href` prop (links) o
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/badge.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/breadcrumb.md
+++ b/apps/docs/src/docs/components/breadcrumb.md
@@ -42,12 +42,6 @@ Use slot `prepend` to put content before the breadcrumb. Use slot `append` to pu
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/breadcrumb.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/button-group.md
+++ b/apps/docs/src/docs/components/button-group.md
@@ -44,12 +44,6 @@ toolbars containing button groups and input groups.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/buttonGroup.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/button-toolbar.md
+++ b/apps/docs/src/docs/components/button-toolbar.md
@@ -35,12 +35,6 @@ input groups and dropdowns, by setting the prop `justify`.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/buttonToolbar.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/button.md
+++ b/apps/docs/src/docs/components/button.md
@@ -149,12 +149,6 @@ added, nor will the keyboard event listeners be enabled.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/button.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/card.md
+++ b/apps/docs/src/docs/components/card.md
@@ -209,12 +209,6 @@ set them to display: inline-block as column-break-inside: avoid is not a bulletp
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/card.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/carousel.md
+++ b/apps/docs/src/docs/components/carousel.md
@@ -133,12 +133,6 @@ You are also able to use the built in methods for going to the next, or previous
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/carousel.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/collapse.md
+++ b/apps/docs/src/docs/components/collapse.md
@@ -102,12 +102,6 @@ element.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/collapse.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/dropdown.md
+++ b/apps/docs/src/docs/components/dropdown.md
@@ -322,12 +322,6 @@ The dropdown menu is rendered with semantic `<ul>` and `<li>` elements for acces
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/dropdown.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-checkbox.md
+++ b/apps/docs/src/docs/components/form-checkbox.md
@@ -208,12 +208,6 @@ The _indeterminate_ state is **visual only**. The checkbox is still either check
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formCheckbox.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-group.md
+++ b/apps/docs/src/docs/components/form-group.md
@@ -225,12 +225,6 @@ scoped `default` slot.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formGroup.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -281,12 +281,6 @@ e.g. With the same setup as above, call `foo?.value?.element?.focus` to set the 
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formInput.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-radio.md
+++ b/apps/docs/src/docs/components/form-radio.md
@@ -176,12 +176,6 @@ Supported `aria-invalid` values are:
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formRadio.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-select.md
+++ b/apps/docs/src/docs/components/form-select.md
@@ -157,12 +157,6 @@ prop set to a value greater than 1.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formSelect.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-spinbutton.md
+++ b/apps/docs/src/docs/components/form-spinbutton.md
@@ -126,12 +126,6 @@ Note the the `repeat-delay`, `repeat-threshold` and `repeat-interval` only appli
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formSpinbutton.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-tags.md
+++ b/apps/docs/src/docs/components/form-tags.md
@@ -214,12 +214,6 @@ Note `<BFormTag>` requires BootstrapVueNext's custom CSS/SCSS for proper styling
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formTags.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form-textarea.md
+++ b/apps/docs/src/docs/components/form-textarea.md
@@ -199,12 +199,6 @@ these methods and properties. Support will vary based on input type.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/formTextarea.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/form.md
+++ b/apps/docs/src/docs/components/form.md
@@ -186,12 +186,6 @@ for details on the Bootstrap v5 validation states.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/form.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/grid-system.md
+++ b/apps/docs/src/docs/components/grid-system.md
@@ -444,14 +444,8 @@ Invisible elements will still affect the layout of the page, but are visually hi
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/gridSystem.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>
 
 <style lang="scss">

--- a/apps/docs/src/docs/components/image.md
+++ b/apps/docs/src/docs/components/image.md
@@ -130,12 +130,6 @@ We implement this `lazy` prop using the native `loading` attribute. See the [MDN
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/image.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/input-group.md
+++ b/apps/docs/src/docs/components/input-group.md
@@ -115,12 +115,6 @@ input groups. However, the inputs inside the input group do support contextual s
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/inputGroup.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/link.md
+++ b/apps/docs/src/docs/components/link.md
@@ -96,12 +96,6 @@ changes).
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/link.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/list-group.md
+++ b/apps/docs/src/docs/components/list-group.md
@@ -123,12 +123,6 @@ help of [flexbox utility classes](/docs/reference/utility-classes).
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/listGroup.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/nav.md
+++ b/apps/docs/src/docs/components/nav.md
@@ -203,12 +203,6 @@ For more details see:
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/nav.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/navbar.md
+++ b/apps/docs/src/docs/components/navbar.md
@@ -171,12 +171,6 @@ Navbars are hidden by default when printing. Force them to be printed by setting
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/navbar.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/offcanvas.md
+++ b/apps/docs/src/docs/components/offcanvas.md
@@ -34,12 +34,6 @@ Below is a simple example showing how to set up such a site.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/offcanvas.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/pagination.md
+++ b/apps/docs/src/docs/components/pagination.md
@@ -162,12 +162,6 @@ pattern.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/pagination.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/progress.md
+++ b/apps/docs/src/docs/components/progress.md
@@ -82,10 +82,4 @@ Include multiple `BProgressBar` sub-components in a `BProgress` component to bui
 
 <script setup lang="ts">
 import {data} from '../../data/components/progress.data'
-import ComponentReference from '../../components/ComponentReference.vue'
-import {BButton, BProgressBar, BCard, BProgress} from 'bootstrap-vue-next'
-import HighlightCard from '../../components/HighlightCard.vue'
-import { ref } from 'vue';
-
-const animate = ref(false);
 </script>

--- a/apps/docs/src/docs/components/spinner.md
+++ b/apps/docs/src/docs/components/spinner.md
@@ -104,12 +104,6 @@ As well, when no label is provided, the spinner will automatically have the attr
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/spinner.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/table.md
+++ b/apps/docs/src/docs/components/table.md
@@ -1043,12 +1043,6 @@ your app handles the various inconsistencies with events.
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/table.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>

--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -262,12 +262,6 @@ It is recommended to use the `disabled` attribute on the `<BTab>` component inst
 
 <ComponentReference :data="data" />
 
-<script lang="ts">
+<script setup lang="ts">
 import {data} from '../../data/components/tabs.data'
-
-export default {
-  setup() {
-    return {data}
-  }
-}
 </script>


### PR DESCRIPTION
# Describe the PR

Someone over in [unplugin-vue-comopnents](https://github.com/unplugin/unplugin-vue-components/issues/801#issuecomment-2924324675) proposed a solution to the issue that we ran into a while back that unplugin components weren't being registered when building the documents. The proposed solution is to add *.ts to the include list, presumably *.js is implied in some way in the system.

In any case, this works and cleans up our *.md files nicely.

## Small replication

Most of the component documentation files.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all component documentation files to use the modern Vue 3 `<script setup>` syntax, simplifying code and improving readability without changing component behavior.
  - Removed unused imports and variables in the progress documentation for cleaner scripts.
- **Chores**
  - Enhanced VitePress configuration to support TypeScript files in component auto-imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->