### PR TITLE
docs: change example styles to be single-attribute-per-line

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -11,3 +11,7 @@ overrides:
       - '**/*.html'
     options:
       singleQuote: false
+  - files:
+      - '**/demo/*.*'
+    options:
+      singleAttributePerLine: true

--- a/apps/docs/src/docs/components/demo/AccordionOverview.vue
+++ b/apps/docs/src/docs/components/demo/AccordionOverview.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <BAccordion>
-    <BAccordionItem title="Accordion Item #1" visible>
+    <BAccordionItem
+      title="Accordion Item #1"
+      visible
+    >
       <strong>This is the first item's accordion body.</strong> It is shown by default, until the
       collapse plugin adds the appropriate classes that we use to style each element. These classes
       control the overall appearance, as well as the showing and hiding via CSS transitions. You can

--- a/apps/docs/src/docs/components/demo/AlertContent.vue
+++ b/apps/docs/src/docs/components/demo/AlertContent.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BAlert :model-value="true" variant="success">
+  <BAlert
+    :model-value="true"
+    variant="success"
+  >
     <h4 class="alert-heading">Well done!</h4>
     <p>
       Aww yeah, you successfully read this important alert message. This example text is going to

--- a/apps/docs/src/docs/components/demo/AlertDismissible.vue
+++ b/apps/docs/src/docs/components/demo/AlertDismissible.vue
@@ -1,5 +1,8 @@
 <template>
-  <BAlert v-model="showDismissibleAlert" dismissible>
+  <BAlert
+    v-model="showDismissibleAlert"
+    dismissible
+  >
     Dismissible Alert! Click the close button over there <b>&rArr;</b>
   </BAlert>
 </template>

--- a/apps/docs/src/docs/components/demo/AlertFade.vue
+++ b/apps/docs/src/docs/components/demo/AlertFade.vue
@@ -1,9 +1,23 @@
 <template>
-  <BAlert :model-value="true" fade>Default Alert</BAlert>
+  <BAlert
+    :model-value="true"
+    fade
+    >Default Alert</BAlert
+  >
 
-  <BAlert variant="success" :model-value="true" fade>Success Alert</BAlert>
+  <BAlert
+    variant="success"
+    :model-value="true"
+    fade
+    >Success Alert</BAlert
+  >
 
-  <BAlert v-model="showDismissibleAlert" variant="danger" dismissible fade>
+  <BAlert
+    v-model="showDismissibleAlert"
+    variant="danger"
+    dismissible
+    fade
+  >
     Dismissible Alert!
   </BAlert>
 
@@ -15,14 +29,27 @@
     @close-countdown="countdown = $event"
   >
     <p>This alert will dismiss after {{ countdown / 1000 }} seconds...</p>
-    <BProgress variant="warning" :max="dismissCountDown" :value="countdown" height="4px" />
+    <BProgress
+      variant="warning"
+      :max="dismissCountDown"
+      :value="countdown"
+      height="4px"
+    />
   </BAlert>
 
-  <BButton variant="info" class="m-1" @click="dismissCountDown = dismissCountDown + 5000">
+  <BButton
+    variant="info"
+    class="m-1"
+    @click="dismissCountDown = dismissCountDown + 5000"
+  >
     Add a five seconds to the alert with countdown timer
   </BButton>
 
-  <BButton variant="info" class="m-1" @click="showDismissibleAlert = !showDismissibleAlert">
+  <BButton
+    variant="info"
+    class="m-1"
+    @click="showDismissibleAlert = !showDismissibleAlert"
+  >
     {{ !showDismissibleAlert ? 'Show' : 'Hide' }} dismissible alert
   </BButton>
 </template>

--- a/apps/docs/src/docs/components/demo/AlertLinkColors.vue
+++ b/apps/docs/src/docs/components/demo/AlertLinkColors.vue
@@ -1,24 +1,76 @@
 <template>
   <!-- #region template -->
-  <BAlert :model-value="true" variant="primary"
-    ><a href="#" class="alert-link">Primary Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="primary"
+    ><a
+      href="#"
+      class="alert-link"
+      >Primary Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="secondary"
-    ><a href="#" class="alert-link">Secondary Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="secondary"
+    ><a
+      href="#"
+      class="alert-link"
+      >Secondary Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="success"
-    ><a href="#" class="alert-link">Success Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="success"
+    ><a
+      href="#"
+      class="alert-link"
+      >Success Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="danger"
-    ><a href="#" class="alert-link">Danger Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="danger"
+    ><a
+      href="#"
+      class="alert-link"
+      >Danger Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="warning"
-    ><a href="#" class="alert-link">Warning Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="warning"
+    ><a
+      href="#"
+      class="alert-link"
+      >Warning Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="info"><a href="#" class="alert-link">Info Alert</a></BAlert>
-  <BAlert :model-value="true" variant="light"
-    ><a href="#" class="alert-link">Light Alert</a></BAlert
+  <BAlert
+    :model-value="true"
+    variant="info"
+    ><a
+      href="#"
+      class="alert-link"
+      >Info Alert</a
+    ></BAlert
   >
-  <BAlert :model-value="true" variant="dark"><a href="#" class="alert-link">Dark Alert</a></BAlert>
+  <BAlert
+    :model-value="true"
+    variant="light"
+    ><a
+      href="#"
+      class="alert-link"
+      >Light Alert</a
+    ></BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="dark"
+    ><a
+      href="#"
+      class="alert-link"
+      >Dark Alert</a
+    ></BAlert
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AlertOverview.vue
+++ b/apps/docs/src/docs/components/demo/AlertOverview.vue
@@ -1,9 +1,19 @@
 <template>
   <BAlert :model-value="true">Default Alert</BAlert>
 
-  <BAlert variant="success" :model-value="true">Success Alert</BAlert>
+  <BAlert
+    variant="success"
+    :model-value="true"
+    >Success Alert</BAlert
+  >
 
-  <BAlert v-model="showDismissibleAlert" variant="danger" dismissible> Dismissible Alert! </BAlert>
+  <BAlert
+    v-model="showDismissibleAlert"
+    variant="danger"
+    dismissible
+  >
+    Dismissible Alert!
+  </BAlert>
 
   <BAlert
     v-model="dismissCountDown"
@@ -12,14 +22,27 @@
     @close-countdown="countdown = $event"
   >
     <p>This alert will dismiss after {{ countdown / 1000 }} seconds...</p>
-    <BProgress variant="warning" :max="dismissCountDown" :value="countdown" height="4px" />
+    <BProgress
+      variant="warning"
+      :max="dismissCountDown"
+      :value="countdown"
+      height="4px"
+    />
   </BAlert>
 
-  <BButton variant="info" class="m-1" @click="dismissCountDown = dismissCountDown + 5000">
+  <BButton
+    variant="info"
+    class="m-1"
+    @click="dismissCountDown = dismissCountDown + 5000"
+  >
     Add a five seconds to the alert with countdown timer
   </BButton>
 
-  <BButton variant="info" class="m-1" @click="showDismissibleAlert = !showDismissibleAlert">
+  <BButton
+    variant="info"
+    class="m-1"
+    @click="showDismissibleAlert = !showDismissibleAlert"
+  >
     {{ !showDismissibleAlert ? 'Show' : 'Hide' }} dismissible alert
   </BButton>
 </template>

--- a/apps/docs/src/docs/components/demo/AlertVariants.vue
+++ b/apps/docs/src/docs/components/demo/AlertVariants.vue
@@ -1,12 +1,44 @@
 <template>
   <!-- #region template -->
-  <BAlert :model-value="true" variant="primary">Primary Alert</BAlert>
-  <BAlert :model-value="true" variant="secondary">Secondary Alert</BAlert>
-  <BAlert :model-value="true" variant="success">Success Alert</BAlert>
-  <BAlert :model-value="true" variant="danger">Danger Alert</BAlert>
-  <BAlert :model-value="true" variant="warning">Warning Alert</BAlert>
-  <BAlert :model-value="true" variant="info">Info Alert</BAlert>
-  <BAlert :model-value="true" variant="light">Light Alert</BAlert>
-  <BAlert :model-value="true" variant="dark">Dark Alert</BAlert>
+  <BAlert
+    :model-value="true"
+    variant="primary"
+    >Primary Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="secondary"
+    >Secondary Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="success"
+    >Success Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="danger"
+    >Danger Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="warning"
+    >Warning Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="info"
+    >Info Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="light"
+    >Light Alert</BAlert
+  >
+  <BAlert
+    :model-value="true"
+    variant="dark"
+    >Dark Alert</BAlert
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarBadge.vue
+++ b/apps/docs/src/docs/components/demo/AvatarBadge.vue
@@ -1,12 +1,35 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar badge />
-    <BAvatar badge badge-variant="danger" src="https://picsum.photos/30/30/?image=40" />
-    <BAvatar badge badge-variant="warning" />
-    <BAvatar badge badge-variant="success" src="https://picsum.photos/30/30/?image=40" />
-    <BAvatar badge badge-variant="dark" text="BV" />
-    <BAvatar square badge badge-variant="dark" text="BV" />
+    <BAvatar
+      badge
+      badge-variant="danger"
+      src="https://picsum.photos/30/30/?image=40"
+    />
+    <BAvatar
+      badge
+      badge-variant="warning"
+    />
+    <BAvatar
+      badge
+      badge-variant="success"
+      src="https://picsum.photos/30/30/?image=40"
+    />
+    <BAvatar
+      badge
+      badge-variant="dark"
+      text="BV"
+    />
+    <BAvatar
+      square
+      badge
+      badge-variant="dark"
+      text="BV"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarBadgeContent.vue
+++ b/apps/docs/src/docs/components/demo/AvatarBadgeContent.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 3%">
+  <div
+    class="d-flex"
+    style="column-gap: 3%"
+  >
     <BAvatar badge="BV" />
-    <BAvatar badge="7" variant="primary" badge-variant="dark" />
+    <BAvatar
+      badge="7"
+      variant="primary"
+      badge-variant="dark"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarBadgeOffset.vue
+++ b/apps/docs/src/docs/components/demo/AvatarBadgeOffset.vue
@@ -1,14 +1,41 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 3%">
+  <div
+    class="d-flex"
+    style="column-gap: 3%"
+  >
     <BAvatar badge />
-    <BAvatar badge badge-offset="-0.5em" />
-    <BAvatar badge badge-offset="-2px" />
-    <BAvatar badge badge-offset="2px" />
-    <BAvatar badge badge-top />
-    <BAvatar badge badge-top badge-offset="-0.5em" />
-    <BAvatar badge badge-top badge-offset="-2px" />
-    <BAvatar badge badge-top badge-offset="2px" />
+    <BAvatar
+      badge
+      badge-offset="-0.5em"
+    />
+    <BAvatar
+      badge
+      badge-offset="-2px"
+    />
+    <BAvatar
+      badge
+      badge-offset="2px"
+    />
+    <BAvatar
+      badge
+      badge-top
+    />
+    <BAvatar
+      badge
+      badge-top
+      badge-offset="-0.5em"
+    />
+    <BAvatar
+      badge
+      badge-top
+      badge-offset="-2px"
+    />
+    <BAvatar
+      badge
+      badge-top
+      badge-offset="2px"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarBadgePositioning.vue
+++ b/apps/docs/src/docs/components/demo/AvatarBadgePositioning.vue
@@ -1,10 +1,22 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 3%">
+  <div
+    class="d-flex"
+    style="column-gap: 3%"
+  >
     <BAvatar badge />
-    <BAvatar badge badge-placement="start" />
-    <BAvatar badge badge-placement="top" />
-    <BAvatar badge badge-placement="top-start" />
+    <BAvatar
+      badge
+      badge-placement="start"
+    />
+    <BAvatar
+      badge
+      badge-placement="top"
+    />
+    <BAvatar
+      badge
+      badge-placement="top-start"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarButton.vue
+++ b/apps/docs/src/docs/components/demo/AvatarButton.vue
@@ -2,11 +2,21 @@
 <template>
   <BListGroup>
     <BListGroupItem>
-      <BAvatar button variant="primary" text="FF" class="align-baseline" @click="alertEvent" />
+      <BAvatar
+        button
+        variant="primary"
+        text="FF"
+        class="align-baseline"
+        @click="alertEvent"
+      />
       Button Text Avatar
     </BListGroupItem>
     <BListGroupItem>
-      <BAvatar button src="https://picsum.photos/30/30/?image=40" @click="alertEvent" />
+      <BAvatar
+        button
+        src="https://picsum.photos/30/30/?image=40"
+        @click="alertEvent"
+      />
       Button Image Avatar
     </BListGroupItem>
   </BListGroup>

--- a/apps/docs/src/docs/components/demo/AvatarCustom.vue
+++ b/apps/docs/src/docs/components/demo/AvatarCustom.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar size="4em">Hello<br />World</BAvatar>
     <BAvatar size="4em">你好<br />世界</BAvatar>
     <BAvatar size="4em"

--- a/apps/docs/src/docs/components/demo/AvatarGroupOverlap.vue
+++ b/apps/docs/src/docs/components/demo/AvatarGroupOverlap.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BAvatarGroup size="3rem" overlap="0.65">
+  <BAvatarGroup
+    size="3rem"
+    overlap="0.65"
+  >
     <BAvatar />
     <BAvatar />
     <BAvatar />

--- a/apps/docs/src/docs/components/demo/AvatarGroups.vue
+++ b/apps/docs/src/docs/components/demo/AvatarGroups.vue
@@ -2,11 +2,23 @@
   <!-- #region template -->
   <BAvatarGroup size="60px">
     <BAvatar />
-    <BAvatar text="BV" variant="primary" />
-    <BAvatar src="https://placekitten.com/300/300" variant="info" />
-    <BAvatar text="OK" variant="danger" />
+    <BAvatar
+      text="BV"
+      variant="primary"
+    />
+    <BAvatar
+      src="https://placekitten.com/300/300"
+      variant="info"
+    />
+    <BAvatar
+      text="OK"
+      variant="danger"
+    />
     <BAvatar variant="warning" />
-    <BAvatar src="https://placekitten.com/320/320" variant="dark" />
+    <BAvatar
+      src="https://placekitten.com/320/320"
+      variant="dark"
+    />
     <BAvatar variant="success" />
   </BAvatarGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/AvatarImage.vue
+++ b/apps/docs/src/docs/components/demo/AvatarImage.vue
@@ -1,8 +1,14 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar src="https://picsum.photos/30/30/?image=40" />
-    <BAvatar src="https://picsum.photos/30/30/?image=40" size="6rem" />
+    <BAvatar
+      src="https://picsum.photos/30/30/?image=40"
+      size="6rem"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarLink.vue
+++ b/apps/docs/src/docs/components/demo/AvatarLink.vue
@@ -2,11 +2,19 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem>
-      <BAvatar href="#foo" variant="primary" text="FF" class="align-baseline" />
+      <BAvatar
+        href="#foo"
+        variant="primary"
+        text="FF"
+        class="align-baseline"
+      />
       Link Text Avatar
     </BListGroupItem>
     <BListGroupItem>
-      <BAvatar href="#bar" src="https://picsum.photos/30/30/?image=40" />
+      <BAvatar
+        href="#bar"
+        src="https://picsum.photos/30/30/?image=40"
+      />
       Link Image Avatar
     </BListGroupItem>
   </BListGroup>

--- a/apps/docs/src/docs/components/demo/AvatarOverview.vue
+++ b/apps/docs/src/docs/components/demo/AvatarOverview.vue
@@ -1,10 +1,19 @@
 <template>
   <!-- #region template -->
   <p>Using stand-alone:</p>
-  <div class="d-flex mb-4" style="column-gap: 1%">
+  <div
+    class="d-flex mb-4"
+    style="column-gap: 1%"
+  >
     <BAvatar />
-    <BAvatar variant="primary" text="BV" />
-    <BAvatar variant="info" src="https://placekitten.com/300/300" />
+    <BAvatar
+      variant="primary"
+      text="BV"
+    />
+    <BAvatar
+      variant="info"
+      src="https://placekitten.com/300/300"
+    />
     <BAvatar variant="success" />
   </div>
   <p>Using in components (list group) example:</p>
@@ -15,17 +24,28 @@
       <BBadge>5</BBadge>
     </BListGroupItem>
     <BListGroupItem class="d-flex align-items-center">
-      <BAvatar variant="primary" text="BV" class="mx-3" />
+      <BAvatar
+        variant="primary"
+        text="BV"
+        class="mx-3"
+      />
       <span class="me-auto">BootstrapVueNext</span>
       <BBadge>12</BBadge>
     </BListGroupItem>
     <BListGroupItem class="d-flex align-items-center">
-      <BAvatar variant="info" src="https://placekitten.com/300/300" class="mx-3" />
+      <BAvatar
+        variant="info"
+        src="https://placekitten.com/300/300"
+        class="mx-3"
+      />
       <span class="me-auto">Super Kitty</span>
       <BBadge>9</BBadge>
     </BListGroupItem>
     <BListGroupItem class="d-flex align-items-center">
-      <BAvatar variant="success" class="mx-3" />
+      <BAvatar
+        variant="success"
+        class="mx-3"
+      />
       <span class="me-auto">ACME group</span>
       <BBadge>7</BBadge>
     </BListGroupItem>

--- a/apps/docs/src/docs/components/demo/AvatarRounding.vue
+++ b/apps/docs/src/docs/components/demo/AvatarRounding.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar rounded="sm" />
     <BAvatar rounded />
     <BAvatar rounded="lg" />
@@ -9,7 +12,10 @@
     <BAvatar rounded-top="lg" />
     <BAvatar rounded-end="md" />
     <BAvatar rounded="circle" />
-    <BAvatar rounded="circle" rounded-top="0" />
+    <BAvatar
+      rounded="circle"
+      rounded-top="0"
+    />
     <BAvatar rounded="0" />
   </div>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/AvatarSize.vue
+++ b/apps/docs/src/docs/components/demo/AvatarSize.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar />
     <BAvatar size="sm" />
     <BAvatar size="lg" />

--- a/apps/docs/src/docs/components/demo/AvatarText.vue
+++ b/apps/docs/src/docs/components/demo/AvatarText.vue
@@ -1,10 +1,16 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar text="BV" />
     <BAvatar text="a" />
     <BAvatar text="Foo" />
-    <BAvatar text="BV" size="4rem" />
+    <BAvatar
+      text="BV"
+      size="4rem"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarVariantOverride.vue
+++ b/apps/docs/src/docs/components/demo/AvatarVariantOverride.vue
@@ -1,12 +1,36 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
-    <BAvatar bg-variant="primary" text="P" />
-    <BAvatar bg-variant="primary" text-variant="info" text="P" />
-    <BAvatar bg-variant="secondary" text="A" />
-    <BAvatar bg-variant="secondary" text-variant="info" text="A" />
-    <BAvatar bg-variant="warning" text="A" />
-    <BAvatar bg-variant="warning" text-variant="light" text="A" />
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
+    <BAvatar
+      bg-variant="primary"
+      text="P"
+    />
+    <BAvatar
+      bg-variant="primary"
+      text-variant="info"
+      text="P"
+    />
+    <BAvatar
+      bg-variant="secondary"
+      text="A"
+    />
+    <BAvatar
+      bg-variant="secondary"
+      text-variant="info"
+      text="A"
+    />
+    <BAvatar
+      bg-variant="warning"
+      text="A"
+    />
+    <BAvatar
+      bg-variant="warning"
+      text-variant="light"
+      text="A"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/AvatarVariants.vue
+++ b/apps/docs/src/docs/components/demo/AvatarVariants.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <div class="d-flex" style="column-gap: 1%">
+  <div
+    class="d-flex"
+    style="column-gap: 1%"
+  >
     <BAvatar variant="secondary" />
     <BAvatar variant="primary" />
     <BAvatar variant="dark" />

--- a/apps/docs/src/docs/components/demo/BadgeBackgroundColors.vue
+++ b/apps/docs/src/docs/components/demo/BadgeBackgroundColors.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="d-flex mb-4" style="column-gap: 1%">
+  <div
+    class="d-flex mb-4"
+    style="column-gap: 1%"
+  >
     <!-- #region template -->
     <BBadge>Primary</BBadge>
     <BBadge variant="secondary">Secondary</BBadge>

--- a/apps/docs/src/docs/components/demo/BadgeDotIndicator.vue
+++ b/apps/docs/src/docs/components/demo/BadgeDotIndicator.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BButton variant="primary" class="position-relative">
+  <BButton
+    variant="primary"
+    class="position-relative"
+  >
     Inbox
     <BBadge
       dot-indicator

--- a/apps/docs/src/docs/components/demo/BadgeHeadings.vue
+++ b/apps/docs/src/docs/components/demo/BadgeHeadings.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="d-flex mb-4" style="column-gap: 1%">
+  <div
+    class="d-flex mb-4"
+    style="column-gap: 1%"
+  >
     <!-- #region template -->
     <h1>
       Example heading

--- a/apps/docs/src/docs/components/demo/BadgePill.vue
+++ b/apps/docs/src/docs/components/demo/BadgePill.vue
@@ -1,14 +1,45 @@
 <template>
-  <div class="d-flex mb-4" style="column-gap: 1%">
+  <div
+    class="d-flex mb-4"
+    style="column-gap: 1%"
+  >
     <!-- #region template -->
     <BBadge pill>Primary</BBadge>
-    <BBadge pill variant="secondary">Secondary</BBadge>
-    <BBadge pill variant="success">Success</BBadge>
-    <BBadge pill variant="danger">Danger</BBadge>
-    <BBadge pill variant="warning">Warning</BBadge>
-    <BBadge pill variant="info">Info</BBadge>
-    <BBadge pill variant="light">Light</BBadge>
-    <BBadge pill variant="dark">Dark</BBadge>
+    <BBadge
+      pill
+      variant="secondary"
+      >Secondary</BBadge
+    >
+    <BBadge
+      pill
+      variant="success"
+      >Success</BBadge
+    >
+    <BBadge
+      pill
+      variant="danger"
+      >Danger</BBadge
+    >
+    <BBadge
+      pill
+      variant="warning"
+      >Warning</BBadge
+    >
+    <BBadge
+      pill
+      variant="info"
+      >Info</BBadge
+    >
+    <BBadge
+      pill
+      variant="light"
+      >Light</BBadge
+    >
+    <BBadge
+      pill
+      variant="dark"
+      >Dark</BBadge
+    >
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/BadgePositioned.vue
+++ b/apps/docs/src/docs/components/demo/BadgePositioned.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- #region template -->
-  <BButton variant="primary" class="position-relative">
+  <BButton
+    variant="primary"
+    class="position-relative"
+  >
     Inbox
-    <BBadge variant="danger" class="position-absolute top-0 start-100 translate-middle">99+</BBadge>
+    <BBadge
+      variant="danger"
+      class="position-absolute top-0 start-100 translate-middle"
+      >99+</BBadge
+    >
   </BButton>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
+++ b/apps/docs/src/docs/components/demo/BreadcrumbManual.vue
@@ -2,7 +2,11 @@
   <BBreadcrumb>
     <BBreadcrumbItem href="#home"> Home </BBreadcrumbItem>
     <BBreadcrumbItem href="#foo">Foo</BBreadcrumbItem>
-    <BBreadcrumbItem href="#bar" @click="alertEvent">Bar</BBreadcrumbItem>
+    <BBreadcrumbItem
+      href="#bar"
+      @click="alertEvent"
+      >Bar</BBreadcrumbItem
+    >
     <BBreadcrumbItem active>Baz</BBreadcrumbItem>
   </BBreadcrumb>
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonDisabledState.vue
+++ b/apps/docs/src/docs/components/demo/ButtonDisabledState.vue
@@ -1,8 +1,17 @@
 <template>
   <div class="d-flex gap-2">
     <!-- #region template -->
-    <BButton disabled size="lg" variant="primary">Disabled</BButton>
-    <BButton disabled size="lg">Also Disabled</BButton>
+    <BButton
+      disabled
+      size="lg"
+      variant="primary"
+      >Disabled</BButton
+    >
+    <BButton
+      disabled
+      size="lg"
+      >Also Disabled</BButton
+    >
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonGroupDropdown.vue
+++ b/apps/docs/src/docs/components/demo/ButtonGroupDropdown.vue
@@ -2,7 +2,10 @@
   <!-- #region template -->
   <BButtonGroup aria-label="Button group with dropdown">
     <BButton variant="secondary">Button</BButton>
-    <BDropdown text="Dropdown" variant="secondary">
+    <BDropdown
+      text="Dropdown"
+      variant="secondary"
+    >
       <BDropdownItem>Action</BDropdownItem>
       <BDropdownItem>Another action</BDropdownItem>
       <BDropdownItem>Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/ButtonGroupSizing.vue
+++ b/apps/docs/src/docs/components/demo/ButtonGroupSizing.vue
@@ -1,21 +1,30 @@
 <template>
   <!-- #region template -->
   <div>
-    <BButtonGroup size="sm" aria-label="Large button group">
+    <BButtonGroup
+      size="sm"
+      aria-label="Large button group"
+    >
       <BButton variant="secondary">Left</BButton>
       <BButton variant="secondary">Middle</BButton>
       <BButton variant="secondary">Right</BButton>
     </BButtonGroup>
   </div>
   <div class="mt-3">
-    <BButtonGroup size="md" aria-label="Small button group">
+    <BButtonGroup
+      size="md"
+      aria-label="Small button group"
+    >
       <BButton variant="secondary">Left</BButton>
       <BButton variant="secondary">Middle</BButton>
       <BButton variant="secondary">Right</BButton>
     </BButtonGroup>
   </div>
   <div class="mt-3">
-    <BButtonGroup size="lg" aria-label="Large button group">
+    <BButtonGroup
+      size="lg"
+      aria-label="Large button group"
+    >
       <BButton variant="secondary">Left</BButton>
       <BButton variant="secondary">Middle</BButton>
       <BButton variant="secondary">Right</BButton>

--- a/apps/docs/src/docs/components/demo/ButtonLoading.vue
+++ b/apps/docs/src/docs/components/demo/ButtonLoading.vue
@@ -2,9 +2,21 @@
   <div class="d-flex gap-2">
     <!-- #region template -->
     <BButton :loading="true">Button</BButton>
-    <BButton :loading="true" loading-fill>Button</BButton>
-    <BButton :loading="true" loading-text="Please Wait...">Button</BButton>
-    <BButton :loading="false" loading-text="Please Wait...">Button</BButton>
+    <BButton
+      :loading="true"
+      loading-fill
+      >Button</BButton
+    >
+    <BButton
+      :loading="true"
+      loading-text="Please Wait..."
+      >Button</BButton
+    >
+    <BButton
+      :loading="false"
+      loading-text="Please Wait..."
+      >Button</BButton
+    >
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonPillStyle.vue
+++ b/apps/docs/src/docs/components/demo/ButtonPillStyle.vue
@@ -2,11 +2,31 @@
   <div class="d-flex gap-2">
     <!-- #region template -->
     <BButton pill>Button</BButton>
-    <BButton pill variant="primary">Button</BButton>
-    <BButton pill variant="outline-secondary">Button</BButton>
-    <BButton pill variant="success">Button</BButton>
-    <BButton pill variant="outline-danger">Button</BButton>
-    <BButton pill variant="info">Button</BButton>
+    <BButton
+      pill
+      variant="primary"
+      >Button</BButton
+    >
+    <BButton
+      pill
+      variant="outline-secondary"
+      >Button</BButton
+    >
+    <BButton
+      pill
+      variant="success"
+      >Button</BButton
+    >
+    <BButton
+      pill
+      variant="outline-danger"
+      >Button</BButton
+    >
+    <BButton
+      pill
+      variant="info"
+      >Button</BButton
+    >
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonPressedState.vue
+++ b/apps/docs/src/docs/components/demo/ButtonPressedState.vue
@@ -1,17 +1,34 @@
 <template>
   <h5>Pressed and un-pressed state</h5>
   <div class="d-flex gap-2">
-    <BButton :pressed="true" variant="success">Always Pressed</BButton>
-    <BButton :pressed="false" variant="success">Not Pressed</BButton>
+    <BButton
+      :pressed="true"
+      variant="success"
+      >Always Pressed</BButton
+    >
+    <BButton
+      :pressed="false"
+      variant="success"
+      >Not Pressed</BButton
+    >
   </div>
   <h5 class="mt-3">Toggleable Button</h5>
-  <BButton v-model:pressed="buttonToggle" variant="primary">Toggle Me</BButton>
+  <BButton
+    v-model:pressed="buttonToggle"
+    variant="primary"
+    >Toggle Me</BButton
+  >
   <p>
     Pressed State: <strong>{{ buttonToggle }}</strong>
   </p>
   <h5>In a button group</h5>
   <BButtonGroup size="sm">
-    <BButton v-for="(btn, idx) in buttons" :key="idx" v-model:pressed="btn.state" variant="primary">
+    <BButton
+      v-for="(btn, idx) in buttons"
+      :key="idx"
+      v-model:pressed="btn.state"
+      variant="primary"
+    >
       {{ btn.caption }}
     </BButton>
   </BButtonGroup>

--- a/apps/docs/src/docs/components/demo/ButtonSizing.vue
+++ b/apps/docs/src/docs/components/demo/ButtonSizing.vue
@@ -1,7 +1,15 @@
 <template>
   <!-- #region template -->
-  <BButton size="sm" class="mx-1">Small Button</BButton>
+  <BButton
+    size="sm"
+    class="mx-1"
+    >Small Button</BButton
+  >
   <BButton class="mx-1">Default Button</BButton>
-  <BButton size="lg" class="mx-1">Large Button</BButton>
+  <BButton
+    size="lg"
+    class="mx-1"
+    >Large Button</BButton
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonSquaredStyle.vue
+++ b/apps/docs/src/docs/components/demo/ButtonSquaredStyle.vue
@@ -2,11 +2,31 @@
   <div class="d-flex gap-2">
     <!-- #region template -->
     <BButton squared>Button</BButton>
-    <BButton squared variant="primary">Button</BButton>
-    <BButton squared variant="outline-secondary">Button</BButton>
-    <BButton squared variant="success">Button</BButton>
-    <BButton squared variant="outline-danger">Button</BButton>
-    <BButton squared variant="info">Button</BButton>
+    <BButton
+      squared
+      variant="primary"
+      >Button</BButton
+    >
+    <BButton
+      squared
+      variant="outline-secondary"
+      >Button</BButton
+    >
+    <BButton
+      squared
+      variant="success"
+      >Button</BButton
+    >
+    <BButton
+      squared
+      variant="outline-danger"
+      >Button</BButton
+    >
+    <BButton
+      squared
+      variant="info"
+      >Button</BButton
+    >
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/ButtonToolbarExample1.vue
+++ b/apps/docs/src/docs/components/demo/ButtonToolbarExample1.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BButtonToolbar key-nav aria-label="Toolbar with button groups">
+  <BButtonToolbar
+    key-nav
+    aria-label="Toolbar with button groups"
+  >
     <BButtonGroup class="mx-1">
       <BButton>&laquo;</BButton>
       <BButton>&lsaquo;</BButton>

--- a/apps/docs/src/docs/components/demo/ButtonToolbarExample2.vue
+++ b/apps/docs/src/docs/components/demo/ButtonToolbarExample2.vue
@@ -1,12 +1,22 @@
 <template>
   <!-- #region template -->
   <BButtonToolbar aria-label="Toolbar with button groups and input groups">
-    <BButtonGroup size="sm" class="me-1">
+    <BButtonGroup
+      size="sm"
+      class="me-1"
+    >
       <BButton>Save</BButton>
       <BButton>Cancel</BButton>
     </BButtonGroup>
-    <BInputGroup size="sm" prepend="$" append=".00">
-      <BFormInput value="100" class="text-end" />
+    <BInputGroup
+      size="sm"
+      prepend="$"
+      append=".00"
+    >
+      <BFormInput
+        value="100"
+        class="text-end"
+      />
     </BInputGroup>
   </BButtonToolbar>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ButtonToolbarExample3.vue
+++ b/apps/docs/src/docs/components/demo/ButtonToolbarExample3.vue
@@ -6,7 +6,11 @@
       <BButton>Edit</BButton>
       <BButton>Undo</BButton>
     </BButtonGroup>
-    <BDropdown class="mx-1" placement="right" text="menu">
+    <BDropdown
+      class="mx-1"
+      placement="right"
+      text="menu"
+    >
       <BDropdownItem>Item 1</BDropdownItem>
       <BDropdownItem>Item 2</BDropdownItem>
       <BDropdownItem>Item 3</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/ButtonToolbarJustify.vue
+++ b/apps/docs/src/docs/components/demo/ButtonToolbarJustify.vue
@@ -1,12 +1,19 @@
 <template>
   <!-- #region template -->
-  <BButtonToolbar justify aria-label="Toolbar with justify">
+  <BButtonToolbar
+    justify
+    aria-label="Toolbar with justify"
+  >
     <BButtonGroup class="mx-1">
       <BButton>New</BButton>
       <BButton>Edit</BButton>
       <BButton>Undo</BButton>
     </BButtonGroup>
-    <BDropdown class="mx-1" placement="right" text="menu">
+    <BDropdown
+      class="mx-1"
+      placement="right"
+      text="menu"
+    >
       <BDropdownItem>Item 1</BDropdownItem>
       <BDropdownItem>Item 2</BDropdownItem>
       <BDropdownItem>Item 3</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/ButtonToolbarSizing.vue
+++ b/apps/docs/src/docs/components/demo/ButtonToolbarSizing.vue
@@ -2,7 +2,10 @@
   <!-- #region template -->
   <div>
     <BButtonToolbar aria-label="Toolbar with size sm">
-      <BButtonGroup size="sm" class="mx-1">
+      <BButtonGroup
+        size="sm"
+        class="mx-1"
+      >
         <BButton>New</BButton>
         <BButton>Edit</BButton>
         <BButton>Undo</BButton>
@@ -11,7 +14,12 @@
   </div>
   <div class="mt-2">
     <BButtonToolbar aria-label="Toolbar with dropdown size sm">
-      <BDropdown size="sm" class="mx-1" placement="right" text="menu">
+      <BDropdown
+        size="sm"
+        class="mx-1"
+        placement="right"
+        text="menu"
+      >
         <BDropdownItem>Item 1</BDropdownItem>
         <BDropdownItem>Item 2</BDropdownItem>
         <BDropdownItem>Item 3</BDropdownItem>
@@ -20,7 +28,10 @@
   </div>
   <div class="mt-2">
     <BButtonToolbar aria-label="Toolbar with size lg">
-      <BButtonGroup size="lg" class="mx-1">
+      <BButtonGroup
+        size="lg"
+        class="mx-1"
+      >
         <BButton>New</BButton>
         <BButton>Edit</BButton>
         <BButton>Undo</BButton>
@@ -29,7 +40,12 @@
   </div>
   <div class="mt-2">
     <BButtonToolbar aria-label="Toolbar with dropdown size lg">
-      <BDropdown size="lg" class="mx-1" placement="right" text="menu">
+      <BDropdown
+        size="lg"
+        class="mx-1"
+        placement="right"
+        text="menu"
+      >
         <BDropdownItem>Item 1</BDropdownItem>
         <BDropdownItem>Item 2</BDropdownItem>
         <BDropdownItem>Item 3</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/CardBorderedVariants.vue
+++ b/apps/docs/src/docs/components/demo/CardBorderedVariants.vue
@@ -19,17 +19,29 @@
       >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard border-variant="success" header="Success" align="center">
+      <BCard
+        border-variant="success"
+        header="Success"
+        align="center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
     </BCardGroup>
   </div>
   <div class="mt-3">
     <BCardGroup deck>
-      <BCard border-variant="info" header="Info" align="center">
+      <BCard
+        border-variant="info"
+        header="Info"
+        align="center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard border-variant="warning" header="Warning" align="center">
+      <BCard
+        border-variant="warning"
+        header="Warning"
+        align="center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
       <BCard
@@ -44,11 +56,22 @@
     </BCardGroup>
   </div>
   <div class="mt-3">
-    <BCardGroup deck class="mb-3">
-      <BCard border-variant="light" header="Light" class="text-center">
+    <BCardGroup
+      deck
+      class="mb-3"
+    >
+      <BCard
+        border-variant="light"
+        header="Light"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard border-variant="dark" header="Dark" align="center">
+      <BCard
+        border-variant="dark"
+        header="Dark"
+        align="center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
     </BCardGroup>

--- a/apps/docs/src/docs/components/demo/CardColumn.vue
+++ b/apps/docs/src/docs/components/demo/CardColumn.vue
@@ -20,13 +20,21 @@
         </footer>
       </blockquote>
     </BCard>
-    <BCard title="Title" img-src="https://picsum.photos/500/350" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/500/350"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This card has supporting text below as a natural lead-in to additional content.
       </BCardText>
       <BCardText class="small text-body-secondary">Last updated 3 mins ago</BCardText>
     </BCard>
-    <BCard bg-variant="primary" text-variant="white">
+    <BCard
+      bg-variant="primary"
+      text-variant="white"
+    >
       <blockquote class="card-blockquote">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
         <footer>
@@ -41,8 +49,16 @@
       </BCardText>
       <BCardText class="small text-body-secondary">Last updated 3 mins ago</BCardText>
     </BCard>
-    <BCard img-src="https://picsum.photos/400/400/?image=41" img-alt="Image" overlay />
-    <BCard img-src="https://picsum.photos/400/200/?image=41" img-alt="Image" img-top>
+    <BCard
+      img-src="https://picsum.photos/400/400/?image=41"
+      img-alt="Image"
+      overlay
+    />
+    <BCard
+      img-src="https://picsum.photos/400/200/?image=41"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This is a wider card with supporting text below as a natural lead-in to additional content.
         This card has even longer content than the first.

--- a/apps/docs/src/docs/components/demo/CardDeck.vue
+++ b/apps/docs/src/docs/components/demo/CardDeck.vue
@@ -1,7 +1,12 @@
 <template>
   <!-- #region template -->
   <BCardGroup deck>
-    <BCard title="Title" img-src="https://picsum.photos/300/300/?image=41" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/300/300/?image=41"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This is a wider card with supporting text below as a natural lead-in to additional content.
         This content is a little bit longer.
@@ -10,7 +15,12 @@
         <small class="text-body-secondary">Last updated 3 mins ago</small>
       </template>
     </BCard>
-    <BCard title="Title" img-src="https://picsum.photos/300/300/?image=41" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/300/300/?image=41"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This card has supporting text below as a natural lead-in to additional content.
       </BCardText>
@@ -18,7 +28,12 @@
         <small class="text-body-secondary">Last updated 3 mins ago</small>
       </template>
     </BCard>
-    <BCard title="Title" img-src="https://picsum.photos/300/300/?image=41" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/300/300/?image=41"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This is a wider card with supporting text below as a natural lead-in to additional content.
         This card has even longer content than the first to show that equal height action.

--- a/apps/docs/src/docs/components/demo/CardGroup.vue
+++ b/apps/docs/src/docs/components/demo/CardGroup.vue
@@ -1,7 +1,12 @@
 <template>
   <!-- #region template -->
   <BCardGroup>
-    <BCard title="Title" img-src="https://picsum.photos/g/300/450" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/g/300/450"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This is a wider card with supporting text below as a natural lead-in to additional content.
         This content is a little bit longer.
@@ -10,7 +15,12 @@
         <small class="text-body-secondary">Last updated 3 mins ago</small>
       </template>
     </BCard>
-    <BCard title="Title" img-src="https://picsum.photos/g/300/450" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/g/300/450"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This card has supporting text below as a natural lead-in to additional content.
       </BCardText>
@@ -18,7 +28,12 @@
         <small class="text-body-secondary">Last updated 3 mins ago</small>
       </template>
     </BCard>
-    <BCard title="Title" img-src="https://picsum.photos/g/300/450" img-alt="Image" img-top>
+    <BCard
+      title="Title"
+      img-src="https://picsum.photos/g/300/450"
+      img-alt="Image"
+      img-top
+    >
       <BCardText>
         This is a wider card with supporting text below as a natural lead-in to additional content.
         This card has even longer content than the first to show that equal height action.

--- a/apps/docs/src/docs/components/demo/CardHeaderFooter.vue
+++ b/apps/docs/src/docs/components/demo/CardHeaderFooter.vue
@@ -9,14 +9,26 @@
       title="Title"
     >
       <BCardText>Header and footers using props.</BCardText>
-      <BButton href="#" variant="primary">Go somewhere</BButton>
+      <BButton
+        href="#"
+        variant="primary"
+        >Go somewhere</BButton
+      >
     </BCard>
-    <BCard title="Title" header-tag="header" footer-tag="footer">
+    <BCard
+      title="Title"
+      header-tag="header"
+      footer-tag="footer"
+    >
       <template #header>
         <h6 class="mb-0">Header Slot</h6>
       </template>
       <BCardText>Header and footers using slots.</BCardText>
-      <BButton href="#" variant="primary">Go somewhere</BButton>
+      <BButton
+        href="#"
+        variant="primary"
+        >Go somewhere</BButton
+      >
       <template #footer>
         <em>Footer Slot</em>
       </template>

--- a/apps/docs/src/docs/components/demo/CardHorizontal.vue
+++ b/apps/docs/src/docs/components/demo/CardHorizontal.vue
@@ -1,9 +1,17 @@
 <template>
   <!-- #region template -->
-  <BCard no-body class="overflow-hidden" style="max-width: 540px">
+  <BCard
+    no-body
+    class="overflow-hidden"
+    style="max-width: 540px"
+  >
     <BRow class="g-0">
       <BCol md="6">
-        <BCardImg src="https://picsum.photos/400/400/?image=20" alt="Image" class="rounded-0" />
+        <BCardImg
+          src="https://picsum.photos/400/400/?image=20"
+          alt="Image"
+          class="rounded-0"
+        />
       </BCol>
       <BCol md="6">
         <BCardBody title="Horizontal Card">

--- a/apps/docs/src/docs/components/demo/CardImages.vue
+++ b/apps/docs/src/docs/components/demo/CardImages.vue
@@ -3,12 +3,20 @@
   <div>
     <h4>Top and Bottom</h4>
     <BCardGroup deck>
-      <BCard img-src="https://picsum.photos/1000/300" img-alt="Card image" img-top>
+      <BCard
+        img-src="https://picsum.photos/1000/300"
+        img-alt="Card image"
+        img-top
+      >
         <BCardText>
           Some quick example text to build on the card and make up the bulk of the card's content.
         </BCardText>
       </BCard>
-      <BCard img-src="https://picsum.photos/1000/300" img-alt="Card image" img-bottom>
+      <BCard
+        img-src="https://picsum.photos/1000/300"
+        img-alt="Card image"
+        img-bottom
+      >
         <BCardText>
           Some quick example text to build on the card and make up the bulk of the card's content.
         </BCardText>
@@ -17,12 +25,21 @@
   </div>
   <div class="mt-4">
     <h4>Left and Right (or Start and End)</h4>
-    <BCard img-src="https://picsum.photos/300/300" img-alt="Card image" img-left class="mb-3">
+    <BCard
+      img-src="https://picsum.photos/300/300"
+      img-alt="Card image"
+      img-left
+      class="mb-3"
+    >
       <BCardText>
         Some quick example text to build on the card and make up the bulk of the card's content.
       </BCardText>
     </BCard>
-    <BCard img-src="https://picsum.photos/300/300" img-alt="Card image" img-right>
+    <BCard
+      img-src="https://picsum.photos/300/300"
+      img-alt="Card image"
+      img-right
+    >
       <BCardText>
         Some quick example text to build on the card and make up the bulk of the card's content.
       </BCardText>

--- a/apps/docs/src/docs/components/demo/CardKitchenSink.vue
+++ b/apps/docs/src/docs/components/demo/CardKitchenSink.vue
@@ -24,11 +24,23 @@
       <BListGroupItem>Vestibulum at eros</BListGroupItem>
     </BListGroup>
     <BCardBody>
-      <a href="#" class="card-link">Card link</a>
-      <a href="#" class="card-link">Another link</a>
+      <a
+        href="#"
+        class="card-link"
+        >Card link</a
+      >
+      <a
+        href="#"
+        class="card-link"
+        >Another link</a
+      >
     </BCardBody>
     <BCardFooter>This is a footer</BCardFooter>
-    <BCardImg src="https://picsum.photos/480/210" alt="Image" bottom />
+    <BCardImg
+      src="https://picsum.photos/480/210"
+      alt="Image"
+      bottom
+    />
   </BCard>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CardNavComponent.vue
+++ b/apps/docs/src/docs/components/demo/CardNavComponent.vue
@@ -2,7 +2,10 @@
   <!-- #region template -->
   <BCard no-body>
     <BCardHeader header-tag="nav">
-      <BNav card-header tabs>
+      <BNav
+        card-header
+        tabs
+      >
         <BNavItem active>Active</BNavItem>
         <BNavItem>Inactive</BNavItem>
         <BNavItem disabled>Disabled</BNavItem>

--- a/apps/docs/src/docs/components/demo/CardNavSlot.vue
+++ b/apps/docs/src/docs/components/demo/CardNavSlot.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- #region template -->
-  <BCard title="Card Title" body-class="text-center" header-tag="nav">
+  <BCard
+    title="Card Title"
+    body-class="text-center"
+    header-tag="nav"
+  >
     <template #header>
-      <BNav card-header tabs>
+      <BNav
+        card-header
+        tabs
+      >
         <BNavItem active>Active</BNavItem>
         <BNavItem>Inactive</BNavItem>
         <BNavItem disabled>Disabled</BNavItem>

--- a/apps/docs/src/docs/components/demo/CardNoBody copy.vue
+++ b/apps/docs/src/docs/components/demo/CardNoBody copy.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BCard no-body class="text-center">
+  <BCard
+    no-body
+    class="text-center"
+  >
     <div class="bg-secondary text-light">
       This is some content without the default <samp>&lt;BCardBody&gt;</samp> section. Notice the
       lack of padding between the card's border and this gray <samp>&lt;div&gt;</samp>.

--- a/apps/docs/src/docs/components/demo/CardNoBody.vue
+++ b/apps/docs/src/docs/components/demo/CardNoBody.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BCard no-body class="text-center">
+  <BCard
+    no-body
+    class="text-center"
+  >
     <div class="bg-secondary text-light">
       This is some content without the default <samp>&lt;BCardBody&gt;</samp> section. Notice the
       lack of padding between the card's border and this gray <samp>&lt;div&gt;</samp>.

--- a/apps/docs/src/docs/components/demo/CardOverview.vue
+++ b/apps/docs/src/docs/components/demo/CardOverview.vue
@@ -11,7 +11,11 @@
     <BCardText>
       Some quick example text to build on the card title and make up the bulk of the card's content.
     </BCardText>
-    <BButton href="#" variant="primary">Go somewhere</BButton>
+    <BButton
+      href="#"
+      variant="primary"
+      >Go somewhere</BButton
+    >
   </BCard>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CardParts.vue
+++ b/apps/docs/src/docs/components/demo/CardParts.vue
@@ -11,7 +11,11 @@
     <BCardText>
       Some quick example text to build on the card title and make up the bulk of the card's content.
     </BCardText>
-    <BButton href="#" variant="primary">Go somewhere</BButton>
+    <BButton
+      href="#"
+      variant="primary"
+      >Go somewhere</BButton
+    >
   </BCard>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CardSolidVariants.vue
+++ b/apps/docs/src/docs/components/demo/CardSolidVariants.vue
@@ -2,39 +2,81 @@
   <!-- #region template -->
   <div>
     <BCardGroup deck>
-      <BCard bg-variant="primary" text-variant="white" header="Primary" class="text-center">
+      <BCard
+        bg-variant="primary"
+        text-variant="white"
+        header="Primary"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard bg-variant="secondary" text-variant="white" header="Secondary" class="text-center">
+      <BCard
+        bg-variant="secondary"
+        text-variant="white"
+        header="Secondary"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard bg-variant="success" text-variant="white" header="Success" class="text-center">
+      <BCard
+        bg-variant="success"
+        text-variant="white"
+        header="Success"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
     </BCardGroup>
   </div>
   <div class="mt-3">
     <BCardGroup deck>
-      <BCard bg-variant="info" text-variant="white" header="Info" class="text-center">
+      <BCard
+        bg-variant="info"
+        text-variant="white"
+        header="Info"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard bg-variant="warning" text-variant="white" header="Warning" class="text-center">
+      <BCard
+        bg-variant="warning"
+        text-variant="white"
+        header="Warning"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard bg-variant="danger" text-variant="white" header="Danger" class="text-center">
+      <BCard
+        bg-variant="danger"
+        text-variant="white"
+        header="Danger"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
     </BCardGroup>
   </div>
   <div class="mt-3">
     <BCardGroup deck>
-      <BCard bg-variant="light" header="Light" class="text-center">
+      <BCard
+        bg-variant="light"
+        header="Light"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard bg-variant="dark" header="Dark" text-variant="white" class="text-center">
+      <BCard
+        bg-variant="dark"
+        header="Dark"
+        text-variant="white"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
-      <BCard header="Default" class="text-center">
+      <BCard
+        header="Default"
+        class="text-center"
+      >
         <BCardText>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</BCardText>
       </BCard>
     </BCardGroup>

--- a/apps/docs/src/docs/components/demo/CardTextVariants.vue
+++ b/apps/docs/src/docs/components/demo/CardTextVariants.vue
@@ -1,8 +1,16 @@
 <template>
   <!-- #region template -->
-  <BCard bg-variant="dark" text-variant="white" title="Card Title">
+  <BCard
+    bg-variant="dark"
+    text-variant="white"
+    title="Card Title"
+  >
     <BCardText> With supporting text below as a natural lead-in to additional content. </BCardText>
-    <BButton href="#" variant="primary">Go somewhere</BButton>
+    <BButton
+      href="#"
+      variant="primary"
+      >Go somewhere</BButton
+    >
   </BCard>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CarouselAutoplay.vue
+++ b/apps/docs/src/docs/components/demo/CarouselAutoplay.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BCarousel controls indicators ride="carousel">
+  <BCarousel
+    controls
+    indicators
+    ride="carousel"
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=13" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=14" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=15" />

--- a/apps/docs/src/docs/components/demo/CarouselAutoplayManipulation.vue
+++ b/apps/docs/src/docs/components/demo/CarouselAutoplayManipulation.vue
@@ -1,13 +1,27 @@
 <template>
-  <BCarousel ref="myCarousel" :interval="2500" controls indicators ride="carousel">
+  <BCarousel
+    ref="myCarousel"
+    :interval="2500"
+    controls
+    indicators
+    ride="carousel"
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=25" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=26" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=27" />
   </BCarousel>
 
   <BButtonGroup>
-    <BButton variant="danger" @click="pause">Pause</BButton>
-    <BButton variant="success" @click="resume">Resume</BButton>
+    <BButton
+      variant="danger"
+      @click="pause"
+      >Pause</BButton
+    >
+    <BButton
+      variant="success"
+      @click="resume"
+      >Resume</BButton
+    >
   </BButtonGroup>
 </template>
 

--- a/apps/docs/src/docs/components/demo/CarouselAutoplayReverse.vue
+++ b/apps/docs/src/docs/components/demo/CarouselAutoplayReverse.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BCarousel controls indicators ride="carousel" :ride-reverse="true">
+  <BCarousel
+    controls
+    indicators
+    ride="carousel"
+    :ride-reverse="true"
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=22" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=23" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=24" />

--- a/apps/docs/src/docs/components/demo/CarouselCaptions.vue
+++ b/apps/docs/src/docs/components/demo/CarouselCaptions.vue
@@ -1,7 +1,13 @@
 <template>
   <!-- #region template -->
-  <BCarousel controls indicators>
-    <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=7" caption="First Caption" />
+  <BCarousel
+    controls
+    indicators
+  >
+    <BCarouselSlide
+      img-src="https://picsum.photos/1024/480/?image=7"
+      caption="First Caption"
+    />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=9">
       <template #caption> Second Caption </template>
     </BCarouselSlide>

--- a/apps/docs/src/docs/components/demo/CarouselCrossfade.vue
+++ b/apps/docs/src/docs/components/demo/CarouselCrossfade.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BCarousel fade controls indicators>
+  <BCarousel
+    fade
+    controls
+    indicators
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=10" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=11" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=12" />

--- a/apps/docs/src/docs/components/demo/CarouselFull.vue
+++ b/apps/docs/src/docs/components/demo/CarouselFull.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BCarousel controls indicators>
+  <BCarousel
+    controls
+    indicators
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=40">
       <h1>First slide</h1>
       <p>Some more detailed description or whatever content.</p>

--- a/apps/docs/src/docs/components/demo/CarouselInterval.vue
+++ b/apps/docs/src/docs/components/demo/CarouselInterval.vue
@@ -1,13 +1,28 @@
 <template>
-  <BCarousel :interval="slideInterval" controls indicators ride="carousel">
+  <BCarousel
+    :interval="slideInterval"
+    controls
+    indicators
+    ride="carousel"
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=19" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=20" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=21" />
   </BCarousel>
 
   <BButtonGroup>
-    <BButton variant="danger" @click="slideInterval = slideInterval - 1000"> Minus 1000 </BButton>
-    <BButton variant="success" @click="slideInterval = slideInterval + 1000"> Plus 1000 </BButton>
+    <BButton
+      variant="danger"
+      @click="slideInterval = slideInterval - 1000"
+    >
+      Minus 1000
+    </BButton>
+    <BButton
+      variant="success"
+      @click="slideInterval = slideInterval + 1000"
+    >
+      Plus 1000
+    </BButton>
   </BButtonGroup>
 
   Current Interval Speed: {{ slideInterval }} ms

--- a/apps/docs/src/docs/components/demo/CarouselMethods.vue
+++ b/apps/docs/src/docs/components/demo/CarouselMethods.vue
@@ -6,8 +6,16 @@
   </BCarousel>
 
   <BButtonGroup class="mt-3">
-    <BButton variant="danger" @click="prev">Previous Slide</BButton>
-    <BButton variant="success" @click="next">Next Slide</BButton>
+    <BButton
+      variant="danger"
+      @click="prev"
+      >Previous Slide</BButton
+    >
+    <BButton
+      variant="success"
+      @click="next"
+      >Next Slide</BButton
+    >
   </BButtonGroup>
 </template>
 

--- a/apps/docs/src/docs/components/demo/CarouselModel.vue
+++ b/apps/docs/src/docs/components/demo/CarouselModel.vue
@@ -1,5 +1,8 @@
 <template>
-  <BCarousel v-model="slide" controls>
+  <BCarousel
+    v-model="slide"
+    controls
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=1" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=2" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=3" />

--- a/apps/docs/src/docs/components/demo/CarouselRideTrue.vue
+++ b/apps/docs/src/docs/components/demo/CarouselRideTrue.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BCarousel controls indicators :ride="true">
+  <BCarousel
+    controls
+    indicators
+    :ride="true"
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=16" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=17" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=18" />

--- a/apps/docs/src/docs/components/demo/CarouselStartingSlide.vue
+++ b/apps/docs/src/docs/components/demo/CarouselStartingSlide.vue
@@ -1,5 +1,8 @@
 <template>
-  <BCarousel v-model="slide" indicators>
+  <BCarousel
+    v-model="slide"
+    indicators
+  >
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=34" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=35" />
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=36" />

--- a/apps/docs/src/docs/components/demo/CarouselTouchThreshold.vue
+++ b/apps/docs/src/docs/components/demo/CarouselTouchThreshold.vue
@@ -5,8 +5,16 @@
     <BCarouselSlide img-src="https://picsum.photos/1024/480/?image=33" />
   </BCarousel>
   <BButtonGroup class="mt-3">
-    <BButton variant="danger" @click="slideThreshold = slideThreshold - 10">Decrease</BButton>
-    <BButton variant="success" @click="slideThreshold = slideThreshold + 10">Increase</BButton>
+    <BButton
+      variant="danger"
+      @click="slideThreshold = slideThreshold - 10"
+      >Decrease</BButton
+    >
+    <BButton
+      variant="success"
+      @click="slideThreshold = slideThreshold + 10"
+      >Increase</BButton
+    >
   </BButtonGroup>
   Threshold: {{ slideThreshold }}
 </template>

--- a/apps/docs/src/docs/components/demo/CheckboxButton.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxButton.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="hstack gap-3">
-    <BFormCheckbox v-model="button1Checked" button>
+    <BFormCheckbox
+      v-model="button1Checked"
+      button
+    >
       Button Checkbox (Checked: {{ button1Checked }})
     </BFormCheckbox>
 
-    <BFormCheckbox v-model="button2Checked" button button-variant="danger">
+    <BFormCheckbox
+      v-model="button2Checked"
+      button
+      button-variant="danger"
+    >
       Button Checkbox (Checked: {{ button2Checked }})
     </BFormCheckbox>
   </div>

--- a/apps/docs/src/docs/components/demo/CheckboxButtonGroup.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxButtonGroup.vue
@@ -3,7 +3,12 @@
     <label>Form-checkbox-group inline checkboxes (default)</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" name="buttons-1" buttons />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    name="buttons-1"
+    buttons
+  />
 
   <div class="my-2">
     <label>Button-group style checkboxes with variant primary and large buttons</label>
@@ -22,7 +27,12 @@
     <label>Stacked (vertical) button-group style checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" stacked buttons />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    stacked
+    buttons
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/CheckboxExample2.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxExample2.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <b-form-group v-slot="{ariaDescribedby}" label="Using options array:">
+    <b-form-group
+      v-slot="{ariaDescribedby}"
+      label="Using options array:"
+    >
       <b-form-checkbox-group
         id="checkbox-group-1"
         v-model="selected"
@@ -10,7 +13,10 @@
       />
     </b-form-group>
 
-    <b-form-group v-slot="{ariaDescribedby}" label="Using sub-components:">
+    <b-form-group
+      v-slot="{ariaDescribedby}"
+      label="Using sub-components:"
+    >
       <b-form-checkbox-group
         id="checkbox-group-2"
         v-model="selected"

--- a/apps/docs/src/docs/components/demo/CheckboxInline.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxInline.vue
@@ -3,13 +3,22 @@
     <label>Form-checkbox-group inline checkboxes (default)</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" name="flavour-1a" />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    name="flavour-1a"
+  />
 
   <div class="my-2">
     <label>Form-checkbox-group stacked checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" name="flavour-2a" stacked />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    name="flavour-2a"
+    stacked
+  />
 
   <div class="my-2">
     <label>Individual stacked checkboxes (default)</label>

--- a/apps/docs/src/docs/components/demo/CheckboxPlain.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxPlain.vue
@@ -3,13 +3,22 @@
     <label>Plain inline checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" plain />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    plain
+  />
 
   <div class="my-2">
     <label>Plain stacked checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" plain stacked />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    plain
+    stacked
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/CheckboxReverse.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxReverse.vue
@@ -1,7 +1,15 @@
 <template>
   <!-- #region template -->
   <BFormCheckbox reverse>Reverse checkbox</BFormCheckbox>
-  <BFormCheckbox reverse disabled>Disabled reverse checkbox</BFormCheckbox>
-  <BFormCheckbox reverse switch>Reverse switch ceckbox input</BFormCheckbox>
+  <BFormCheckbox
+    reverse
+    disabled
+    >Disabled reverse checkbox</BFormCheckbox
+  >
+  <BFormCheckbox
+    reverse
+    switch
+    >Reverse switch ceckbox input</BFormCheckbox
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CheckboxSwitch.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxSwitch.vue
@@ -1,5 +1,8 @@
 <template>
-  <BFormCheckbox v-model="switchChecked" switch>
+  <BFormCheckbox
+    v-model="switchChecked"
+    switch
+  >
     Switch Checkbox <strong>(Checked: {{ switchChecked }})</strong>
   </BFormCheckbox>
 </template>

--- a/apps/docs/src/docs/components/demo/CheckboxSwitchGroup.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxSwitchGroup.vue
@@ -3,13 +3,22 @@
     <label>Inline switch style checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" switches />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    switches
+  />
 
   <div class="my-2">
     <label>Stacked (vertical) switch style checkboxes</label>
   </div>
 
-  <BFormCheckboxGroup v-model="selected" :options="options" switches stacked />
+  <BFormCheckboxGroup
+    v-model="selected"
+    :options="options"
+    switches
+    stacked
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/CheckboxSwitchSize.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxSwitchSize.vue
@@ -1,7 +1,15 @@
 <template>
   <!-- #region template -->
-  <BFormCheckbox switch size="sm">Small</BFormCheckbox>
+  <BFormCheckbox
+    switch
+    size="sm"
+    >Small</BFormCheckbox
+  >
   <BFormCheckbox switch>Default</BFormCheckbox>
-  <BFormCheckbox switch size="lg">Large</BFormCheckbox>
+  <BFormCheckbox
+    switch
+    size="lg"
+    >Large</BFormCheckbox
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/CheckboxTriState.vue
+++ b/apps/docs/src/docs/components/demo/CheckboxTriState.vue
@@ -1,8 +1,13 @@
 <template>
-  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate"
+  <BFormCheckbox
+    v-model="checked"
+    v-model:indeterminate="indeterminate"
     >Click me to see what happens</BFormCheckbox
   >
-  <BButton class="mt-2" :disabled="indeterminate" @click="indeterminate = true"
+  <BButton
+    class="mt-2"
+    :disabled="indeterminate"
+    @click="indeterminate = true"
     >Reset Indeterminate</BButton
   >
   <div class="mt-2">

--- a/apps/docs/src/docs/components/demo/ColMixed.vue
+++ b/apps/docs/src/docs/components/demo/ColMixed.vue
@@ -3,15 +3,35 @@
   <BContainer class="bv-example-row">
     <!-- Stack the columns on mobile by making one full-width and the other half-width -->
     <BRow>
-      <BCol cols="12" md="8">cols="12" md="8"</BCol>
-      <BCol cols="6" md="4">cols="6" md="4"</BCol>
+      <BCol
+        cols="12"
+        md="8"
+        >cols="12" md="8"</BCol
+      >
+      <BCol
+        cols="6"
+        md="4"
+        >cols="6" md="4"</BCol
+      >
     </BRow>
 
     <!-- Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop -->
     <BRow>
-      <BCol cols="6" md="4">cols="6" md="4"</BCol>
-      <BCol cols="6" md="4">cols="6" md="4"</BCol>
-      <BCol cols="6" md="4">cols="6" md="4"</BCol>
+      <BCol
+        cols="6"
+        md="4"
+        >cols="6" md="4"</BCol
+      >
+      <BCol
+        cols="6"
+        md="4"
+        >cols="6" md="4"</BCol
+      >
+      <BCol
+        cols="6"
+        md="4"
+        >cols="6" md="4"</BCol
+      >
     </BRow>
 
     <!-- Columns are always 50% wide, on mobile and desktop -->

--- a/apps/docs/src/docs/components/demo/ColNesting.vue
+++ b/apps/docs/src/docs/components/demo/ColNesting.vue
@@ -1,12 +1,23 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="bv-example-row">
+  <BContainer
+    fluid
+    class="bv-example-row"
+  >
     <BRow>
       <BCol sm="9">
         Level 1: sm="9"
         <BRow>
-          <BCol cols="8" sm="6">Level 2: cols="8" sm="6"</BCol>
-          <BCol cols="4" sm="6">Level 2: cols="4" sm="6"</BCol>
+          <BCol
+            cols="8"
+            sm="6"
+            >Level 2: cols="8" sm="6"</BCol
+          >
+          <BCol
+            cols="4"
+            sm="6"
+            >Level 2: cols="4" sm="6"</BCol
+          >
         </BRow>
       </BCol>
     </BRow>

--- a/apps/docs/src/docs/components/demo/ColOffset.vue
+++ b/apps/docs/src/docs/components/demo/ColOffset.vue
@@ -1,18 +1,37 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="bv-example-row">
+  <BContainer
+    fluid
+    class="bv-example-row"
+  >
     <BRow>
       <BCol md="4">md="4"</BCol>
-      <BCol md="4" offset-md="4">md="4" offset-md="4"</BCol>
+      <BCol
+        md="4"
+        offset-md="4"
+        >md="4" offset-md="4"</BCol
+      >
     </BRow>
 
     <BRow>
-      <BCol md="3" offset-md="3">md="3" offset-md="3"</BCol>
-      <BCol md="3" offset-md="3">md="3" offset-md="3"</BCol>
+      <BCol
+        md="3"
+        offset-md="3"
+        >md="3" offset-md="3"</BCol
+      >
+      <BCol
+        md="3"
+        offset-md="3"
+        >md="3" offset-md="3"</BCol
+      >
     </BRow>
 
     <BRow>
-      <BCol md="6" offset-md="3">md="6" offset-md="3"</BCol>
+      <BCol
+        md="6"
+        offset-md="3"
+        >md="6" offset-md="3"</BCol
+      >
     </BRow>
   </BContainer>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ColOffsetClear.vue
+++ b/apps/docs/src/docs/components/demo/ColOffsetClear.vue
@@ -1,16 +1,37 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="bv-example-row">
+  <BContainer
+    fluid
+    class="bv-example-row"
+  >
     <BRow>
-      <BCol sm="5" md="6">sm="5" md="6"</BCol>
-      <BCol sm="5" offset-sm="2" md="6" offset-md="0"
+      <BCol
+        sm="5"
+        md="6"
+        >sm="5" md="6"</BCol
+      >
+      <BCol
+        sm="5"
+        offset-sm="2"
+        md="6"
+        offset-md="0"
         >sm="5" offset-sm="2" md="6" offset-md="0"</BCol
       >
     </BRow>
 
     <BRow>
-      <BCol sm="6" md="5" lg="6">sm="6" md="5" lg="6"</BCol>
-      <BCol sm="6" md="5" offset-md="2" lg="6" offset-lg="0"
+      <BCol
+        sm="6"
+        md="5"
+        lg="6"
+        >sm="6" md="5" lg="6"</BCol
+      >
+      <BCol
+        sm="6"
+        md="5"
+        offset-md="2"
+        lg="6"
+        offset-lg="0"
         >sm="6" md="5" offset-md="2" col-lg="6" offset-lg="0"</BCol
       >
     </BRow>

--- a/apps/docs/src/docs/components/demo/ColOrder.vue
+++ b/apps/docs/src/docs/components/demo/ColOrder.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="bv-example-row">
+  <BContainer
+    fluid
+    class="bv-example-row"
+  >
     <BRow class="mb-3">
       <BCol>First in DOM, no order applied</BCol>
       <BCol order="5">Second in DOM, with a larger order</BCol>

--- a/apps/docs/src/docs/components/demo/ColSpacing.vue
+++ b/apps/docs/src/docs/components/demo/ColSpacing.vue
@@ -1,20 +1,51 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="text-light text-center">
+  <BContainer
+    fluid
+    class="text-light text-center"
+  >
     <BRow class="mb-3">
-      <BCol md="4" class="p-3 bg-info">md="4"</BCol>
-      <BCol md="4" class="ms-auto p-3 bg-info">md="4" .ml-auto</BCol>
+      <BCol
+        md="4"
+        class="p-3 bg-info"
+        >md="4"</BCol
+      >
+      <BCol
+        md="4"
+        class="ms-auto p-3 bg-info"
+        >md="4" .ml-auto</BCol
+      >
     </BRow>
 
     <BRow class="mb-3">
-      <BCol md="3" class="ms-md-auto p-3 bg-info">md="3" .ml-md-auto</BCol>
-      <BCol md="3" class="ms-md-auto p-3 bg-info">md="3" .ml-md-auto</BCol>
+      <BCol
+        md="3"
+        class="ms-md-auto p-3 bg-info"
+        >md="3" .ml-md-auto</BCol
+      >
+      <BCol
+        md="3"
+        class="ms-md-auto p-3 bg-info"
+        >md="3" .ml-md-auto</BCol
+      >
     </BRow>
 
     <BRow>
-      <BCol cols="auto" class="me-auto p-3 bg-info">cols="auto" .mr-auto</BCol>
-      <BCol cols="auto" class="me-auto p-3 bg-info">cols="auto" .mr-auto</BCol>
-      <BCol cols="auto" class="p-3 bg-info">cols="auto"</BCol>
+      <BCol
+        cols="auto"
+        class="me-auto p-3 bg-info"
+        >cols="auto" .mr-auto</BCol
+      >
+      <BCol
+        cols="auto"
+        class="me-auto p-3 bg-info"
+        >cols="auto" .mr-auto</BCol
+      >
+      <BCol
+        cols="auto"
+        class="p-3 bg-info"
+        >cols="auto"</BCol
+      >
     </BRow>
   </BContainer>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ColVariableWidth.vue
+++ b/apps/docs/src/docs/components/demo/ColVariableWidth.vue
@@ -2,15 +2,35 @@
   <!-- #region template -->
   <BContainer class="bv-example-row">
     <BRow class="justify-content-md-center">
-      <BCol col lg="2">1 of 3</BCol>
-      <BCol cols="12" md="auto">Variable width content</BCol>
-      <BCol col lg="2">3 of 3</BCol>
+      <BCol
+        col
+        lg="2"
+        >1 of 3</BCol
+      >
+      <BCol
+        cols="12"
+        md="auto"
+        >Variable width content</BCol
+      >
+      <BCol
+        col
+        lg="2"
+        >3 of 3</BCol
+      >
     </BRow>
 
     <BRow>
       <BCol>1 of 3</BCol>
-      <BCol cols="12" md="auto">Variable width content</BCol>
-      <BCol col lg="2">3 of 3</BCol>
+      <BCol
+        cols="12"
+        md="auto"
+        >Variable width content</BCol
+      >
+      <BCol
+        col
+        lg="2"
+        >3 of 3</BCol
+      >
     </BRow>
   </BContainer>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/CollapseContent.vue
+++ b/apps/docs/src/docs/components/demo/CollapseContent.vue
@@ -2,7 +2,12 @@
   <!-- #region template -->
   <BCollapse id="my-collapse">
     <template #header="{visible, toggle, id}">
-      <BButton variant="primary" :aria-expanded="visible" :aria-controls="id" @click="toggle">
+      <BButton
+        variant="primary"
+        :aria-expanded="visible"
+        :aria-controls="id"
+        @click="toggle"
+      >
         <span>{{ visible ? 'Close' : 'Open' }}</span> My Collapse
       </BButton>
     </template>

--- a/apps/docs/src/docs/components/demo/CollapseExpose.vue
+++ b/apps/docs/src/docs/components/demo/CollapseExpose.vue
@@ -4,7 +4,10 @@
     <BButton @click="hide">hide</BButton>
     <BButton @click="toggle">toggle</BButton>
   </BButtonGroup>
-  <BCollapse ref="myCollapse" class="mt-2">
+  <BCollapse
+    ref="myCollapse"
+    class="mt-2"
+  >
     <BCard>I am controlled by exposed functions!</BCard>
   </BCollapse>
   <pre class="mt-2">

--- a/apps/docs/src/docs/components/demo/CollapseInitial.vue
+++ b/apps/docs/src/docs/components/demo/CollapseInitial.vue
@@ -1,9 +1,16 @@
 <template>
   <!-- #region template -->
   <!-- Using modifiers -->
-  <BButton v-b-toggle.collapse-3 class="m-1">Toggle Collapse</BButton>
+  <BButton
+    v-b-toggle.collapse-3
+    class="m-1"
+    >Toggle Collapse</BButton
+  >
 
-  <BCollapse id="collapse-3" visible>
+  <BCollapse
+    id="collapse-3"
+    visible
+  >
     <BCard class="mt-4">I should start open!</BCard>
   </BCollapse>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/CollapseModel.vue
+++ b/apps/docs/src/docs/components/demo/CollapseModel.vue
@@ -8,7 +8,11 @@
     >
       Toggle Collapse
     </BButton>
-    <BCollapse id="collapse-4" v-model="visible" class="mt-2">
+    <BCollapse
+      id="collapse-4"
+      v-model="visible"
+      class="mt-2"
+    >
       <BCard>I should start open!</BCard>
     </BCollapse>
   </BCard>

--- a/apps/docs/src/docs/components/demo/CollapseOverview.vue
+++ b/apps/docs/src/docs/components/demo/CollapseOverview.vue
@@ -1,11 +1,19 @@
 <template>
   <!-- #region template -->
-  <BButton v-b-toggle.collapse-1 variant="primary">Toggle Collapse</BButton>
+  <BButton
+    v-b-toggle.collapse-1
+    variant="primary"
+    >Toggle Collapse</BButton
+  >
 
   <BCollapse id="collapse-1">
     <BCard class="mt-4">
       <p class="card-text">Collapse contents Here</p>
-      <BButton v-b-toggle.collapse-1-inner size="sm">Toggle Inner Collapse</BButton>
+      <BButton
+        v-b-toggle.collapse-1-inner
+        size="sm"
+        >Toggle Inner Collapse</BButton
+      >
       <BCollapse id="collapse-1-inner">
         <BCard class="mt-4">Hello!</BCard>
       </BCollapse>

--- a/apps/docs/src/docs/components/demo/CollapseUsage.vue
+++ b/apps/docs/src/docs/components/demo/CollapseUsage.vue
@@ -1,10 +1,18 @@
 <template>
   <!-- #region template -->
   <!-- Using modifiers -->
-  <BButton v-b-toggle.collapse-2 class="m-1">Toggle Collapse</BButton>
+  <BButton
+    v-b-toggle.collapse-2
+    class="m-1"
+    >Toggle Collapse</BButton
+  >
 
   <!-- Using value -->
-  <BButton v-b-toggle="'collapse-2'" class="m-1">Toggle Collapse</BButton>
+  <BButton
+    v-b-toggle="'collapse-2'"
+    class="m-1"
+    >Toggle Collapse</BButton
+  >
 
   <!-- Element to collapse -->
   <BCollapse id="collapse-2">

--- a/apps/docs/src/docs/components/demo/DropdownAccessibility.vue
+++ b/apps/docs/src/docs/components/demo/DropdownAccessibility.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Dropdown ARIA" variant="primary">
+  <BDropdown
+    text="Dropdown ARIA"
+    variant="primary"
+  >
     <BDropdownHeader id="dropdown-header-1">Groups</BDropdownHeader>
     <BDropdownItemButton aria-describedby="dropdown-header-1">Add</BDropdownItemButton>
     <BDropdownItemButton aria-describedby="dropdown-header-1">Delete</BDropdownItemButton>

--- a/apps/docs/src/docs/components/demo/DropdownAutoClose.vue
+++ b/apps/docs/src/docs/components/demo/DropdownAutoClose.vue
@@ -1,22 +1,37 @@
 <template>
   <div class="d-flex flex-wrap gap-2">
     <!-- #region template -->
-    <BDropdown text="Default Dropdown" class="me-2">
+    <BDropdown
+      text="Default Dropdown"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here</BDropdownItemButton>
     </BDropdown>
-    <BDropdown text="Clickable outside (auto-close=inside)" auto-close="inside" class="me-2">
+    <BDropdown
+      text="Clickable outside (auto-close=inside)"
+      auto-close="inside"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here</BDropdownItemButton>
     </BDropdown>
-    <BDropdown text="Clickable inside (auto-close=outside)" auto-close="outside" class="me-2">
+    <BDropdown
+      text="Clickable inside (auto-close=outside)"
+      auto-close="outside"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here</BDropdownItemButton>
     </BDropdown>
-    <BDropdown text="Manual close (auto-close=false)" :auto-close="false" class="me-2">
+    <BDropdown
+      text="Manual close (auto-close=false)"
+      :auto-close="false"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here</BDropdownItemButton>

--- a/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Block Level Dropdown Menu" block variant="primary" menu-class="w-100">
+  <BDropdown
+    text="Block Level Dropdown Menu"
+    block
+    variant="primary"
+    menu-class="w-100"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Block Level Dropdown" variant="primary" class="d-grid gap-2 mb-2">
+  <BDropdown
+    text="Block Level Dropdown"
+    variant="primary"
+    class="d-grid gap-2 mb-2"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
+++ b/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <div class="d-flex gap-2">
-    <BDropdown text="Button text via Prop" class="me-2">
+    <BDropdown
+      text="Button text via Prop"
+      class="me-2"
+    >
       <BDropdownItem href="#">An item</BDropdownItem>
       <BDropdownItem href="#">Another item</BDropdownItem>
     </BDropdown>

--- a/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
+++ b/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
@@ -1,17 +1,29 @@
 <template>
   <div class="d-flex flex-wrap gap-2">
     <!-- #region template -->
-    <BDropdown text="Primary" variant="primary" class="me-2">
+    <BDropdown
+      text="Primary"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown text="Success" variant="success" class="me-2">
+    <BDropdown
+      text="Success"
+      variant="success"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown text="Outline Danger" variant="outline-danger" class="me-2">
+    <BDropdown
+      text="Outline Danger"
+      variant="outline-danger"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownDropup.vue
+++ b/apps/docs/src/docs/components/demo/DropdownDropup.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BDropdown placement="top" text="Drop-Up" variant="primary" class="me-2">
+  <BDropdown
+    placement="top"
+    text="Drop-Up"
+    variant="primary"
+    class="me-2"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownFloating.vue
+++ b/apps/docs/src/docs/components/demo/DropdownFloating.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Strategy fixed" strategy="fixed" class="me-2">
+  <BDropdown
+    text="Strategy fixed"
+    strategy="fixed"
+    class="me-2"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownForm.vue
+++ b/apps/docs/src/docs/components/demo/DropdownForm.vue
@@ -1,25 +1,46 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Dropdown with form" auto-close="outside">
+  <BDropdown
+    text="Dropdown with form"
+    auto-close="outside"
+  >
     <BDropdownForm>
       <BFormGroup
         label="Email address:"
         label-for="email"
         description="We'll never share your email with anyone else."
       >
-        <BFormInput id="email" type="email" placeholder="Enter email" required />
+        <BFormInput
+          id="email"
+          type="email"
+          placeholder="Enter email"
+          required
+        />
       </BFormGroup>
       <BFormGroup
         label="Password:"
         label-for="password"
         description="We'll never share your email with anyone else."
       >
-        <BFormInput id="password" type="password" required />
+        <BFormInput
+          id="password"
+          type="password"
+          required
+        />
       </BFormGroup>
-      <BFormCheckbox id="remember" name="remember" value="remember" checked>
+      <BFormCheckbox
+        id="remember"
+        name="remember"
+        value="remember"
+        checked
+      >
         Remember me</BFormCheckbox
       >
-      <BButton type="submit" variant="primary">Sign In</BButton>
+      <BButton
+        type="submit"
+        variant="primary"
+        >Sign In</BButton
+      >
     </BDropdownForm>
     <BDropdownDivider />
     <BDropdownItemButton>New around here? Sign up</BDropdownItemButton>

--- a/apps/docs/src/docs/components/demo/DropdownGroup.vue
+++ b/apps/docs/src/docs/components/demo/DropdownGroup.vue
@@ -7,7 +7,10 @@
       <BDropdownItemButton>First Grouped item</BDropdownItemButton>
       <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
     </BDropdownGroup>
-    <BDropdownGroup header="Group 2" header-variant="primary">
+    <BDropdownGroup
+      header="Group 2"
+      header-variant="primary"
+    >
       <BDropdownItemButton>First Grouped item</BDropdownItemButton>
       <BDropdownItemButton>Second Grouped Item</BDropdownItemButton>
     </BDropdownGroup>

--- a/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
+++ b/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BDropdown size="lg" variant="link" toggle-class="text-decoration-none" no-caret>
+  <BDropdown
+    size="lg"
+    variant="link"
+    toggle-class="text-decoration-none"
+    no-caret
+  >
     <template #button-content> &#x1f50d;<span class="visually-hidden">Search</span> </template>
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownInlineForm.vue
+++ b/apps/docs/src/docs/components/demo/DropdownInlineForm.vue
@@ -1,12 +1,34 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Dropdown with inline form" auto-close="outside">
+  <BDropdown
+    text="Dropdown with inline form"
+    auto-close="outside"
+  >
     <BDropdownForm form-class="d-flex flex-row align-items-center flex-wrap">
-      <BFormGroup label="Email:" label-for="email-inline" label-cols="3" label-align="end">
-        <BFormInput id="email-inline" type="email" placeholder="Enter email" required />
+      <BFormGroup
+        label="Email:"
+        label-for="email-inline"
+        label-cols="3"
+        label-align="end"
+      >
+        <BFormInput
+          id="email-inline"
+          type="email"
+          placeholder="Enter email"
+          required
+        />
       </BFormGroup>
-      <BFormGroup label="Password:" label-for="password-inline" label-cols="4" label-align="end">
-        <BFormInput id="password-inline" type="password" required />
+      <BFormGroup
+        label="Password:"
+        label-for="password-inline"
+        label-cols="4"
+        label-align="end"
+      >
+        <BFormInput
+          id="password-inline"
+          type="password"
+          required
+        />
       </BFormGroup>
     </BDropdownForm>
     <BDropdownDivider />

--- a/apps/docs/src/docs/components/demo/DropdownLazy.vue
+++ b/apps/docs/src/docs/components/demo/DropdownLazy.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BDropdown lazy text="Dropdown">
+  <BDropdown
+    lazy
+    text="Dropdown"
+  >
     <BDropdownItem>First Action</BDropdownItem>
     <BDropdownItem>Second Action</BDropdownItem>
     <BDropdownItem>Third Action</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
@@ -1,22 +1,41 @@
 <template>
   <div class="d-flex flex-wrap gap-2">
     <!-- #region template -->
-    <BDropdown text="Default Alignment" variant="primary" class="me-2">
+    <BDropdown
+      text="Default Alignment"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown start text="Start Alignment" variant="primary" class="me-2">
+    <BDropdown
+      start
+      text="Start Alignment"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown end text="End Align" variant="primary" class="me-2">
+    <BDropdown
+      end
+      text="End Align"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown center text="Center" variant="primary" class="me-2">
+    <BDropdown
+      center
+      text="Center"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="d-flex flex-wrap gap-2">
     <!-- #region template -->
-    <BDropdown offset="25" text="Offset Dropdown" class="me-2">
+    <BDropdown
+      offset="25"
+      text="Offset Dropdown"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownMethods.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMethods.vue
@@ -1,11 +1,24 @@
 <template>
   <div class="d-flex gap-2 mb-2">
-    <BButton variant="danger" @click="show">Show</BButton>
-    <BButton variant="success" @click="hide">Hide</BButton>
+    <BButton
+      variant="danger"
+      @click="show"
+      >Show</BButton
+    >
+    <BButton
+      variant="success"
+      @click="hide"
+      >Hide</BButton
+    >
     <BButton @click="toggle">Toggle</BButton>
   </div>
 
-  <BDropdown ref="myDropdown" text="Dropdown Button" :auto-close="false" class="me-2">
+  <BDropdown
+    ref="myDropdown"
+    text="Dropdown Button"
+    :auto-close="false"
+    class="me-2"
+  >
     <BDropdownItem>First Action</BDropdownItem>
     <BDropdownItem>Second Action</BDropdownItem>
     <BDropdownItem>Third Action</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownModel.vue
+++ b/apps/docs/src/docs/components/demo/DropdownModel.vue
@@ -6,7 +6,11 @@
     <BButton @click="model = false">Close Dropdown</BButton>
   </div>
 
-  <BDropdown v-model="model" text="Dropdown Button" class="me-2">
+  <BDropdown
+    v-model="model"
+    text="Dropdown Button"
+    class="me-2"
+  >
     <BDropdownItem>First Action</BDropdownItem>
     <BDropdownItem>Second Action</BDropdownItem>
     <BDropdownItem>Third Action</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
+++ b/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="No flipping" no-flip class="me-2">
+  <BDropdown
+    text="No flipping"
+    no-flip
+    class="me-2"
+  >
     <BDropdownItem href="#">An item</BDropdownItem>
     <BDropdownItem href="#">Another item</BDropdownItem>
     <BDropdownItem href="#">Yet Another item</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownOverview.vue
+++ b/apps/docs/src/docs/components/demo/DropdownOverview.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BDropdown text="Dropdown Button" class="me-2">
+  <BDropdown
+    text="Dropdown Button"
+    class="me-2"
+  >
     <BDropdownItem>First Action</BDropdownItem>
     <BDropdownItem>Second Action</BDropdownItem>
     <BDropdownItem>Third Action</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownPlacement.vue
+++ b/apps/docs/src/docs/components/demo/DropdownPlacement.vue
@@ -1,22 +1,42 @@
 <template>
   <div class="d-flex flex-wrap gap-2">
     <!-- #region template -->
-    <BDropdown placement="right" text="Drop-right" variant="primary" class="me-2">
+    <BDropdown
+      placement="right"
+      text="Drop-right"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown placement="left" text="Drop-left" variant="primary" class="me-2">
+    <BDropdown
+      placement="left"
+      text="Drop-left"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown placement="right-start" text="Drop-right-start" variant="primary" class="me-2">
+    <BDropdown
+      placement="right-start"
+      text="Drop-right-start"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>
     </BDropdown>
-    <BDropdown placement="left-end" text="Drop-left-end" variant="primary" class="me-2">
+    <BDropdown
+      placement="left-end"
+      text="Drop-left-end"
+      variant="primary"
+      class="me-2"
+    >
       <BDropdownItem href="#">Action</BDropdownItem>
       <BDropdownItem href="#">Another action</BDropdownItem>
       <BDropdownItem href="#">Something else here</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownSizing.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSizing.vue
@@ -1,24 +1,42 @@
 <template>
   <!-- #region template -->
   <div class="d-flex flex-wrap gap-2">
-    <BDropdown size="lg" text="Large" class="me-2">
+    <BDropdown
+      size="lg"
+      text="Large"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here</BDropdownItemButton>
     </BDropdown>
-    <BDropdown size="lg" split text="Large Split" class="me-2">
+    <BDropdown
+      size="lg"
+      split
+      text="Large Split"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here...</BDropdownItemButton>
     </BDropdown>
   </div>
   <div class="d-flex flex-wrap gap-2 mt-2">
-    <BDropdown size="sm" text="Small" class="me-2">
+    <BDropdown
+      size="sm"
+      text="Small"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here...</BDropdownItemButton>
     </BDropdown>
-    <BDropdown size="sm" split text="Small Split" class="me-2">
+    <BDropdown
+      size="sm"
+      split
+      text="Small Split"
+      class="me-2"
+    >
       <BDropdownItemButton>Action</BDropdownItemButton>
       <BDropdownItemButton>Another action</BDropdownItemButton>
       <BDropdownItemButton>Something else here...</BDropdownItemButton>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BDropdown split text="Split Dropdown" class="me-2">
+  <BDropdown
+    split
+    text="Split Dropdown"
+    class="me-2"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here...</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BDropdown split split-href="#foo/bar" text="Split Link" class="me-2">
+  <BDropdown
+    split
+    split-href="#foo/bar"
+    text="Split Link"
+    class="me-2"
+  >
     <BDropdownItem href="#">Action</BDropdownItem>
     <BDropdownItem href="#">Another action</BDropdownItem>
     <BDropdownItem href="#">Something else here...</BDropdownItem>

--- a/apps/docs/src/docs/components/demo/FormDataHelper.vue
+++ b/apps/docs/src/docs/components/demo/FormDataHelper.vue
@@ -1,8 +1,14 @@
 <template>
   <div>
     <label for="input-with-list">Input with datalist</label>
-    <BFormInput id="input-with-list" list="input-list" />
-    <BFormDatalist id="input-list" :options="datalistOptions" />
+    <BFormInput
+      id="input-with-list"
+      list="input-list"
+    />
+    <BFormDatalist
+      id="input-list"
+      :options="datalistOptions"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormFeedbackHelper.vue
+++ b/apps/docs/src/docs/components/demo/FormFeedbackHelper.vue
@@ -1,7 +1,11 @@
 <template>
   <BForm @submit.stop.prevent>
     <label for="feedback-user">User Id</label>
-    <BFormInput id="feedback-user" v-model="userId" :state="validation" />
+    <BFormInput
+      id="feedback-user"
+      v-model="userId"
+      :state="validation"
+    />
     <BFormInvalidFeedback :state="validation">
       Your user Id must be 5-12 characters long.
     </BFormInvalidFeedback>

--- a/apps/docs/src/docs/components/demo/FormFloatingLabels.vue
+++ b/apps/docs/src/docs/components/demo/FormFloatingLabels.vue
@@ -1,11 +1,27 @@
 <template>
   <!-- #region template -->
   <BForm>
-    <BFormFloatingLabel label="Email address" label-for="floatingEmail" class="my-2">
-      <BFormInput id="floatingEmail" type="email" placeholder="Email address" />
+    <BFormFloatingLabel
+      label="Email address"
+      label-for="floatingEmail"
+      class="my-2"
+    >
+      <BFormInput
+        id="floatingEmail"
+        type="email"
+        placeholder="Email address"
+      />
     </BFormFloatingLabel>
-    <BFormFloatingLabel label="Password" label-for="floatingPassword" class="my-2">
-      <BFormInput id="floatingPassword" type="password" placeholder="Password" />
+    <BFormFloatingLabel
+      label="Password"
+      label-for="floatingPassword"
+      class="my-2"
+    >
+      <BFormInput
+        id="floatingPassword"
+        type="password"
+        placeholder="Password"
+      />
     </BFormFloatingLabel>
   </BForm>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/FormGroupLabelSize.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupLabelSize.vue
@@ -8,7 +8,10 @@
     label-for="input-sm"
     class="my-1"
   >
-    <BFormInput id="input-sm" size="sm" />
+    <BFormInput
+      id="input-sm"
+      size="sm"
+    />
   </BFormGroup>
   <BFormGroup
     label-cols="4"
@@ -27,7 +30,10 @@
     label-for="input-lg"
     class="my-1"
   >
-    <BFormInput id="input-lg" size="lg" />
+    <BFormInput
+      id="input-lg"
+      size="lg"
+    />
   </BFormGroup>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormGroupNested.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupNested.vue
@@ -8,13 +8,28 @@
       label-class="fw-bold pt-0"
       class="mb-0"
     >
-      <BFormGroup label="Street:" label-for="nested-street" label-cols-sm="3" label-align-sm="end">
+      <BFormGroup
+        label="Street:"
+        label-for="nested-street"
+        label-cols-sm="3"
+        label-align-sm="end"
+      >
         <BFormInput id="nested-street" />
       </BFormGroup>
-      <BFormGroup label="City:" label-for="nested-city" label-cols-sm="3" label-align-sm="end">
+      <BFormGroup
+        label="City:"
+        label-for="nested-city"
+        label-cols-sm="3"
+        label-align-sm="end"
+      >
         <BFormInput id="nested-city" />
       </BFormGroup>
-      <BFormGroup label="State:" label-for="nested-state" label-cols-sm="3" label-align-sm="end">
+      <BFormGroup
+        label="State:"
+        label-for="nested-state"
+        label-cols-sm="3"
+        label-align-sm="end"
+      >
         <BFormInput id="nested-state" />
       </BFormGroup>
       <BFormGroup
@@ -25,8 +40,16 @@
       >
         <BFormInput id="nested-country" />
       </BFormGroup>
-      <BFormGroup label="Ship via:" label-cols-sm="3" label-align-sm="end" class="mb-0">
-        <BFormRadioGroup class="pt-2" :options="['Air', 'Courier', 'Mail']" />
+      <BFormGroup
+        label="Ship via:"
+        label-cols-sm="3"
+        label-align-sm="end"
+        class="mb-0"
+      >
+        <BFormRadioGroup
+          class="pt-2"
+          :options="['Air', 'Courier', 'Mail']"
+        />
       </BFormGroup>
     </BFormGroup>
   </BCard>

--- a/apps/docs/src/docs/components/demo/FormGroupOverview.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupOverview.vue
@@ -9,7 +9,12 @@
     :state="state"
     label-class="mb-1"
   >
-    <BFormInput id="input-1" v-model="name" :state="state" trim />
+    <BFormInput
+      id="input-1"
+      v-model="name"
+      :state="state"
+      trim
+    />
   </BFormGroup>
   <div>
     Name: <strong>{{ name }}</strong>

--- a/apps/docs/src/docs/components/demo/FormGroupState.vue
+++ b/apps/docs/src/docs/components/demo/FormGroupState.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <BCard>
-    <BFormGroup :state="false" class="mb-2">
+    <BFormGroup
+      :state="false"
+      class="mb-2"
+    >
       <BFormInput />
     </BFormGroup>
     <BFormGroup :state="false">

--- a/apps/docs/src/docs/components/demo/FormInline.vue
+++ b/apps/docs/src/docs/components/demo/FormInline.vue
@@ -1,14 +1,31 @@
 <template>
   <!-- #region template -->
   <BForm class="d-flex flex-row align-items-center flex-wrap">
-    <label class="col-form-label visually-hidden" for="inline-form-input-name">Name</label>
+    <label
+      class="col-form-label visually-hidden"
+      for="inline-form-input-name"
+      >Name</label
+    >
     <div class="col-lg-3 me-2 my-2">
-      <BFormInput id="inline-form-input-name" placeholder="Jane Doe" />
+      <BFormInput
+        id="inline-form-input-name"
+        placeholder="Jane Doe"
+      />
     </div>
-    <label class="col-form-label visually-hidden" for="inline-form-input-username">Username</label>
+    <label
+      class="col-form-label visually-hidden"
+      for="inline-form-input-username"
+      >Username</label
+    >
     <div class="col-lg-3 me-2 my-2">
-      <BInputGroup prepend="@" class="col-lg-4">
-        <BFormInput id="inline-form-input-username" placeholder="Username" />
+      <BInputGroup
+        prepend="@"
+        class="col-lg-4"
+      >
+        <BFormInput
+          id="inline-form-input-username"
+          placeholder="Username"
+        />
       </BInputGroup>
     </div>
     <div class="col-lg-3 me-2 my-2">

--- a/apps/docs/src/docs/components/demo/FormInlineSelect.vue
+++ b/apps/docs/src/docs/components/demo/FormInlineSelect.vue
@@ -1,7 +1,9 @@
 <template>
   <BForm>
     <div class="row">
-      <label class="col-form-label col-lg-2 me-sm-2" for="inline-form-custom-select-pref"
+      <label
+        class="col-form-label col-lg-2 me-sm-2"
+        for="inline-form-custom-select-pref"
         >Preference</label
       >
       <div class="col-lg-2">

--- a/apps/docs/src/docs/components/demo/FormInputDatalist.vue
+++ b/apps/docs/src/docs/components/demo/FormInputDatalist.vue
@@ -4,7 +4,12 @@
 
     <datalist id="my-list-id">
       <option>Manual Option</option>
-      <option v-for="size in datalistSizes" :key="size">{{ size }}</option>
+      <option
+        v-for="size in datalistSizes"
+        :key="size"
+      >
+        {{ size }}
+      </option>
     </datalist>
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/FormInputDebounce.vue
+++ b/apps/docs/src/docs/components/demo/FormInputDebounce.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <b-form-input v-model="value" type="text" debounce="500" />
+    <b-form-input
+      v-model="value"
+      type="text"
+      debounce="500"
+    />
     <div class="mt-2">Value: "{{ value }}"</div>
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/FormInputMethods.vue
+++ b/apps/docs/src/docs/components/demo/FormInputMethods.vue
@@ -1,12 +1,24 @@
 <template>
   <div role="group">
-    <BFormInput ref="inputRef" v-model="value" placeholder="Enter your name" />
+    <BFormInput
+      ref="inputRef"
+      v-model="value"
+      placeholder="Enter your name"
+    />
   </div>
   <div class="mt-2">
-    <BButton primary @click="selectAllText">Select all text</BButton>
+    <BButton
+      primary
+      @click="selectAllText"
+      >Select all text</BButton
+    >
   </div>
   <div class="mt-2">
-    <BButton primary @click="inputRef?.focus">Set Focus</BButton>
+    <BButton
+      primary
+      @click="inputRef?.focus"
+      >Set Focus</BButton
+    >
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormInputOverview.vue
+++ b/apps/docs/src/docs/components/demo/FormInputOverview.vue
@@ -1,5 +1,8 @@
 <template>
-  <BFormInput v-model="text" placeholder="Enter your name" />
+  <BFormInput
+    v-model="text"
+    placeholder="Enter your name"
+  />
   <div class="mt-2">Value: {{ text }}</div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormInputRange.vue
+++ b/apps/docs/src/docs/components/demo/FormInputRange.vue
@@ -1,6 +1,12 @@
 <template>
   <label for="range-1">Example range with min and max</label>
-  <BFormInput id="range-1" v-model="value" type="range" min="0" max="5" />
+  <BFormInput
+    id="range-1"
+    v-model="value"
+    type="range"
+    min="0"
+    max="5"
+  />
   <div class="mt-2">Value: {{ value }}</div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormInputRangeStep.vue
+++ b/apps/docs/src/docs/components/demo/FormInputRangeStep.vue
@@ -1,6 +1,13 @@
 <template>
   <label for="range-step">Example range with min and max</label>
-  <BFormInput id="range-step" v-model="value" type="range" min="0" max="5" step="0.5" />
+  <BFormInput
+    id="range-step"
+    v-model="value"
+    type="range"
+    min="0"
+    max="5"
+    step="0.5"
+  />
   <div class="mt-2">Value: {{ value }}</div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormInputSize.vue
+++ b/apps/docs/src/docs/components/demo/FormInputSize.vue
@@ -5,7 +5,11 @@
       <label for="input-small">Small:</label>
     </BCol>
     <BCol sm="10">
-      <BFormInput id="input-small" size="sm" placeholder="Enter your name" />
+      <BFormInput
+        id="input-small"
+        size="sm"
+        placeholder="Enter your name"
+      />
     </BCol>
   </BRow>
   <BRow class="my-1">
@@ -13,7 +17,10 @@
       <label for="input-default">Default:</label>
     </BCol>
     <BCol sm="10">
-      <BFormInput id="input-default" placeholder="Enter your name" />
+      <BFormInput
+        id="input-default"
+        placeholder="Enter your name"
+      />
     </BCol>
   </BRow>
   <BRow class="my-1">
@@ -21,7 +28,11 @@
       <label for="input-large">Large:</label>
     </BCol>
     <BCol sm="10">
-      <BFormInput id="input-large" size="lg" placeholder="Enter your name" />
+      <BFormInput
+        id="input-large"
+        size="lg"
+        placeholder="Enter your name"
+      />
     </BCol>
   </BRow>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/FormInputState.vue
+++ b/apps/docs/src/docs/components/demo/FormInputState.vue
@@ -5,7 +5,11 @@
       <label for="input-none">No State:</label>
     </BCol>
     <BCol sm="9">
-      <BFormInput id="input-none" :state="null" placeholder="No validation" />
+      <BFormInput
+        id="input-none"
+        :state="null"
+        placeholder="No validation"
+      />
     </BCol>
   </BRow>
   <BRow class="my-1">
@@ -13,7 +17,11 @@
       <label for="input-valid">Valid State:</label>
     </BCol>
     <BCol sm="9">
-      <BFormInput id="input-valid" :state="true" placeholder="Valid input" />
+      <BFormInput
+        id="input-valid"
+        :state="true"
+        placeholder="Valid input"
+      />
     </BCol>
   </BRow>
   <BRow class="my-1">
@@ -21,7 +29,11 @@
       <label for="input-invalid">Invalid State:</label>
     </BCol>
     <BCol sm="9">
-      <BFormInput id="input-invalid" :state="false" placeholder="Invalid input" />
+      <BFormInput
+        id="input-invalid"
+        :state="false"
+        placeholder="Invalid input"
+      />
     </BCol>
   </BRow>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/FormInputTypes.vue
+++ b/apps/docs/src/docs/components/demo/FormInputTypes.vue
@@ -1,5 +1,9 @@
 <template>
-  <BRow v-for="type in inputTypes" :key="type" class="my-1">
+  <BRow
+    v-for="type in inputTypes"
+    :key="type"
+    class="my-1"
+  >
     <BCol sm="3">
       <label :for="`type-${type}`"
         >Type <code>{{ type }}</code
@@ -7,7 +11,10 @@
       >
     </BCol>
     <BCol sm="9">
-      <BFormInput :id="`type-${type}`" :type="type" />
+      <BFormInput
+        :id="`type-${type}`"
+        :type="type"
+      />
     </BCol>
   </BRow>
 </template>

--- a/apps/docs/src/docs/components/demo/FormOverview.vue
+++ b/apps/docs/src/docs/components/demo/FormOverview.vue
@@ -1,5 +1,9 @@
 <template>
-  <BForm v-if="show" @submit="onSubmit" @reset="onReset">
+  <BForm
+    v-if="show"
+    @submit="onSubmit"
+    @reset="onReset"
+  >
     <BFormGroup
       id="input-group-1"
       label="Email address:"
@@ -15,24 +19,56 @@
       />
     </BFormGroup>
 
-    <BFormGroup id="input-group-2" label="Your Name:" label-for="input-2">
-      <BFormInput id="input-2" v-model="form.name" placeholder="Enter name" required />
+    <BFormGroup
+      id="input-group-2"
+      label="Your Name:"
+      label-for="input-2"
+    >
+      <BFormInput
+        id="input-2"
+        v-model="form.name"
+        placeholder="Enter name"
+        required
+      />
     </BFormGroup>
-    <BFormGroup id="input-group-3" label="Food:" label-for="input-3">
-      <BFormSelect id="input-3" v-model="form.food" :options="foods" required />
+    <BFormGroup
+      id="input-group-3"
+      label="Food:"
+      label-for="input-3"
+    >
+      <BFormSelect
+        id="input-3"
+        v-model="form.food"
+        :options="foods"
+        required
+      />
     </BFormGroup>
 
     <BFormGroup id="input-group-4">
-      <BFormCheckboxGroup id="checkboxes-4" v-model="form.checked">
+      <BFormCheckboxGroup
+        id="checkboxes-4"
+        v-model="form.checked"
+      >
         <BFormCheckbox value="me">Check me out</BFormCheckbox>
         <BFormCheckbox value="that">Check that out</BFormCheckbox>
       </BFormCheckboxGroup>
     </BFormGroup>
-    <BButton type="submit" variant="primary">Submit</BButton>
-    <BButton type="reset" variant="danger">Reset</BButton>
+    <BButton
+      type="submit"
+      variant="primary"
+      >Submit</BButton
+    >
+    <BButton
+      type="reset"
+      variant="danger"
+      >Reset</BButton
+    >
   </BForm>
 
-  <BCard class="mt-3" header="Form Data Result">
+  <BCard
+    class="mt-3"
+    header="Form Data Result"
+  >
     <pre class="m-0">{{ form }}</pre>
   </BCard>
 </template>

--- a/apps/docs/src/docs/components/demo/FormSingleFloat.vue
+++ b/apps/docs/src/docs/components/demo/FormSingleFloat.vue
@@ -1,7 +1,11 @@
 <template>
   <!-- #region template -->
   <BForm floating>
-    <BFormInput id="floatingFormInputValue" type="email" placeholder="name@example.com" />
+    <BFormInput
+      id="floatingFormInputValue"
+      type="email"
+      placeholder="name@example.com"
+    />
     <label for="floatingFormInputValue">Input with value</label>
   </BForm>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonCustomFormatting.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonCustomFormatting.vue
@@ -1,8 +1,23 @@
 <template>
   <label for="sb-locales">Locale</label>
-  <BFormSelect id="sb-locales" v-model="locale" :options="locales" />
-  <label for="sb-local" class="mt-2">Spin button with locale</label>
-  <BFormSpinbutton id="sb-locale" v-model="value" :locale="locale" min="0" max="10" step="0.125" />
+  <BFormSelect
+    id="sb-locales"
+    v-model="locale"
+    :options="locales"
+  />
+  <label
+    for="sb-local"
+    class="mt-2"
+    >Spin button with locale</label
+  >
+  <BFormSpinbutton
+    id="sb-locale"
+    v-model="value"
+    :locale="locale"
+    min="0"
+    max="10"
+    step="0.125"
+  />
   <p>Value: {{ value }}</p>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonEvents.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonEvents.vue
@@ -1,6 +1,11 @@
 <template>
   <label for="sb-input">Spin button - input and change events</label>
-  <BFormSpinbutton id="sb-input" v-model="value1" wrap @change="value2 = $event" />
+  <BFormSpinbutton
+    id="sb-input"
+    v-model="value1"
+    wrap
+    @change="value2 = $event"
+  />
   <p>Input event: {{ value1 }}</p>
   <p>Change event: {{ value2 }}</p>
 </template>

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonFormatting.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonFormatting.vue
@@ -1,8 +1,23 @@
 <template>
   <label for="sb-locales">Locale</label>
-  <BFormSelect id="sb-locales" v-model="locale" :options="locales" />
-  <label for="sb-local" class="mt-2">Spin button with locale</label>
-  <BFormSpinbutton id="sb-locale" v-model="value" :locale="locale" min="0" max="10" step="0.125" />
+  <BFormSelect
+    id="sb-locales"
+    v-model="locale"
+    :options="locales"
+  />
+  <label
+    for="sb-local"
+    class="mt-2"
+    >Spin button with locale</label
+  >
+  <BFormSpinbutton
+    id="sb-locale"
+    v-model="value"
+    :locale="locale"
+    min="0"
+    max="10"
+    step="0.125"
+  />
   <p>Value: {{ value }}</p>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonInline.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonInline.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
   <label for="sb-inline">Inline spin button</label>
-  <BFormSpinbutton id="sb-inline" inline placeholder="--" />
+  <BFormSpinbutton
+    id="sb-inline"
+    inline
+    placeholder="--"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonOverview.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonOverview.vue
@@ -1,6 +1,11 @@
 <template>
   <label for="demo-sb">Spin Button</label>
-  <BFormSpinbutton id="demo-sb" v-model="value" min="1" max="100" />
+  <BFormSpinbutton
+    id="demo-sb"
+    v-model="value"
+    min="1"
+    max="100"
+  />
   <p>Value: {{ value }}</p>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonReadonly.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonReadonly.vue
@@ -1,13 +1,31 @@
 <template>
   <!-- #region template -->
   <BRow>
-    <BCol md="6" class="mb-2">
+    <BCol
+      md="6"
+      class="mb-2"
+    >
       <label for="sb-disabled">Disabled spin button</label>
-      <BFormSpinbutton id="sb-disabled" disabled placeholder="--" />
+      <BFormSpinbutton
+        id="sb-disabled"
+        disabled
+        placeholder="--"
+      />
     </BCol>
-    <BCol md="6" class="mb-2">
-      <label for="sb-readonly" class="">Readonly spin button</label>
-      <BFormSpinbutton id="sb-readonly" readonly placeholder="--" />
+    <BCol
+      md="6"
+      class="mb-2"
+    >
+      <label
+        for="sb-readonly"
+        class=""
+        >Readonly spin button</label
+      >
+      <BFormSpinbutton
+        id="sb-readonly"
+        readonly
+        placeholder="--"
+      />
     </BCol>
   </BRow>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonSizing.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonSizing.vue
@@ -1,10 +1,24 @@
 <template>
   <!-- #region template -->
   <label for="sb-small">Spin button - Small size</label>
-  <BFormSpinbutton id="sb-small" size="sm" placeholder="--" class="mb-2" />
+  <BFormSpinbutton
+    id="sb-small"
+    size="sm"
+    placeholder="--"
+    class="mb-2"
+  />
   <label for="sb-default">Spin button - Default size</label>
-  <BFormSpinbutton id="sb-default" placeholder="--" class="mb-2" />
+  <BFormSpinbutton
+    id="sb-default"
+    placeholder="--"
+    class="mb-2"
+  />
   <label for="sb-large">Spin button - Large size</label>
-  <BFormSpinbutton id="sb-large" size="lg" placeholder="--" class="mb-2" />
+  <BFormSpinbutton
+    id="sb-large"
+    size="lg"
+    placeholder="--"
+    class="mb-2"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonStep.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonStep.vue
@@ -1,6 +1,12 @@
 <template>
   <!-- #region template -->
   <label for="sb-step">Spin button with step of 0.25</label>
-  <BFormSpinbutton id="sb-step" min="0" max="10" step="0.25" placeholder="--" />
+  <BFormSpinbutton
+    id="sb-step"
+    min="0"
+    max="10"
+    step="0.25"
+    placeholder="--"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonVertical.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonVertical.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
   <label for="sb-vertical">Vertical spin button</label>
-  <BFormSpinbutton id="sb-vertical" vertical placeholder="--" />
+  <BFormSpinbutton
+    id="sb-vertical"
+    vertical
+    placeholder="--"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormSpinbuttonWrapping.vue
+++ b/apps/docs/src/docs/components/demo/FormSpinbuttonWrapping.vue
@@ -1,6 +1,12 @@
 <template>
   <!-- #region template -->
   <label for="sb-wrap">Wrapping value spin button</label>
-  <BFormSpinbutton id="sb-wrap" wrap min="1" max="25" placeholder="--" />
+  <BFormSpinbutton
+    id="sb-wrap"
+    wrap
+    min="1"
+    max="25"
+    placeholder="--"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/FormTagsBasic.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsBasic.vue
@@ -1,6 +1,9 @@
 <template>
   <label for="tags-basic">Type a new tag and press enter</label>
-  <BFormTags v-model="value" input-id="tags-basic" />
+  <BFormTags
+    v-model="value"
+    input-id="tags-basic"
+  />
   <p class="mt-2">Value: {{ value }}</p>
 </template>
 

--- a/apps/docs/src/docs/components/demo/FormTagsCustom.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsCustom.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BFormTags v-model="value" no-outer-focus class="mb-2">
+    <BFormTags
+      v-model="value"
+      no-outer-focus
+      class="mb-2"
+    >
       <template #default="{tags, inputAttrs, inputHandlers, tagVariant, addTag, removeTag}">
         <BInputGroup class="mb-2">
           <BFormInput
@@ -10,10 +14,17 @@
             v-on="inputHandlers"
           />
           <BInputGroupText>
-            <BButton variant="primary" @click="addTag()">Add</BButton>
+            <BButton
+              variant="primary"
+              @click="addTag()"
+              >Add</BButton
+            >
           </BInputGroupText>
         </BInputGroup>
-        <div class="d-inline-block" style="font-size: 1.5rem">
+        <div
+          class="d-inline-block"
+          style="font-size: 1.5rem"
+        >
           <BFormTag
             v-for="tag in tags"
             :key="tag"

--- a/apps/docs/src/docs/components/demo/FormTagsDropdown.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsDropdown.vue
@@ -1,17 +1,42 @@
 <template>
   <div>
-    <BFormGroup label="Tagged input using dropdown" label-for="tags-with-dropdown">
-      <BFormTags id="tags-with-dropdown" v-model="value" no-outer-focus class="mb-2">
+    <BFormGroup
+      label="Tagged input using dropdown"
+      label-for="tags-with-dropdown"
+    >
+      <BFormTags
+        id="tags-with-dropdown"
+        v-model="value"
+        no-outer-focus
+        class="mb-2"
+      >
         <template #default="{tags, disabled, addTag, removeTag}">
-          <ul v-if="tags.length > 0" class="list-inline d-inline-block mb-2">
-            <li v-for="tag in tags" :key="tag" class="list-inline-item">
-              <BFormTag :title="tag" :disabled="disabled" variant="info" @remove="removeTag(tag)">{{
-                tag
-              }}</BFormTag>
+          <ul
+            v-if="tags.length > 0"
+            class="list-inline d-inline-block mb-2"
+          >
+            <li
+              v-for="tag in tags"
+              :key="tag"
+              class="list-inline-item"
+            >
+              <BFormTag
+                :title="tag"
+                :disabled="disabled"
+                variant="info"
+                @remove="removeTag(tag)"
+                >{{ tag }}</BFormTag
+              >
             </li>
           </ul>
 
-          <BDropdown size="sm" variant="outline-secondary" block menu-class="w-100" no-caret>
+          <BDropdown
+            size="sm"
+            variant="outline-secondary"
+            block
+            menu-class="w-100"
+            no-caret
+          >
             <template #button-content> &#x1f50d; <span>Choose tags</span> </template>
             <BDropdownForm @submit.stop.prevent="() => {}">
               <BFormGroup

--- a/apps/docs/src/docs/components/demo/FormTagsLimit.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsLimit.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <label for="tags-limit">Enter tags</label>
-    <BFormTags v-model="value" input-id="tags-limit" :limit="limit" remove-on-delete />
+    <BFormTags
+      v-model="value"
+      input-id="tags-limit"
+      :limit="limit"
+      remove-on-delete
+    />
     <p class="mt-2">Value: {{ value }}</p>
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/FormTagsNative.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsNative.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BFormTags v-model="value" no-outer-focus class="mb-2">
+    <BFormTags
+      v-model="value"
+      no-outer-focus
+      class="mb-2"
+    >
       <template #default="{tags, inputAttrs, inputHandlers, addTag, removeTag}">
         <BInputGroup aria-controls="my-custom-tags-list">
           <input
@@ -10,7 +14,11 @@
             v-on="inputHandlers"
           />
           <BInputGroupText>
-            <BButton variant="primary" @click="addTag()">Add</BButton>
+            <BButton
+              variant="primary"
+              @click="addTag()"
+              >Add</BButton
+            >
           </BInputGroupText>
         </BInputGroup>
         <ul

--- a/apps/docs/src/docs/components/demo/FormTagsRemoval.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsRemoval.vue
@@ -10,7 +10,10 @@
       remove-on-delete
       no-add-on-enter
     />
-    <BFormText id="tags-remove-on-delete-help" class="mt-2">
+    <BFormText
+      id="tags-remove-on-delete-help"
+      class="mt-2"
+    >
       Press <kbd>Backspace</kbd> to remove the last tag entered
     </BFormText>
     <p>Value: {{ value }}</p>

--- a/apps/docs/src/docs/components/demo/FormTagsScopedSlot.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsScopedSlot.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <BFormCheckbox v-model="disabled" switch size="lg">Disable</BFormCheckbox>
+    <BFormCheckbox
+      v-model="disabled"
+      switch
+      size="lg"
+      >Disable</BFormCheckbox
+    >
     <BFormTags
       v-model="tags"
       tag-variant="success"
@@ -42,8 +47,16 @@
         <BFormInvalidFeedback :state="state">
           Duplicate tag value cannot be added again!
         </BFormInvalidFeedback>
-        <ul v-if="innerTags.length > 0" class="mb-0">
-          <li v-for="tag in innerTags" :key="tag" :title="`Tag: ${tag}`" class="mt-2">
+        <ul
+          v-if="innerTags.length > 0"
+          class="mb-0"
+        >
+          <li
+            v-for="tag in innerTags"
+            :key="tag"
+            :title="`Tag: ${tag}`"
+            class="mt-2"
+          >
             <span class="d-flex align-items-center">
               <span class="me-2">{{ tag }}</span>
               <BButton

--- a/apps/docs/src/docs/components/demo/FormTagsSelect.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsSelect.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BFormGroup label="Tagged input using select" label-for="tags-component-select">
+    <BFormGroup
+      label="Tagged input using select"
+      label-for="tags-component-select"
+    >
       <!-- Prop `add-on-change` is needed to enable adding tags vie the `change` event -->
       <BFormTags
         id="tags-component-select"
@@ -11,11 +14,22 @@
         no-outer-focus
       >
         <template #default="{tags, inputAttrs, disabled, addTag, removeTag}">
-          <ul v-if="tags.length > 0" class="list-inline d-inline-block mb-2">
-            <li v-for="tag in tags" :key="tag" class="list-inline-item">
-              <BFormTag :title="tag" :disabled="disabled" variant="info" @remove="removeTag(tag)">{{
-                tag
-              }}</BFormTag>
+          <ul
+            v-if="tags.length > 0"
+            class="list-inline d-inline-block mb-2"
+          >
+            <li
+              v-for="tag in tags"
+              :key="tag"
+              class="list-inline-item"
+            >
+              <BFormTag
+                :title="tag"
+                :disabled="disabled"
+                variant="info"
+                @remove="removeTag(tag)"
+                >{{ tag }}</BFormTag
+              >
             </li>
           </ul>
           <BFormSelect
@@ -26,7 +40,12 @@
           >
             <template #first>
               <!-- This is required to prevent bugs with Safari -->
-              <option disabled value="">Choose a tag...</option>
+              <option
+                disabled
+                value=""
+              >
+                Choose a tag...
+              </option>
             </template>
           </BFormSelect>
         </template>

--- a/apps/docs/src/docs/components/demo/FormTagsValidation.vue
+++ b/apps/docs/src/docs/components/demo/FormTagsValidation.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BFormGroup label="Tags validation example" label-for="tags-validation" :state="state">
+    <BFormGroup
+      label="Tags validation example"
+      label-for="tags-validation"
+      :state="state"
+    >
       <BFormTags
         v-model="tags"
         input-id="tags-validation"

--- a/apps/docs/src/docs/components/demo/FormTextHelper.vue
+++ b/apps/docs/src/docs/components/demo/FormTextHelper.vue
@@ -2,7 +2,11 @@
   <!-- #region template -->
   <BForm @submit.stop.prevent>
     <label for="text-password">Password</label>
-    <BFormInput id="text-password" type="password" aria-describedby="password-help-block" />
+    <BFormInput
+      id="text-password"
+      type="password"
+      aria-describedby="password-help-block"
+    />
     <BFormText id="password-help-block">
       Your password must be 8-20 characters long, contain letters and numbers, and must not contain
       spaces, special characters, or emoji.

--- a/apps/docs/src/docs/components/demo/ImageBlank.vue
+++ b/apps/docs/src/docs/components/demo/ImageBlank.vue
@@ -1,12 +1,39 @@
 <template>
   <div class="d-flex gap-2">
-    <BImg v-bind="propsTr" alt="Transparent image" />
-    <BImg v-bind="propsTr" blank-color="#777" alt="HEX shorthand color image (#777)" />
-    <BImg v-bind="propsTr" blank-color="red" alt="Named color image (red)" />
-    <BImg v-bind="propsTr" blank-color="black" alt="Named color image (black)" />
-    <BImg v-bind="propsTr" blank-color="#338833" alt="HEX color image" />
-    <BImg v-bind="propsTr" blank-color="rgba(128, 255, 255, 0.5)" alt="RGBa color image" />
-    <BImg v-bind="propsTr" blank-color="#88f" alt="HEX shorthand color (#88f)" />
+    <BImg
+      v-bind="propsTr"
+      alt="Transparent image"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="#777"
+      alt="HEX shorthand color image (#777)"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="red"
+      alt="Named color image (red)"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="black"
+      alt="Named color image (black)"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="#338833"
+      alt="HEX color image"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="rgba(128, 255, 255, 0.5)"
+      alt="RGBa color image"
+    />
+    <BImg
+      v-bind="propsTr"
+      blank-color="#88f"
+      alt="HEX shorthand color (#88f)"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/ImageCenter.vue
+++ b/apps/docs/src/docs/components/demo/ImageCenter.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BImg placement="center" src="https://picsum.photos/125/125/?image=58" alt="Center image" />
+  <BImg
+    placement="center"
+    src="https://picsum.photos/125/125/?image=58"
+    alt="Center image"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ImageFluid.vue
+++ b/apps/docs/src/docs/components/demo/ImageFluid.vue
@@ -1,8 +1,16 @@
 <template>
   <!-- #region template -->
   <h5>Small image with <code>fluid</code>:</h5>
-  <BImg src="https://picsum.photos/300/150/?image=41" fluid alt="Fluid image" />
+  <BImg
+    src="https://picsum.photos/300/150/?image=41"
+    fluid
+    alt="Fluid image"
+  />
   <h5 class="my-3">Small image with <code>fluid-grow</code>:</h5>
-  <BImg src="https://picsum.photos/300/150/?image=41" fluid-grow alt="Fluid-grow image" />
+  <BImg
+    src="https://picsum.photos/300/150/?image=41"
+    fluid-grow
+    alt="Fluid-grow image"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ImageLeftRight.vue
+++ b/apps/docs/src/docs/components/demo/ImageLeftRight.vue
@@ -1,6 +1,14 @@
 <template>
   <!-- #region template -->
-  <BImg placement="start" src="https://picsum.photos/125/125/?image=58" alt="Left image" />
-  <BImg placement="end" src="https://picsum.photos/125/125/?image=58" alt="Right image" />
+  <BImg
+    placement="start"
+    src="https://picsum.photos/125/125/?image=58"
+    alt="Left image"
+  />
+  <BImg
+    placement="end"
+    src="https://picsum.photos/125/125/?image=58"
+    alt="Right image"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ImageResponsive.vue
+++ b/apps/docs/src/docs/components/demo/ImageResponsive.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BImg src="https://picsum.photos/1024/400/?image=41" fluid alt="Responsive image" />
+  <BImg
+    src="https://picsum.photos/1024/400/?image=41"
+    fluid
+    alt="Responsive image"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ImageRounded.vue
+++ b/apps/docs/src/docs/components/demo/ImageRounded.vue
@@ -1,13 +1,44 @@
 <template>
   <div class="d-flex gap-2">
-    <BImg v-bind="mainProps" alt="Rounded image" />
-    <BImg v-bind="mainProps" rounded alt="Rounded image" />
-    <BImg v-bind="mainProps" rounded-top alt="Top-rounded image" />
-    <BImg v-bind="mainProps" rounded-end alt="Right-rounded image" />
-    <BImg v-bind="mainProps" rounded-bottom alt="Bottom-rounded image" />
-    <BImg v-bind="mainProps" rounded-start alt="Left-rounded image" />
-    <BImg v-bind="mainProps" rounded="circle" alt="Circle image" />
-    <BImg v-bind="mainProps" rounded="0" alt="Not rounded image" />
+    <BImg
+      v-bind="mainProps"
+      alt="Rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded
+      alt="Rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded-top
+      alt="Top-rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded-end
+      alt="Right-rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded-bottom
+      alt="Bottom-rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded-start
+      alt="Left-rounded image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded="circle"
+      alt="Circle image"
+    />
+    <BImg
+      v-bind="mainProps"
+      rounded="0"
+      alt="Not rounded image"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/ImageThumbnail.vue
+++ b/apps/docs/src/docs/components/demo/ImageThumbnail.vue
@@ -1,15 +1,33 @@
 <template>
   <!-- #region template -->
-  <BContainer fluid class="p-4 bg-dark">
+  <BContainer
+    fluid
+    class="p-4 bg-dark"
+  >
     <BRow>
       <BCol>
-        <BImg thumbnail fluid src="https://picsum.photos/250/250/?image=54" alt="Image 1" />
+        <BImg
+          thumbnail
+          fluid
+          src="https://picsum.photos/250/250/?image=54"
+          alt="Image 1"
+        />
       </BCol>
       <BCol>
-        <BImg thumbnail fluid src="https://picsum.photos/250/250/?image=58" alt="Image 2" />
+        <BImg
+          thumbnail
+          fluid
+          src="https://picsum.photos/250/250/?image=58"
+          alt="Image 2"
+        />
       </BCol>
       <BCol>
-        <BImg thumbnail fluid src="https://picsum.photos/250/250/?image=59" alt="Image 3" />
+        <BImg
+          thumbnail
+          fluid
+          src="https://picsum.photos/250/250/?image=59"
+          alt="Image 3"
+        />
       </BCol>
     </BRow>
   </BContainer>

--- a/apps/docs/src/docs/components/demo/InputGroupCheckboxSize.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupCheckboxSize.vue
@@ -1,17 +1,31 @@
 <template>
   <!-- #region template -->
-  <BInputGroup size="sm" prepend="Small" class="mb-2">
+  <BInputGroup
+    size="sm"
+    prepend="Small"
+    class="mb-2"
+  >
     <BFormInput aria-label="Small text input with custom switch" />
     <BInputGroupText>
-      <BFormCheckbox switch class="me-n2 mb-n1">
+      <BFormCheckbox
+        switch
+        class="me-n2 mb-n1"
+      >
         <span class="visually-hidden">Checkbox for previous text input</span>
       </BFormCheckbox>
     </BInputGroupText>
   </BInputGroup>
-  <BInputGroup size="lg" prepend="Large" class="mb-2">
+  <BInputGroup
+    size="lg"
+    prepend="Large"
+    class="mb-2"
+  >
     <BFormInput aria-label="Large text input with switch" />
     <BInputGroupText>
-      <BFormCheckbox switch class="me-n2">
+      <BFormCheckbox
+        switch
+        class="me-n2"
+      >
         <span class="visually-hidden">Switch for previous text input</span>
       </BFormCheckbox>
     </BInputGroupText>

--- a/apps/docs/src/docs/components/demo/InputGroupCustomCheckbox.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupCustomCheckbox.vue
@@ -18,7 +18,10 @@
   </BInputGroup>
   <BInputGroup>
     <BInputGroupText>
-      <BFormCheckbox switch class="me-n2">
+      <BFormCheckbox
+        switch
+        class="me-n2"
+      >
         <span class="visually-hidden">Switch for following text input</span>
       </BFormCheckbox>
     </BInputGroupText>

--- a/apps/docs/src/docs/components/demo/InputGroupDropdown.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupDropdown.vue
@@ -2,14 +2,22 @@
   <!-- #region template -->
   <BInputGroup>
     <template #prepend>
-      <BDropdown text="Dropdown" variant="info">
+      <BDropdown
+        text="Dropdown"
+        variant="info"
+      >
         <BDropdownItem>Action A</BDropdownItem>
         <BDropdownItem>Action B</BDropdownItem>
       </BDropdown>
     </template>
     <BFormInput />
     <template #append>
-      <BDropdown v-for="i in 2" :key="i" text="Dropdown" variant="outline-secondary">
+      <BDropdown
+        v-for="i in 2"
+        :key="i"
+        text="Dropdown"
+        variant="outline-secondary"
+      >
         <BDropdownItem>Action C</BDropdownItem>
         <BDropdownItem>Action D</BDropdownItem>
       </BDropdown>

--- a/apps/docs/src/docs/components/demo/InputGroupMultipleAddons.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupMultipleAddons.vue
@@ -2,14 +2,23 @@
   <!-- #region template -->
   <BInputGroup prepend="Item">
     <BInputGroupText>
-      <input type="checkbox" aria-label="Checkbox for following text input" />
+      <input
+        type="checkbox"
+        aria-label="Checkbox for following text input"
+      />
     </BInputGroupText>
     <BInputGroupText><b>$</b></BInputGroupText>
-    <BFormInput type="number" aria-label="Text input with checkbox" />
+    <BFormInput
+      type="number"
+      aria-label="Text input with checkbox"
+    />
   </BInputGroup>
   <BInputGroup class="mt-2">
     <BButton variant="outline-info">Button</BButton>
-    <BFormInput type="number" min="0.00" />
+    <BFormInput
+      type="number"
+      min="0.00"
+    />
     <BButton variant="outline-secondary">Button</BButton>
     <BButton variant="outline-primary">Button</BButton>
   </BInputGroup>

--- a/apps/docs/src/docs/components/demo/InputGroupMultipleInputs.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupMultipleInputs.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BInputGroup prepend="First and last name" class="mb-2">
+  <BInputGroup
+    prepend="First and last name"
+    class="mb-2"
+  >
     <BFormInput aria-label="First name" />
     <BFormInput aria-label="Last name" />
   </BInputGroup>

--- a/apps/docs/src/docs/components/demo/InputGroupNativeCheckbox.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupNativeCheckbox.vue
@@ -2,13 +2,19 @@
   <!-- #region template -->
   <BInputGroup class="mb-2">
     <BInputGroupText>
-      <input type="checkbox" aria-label="Checkbox for following text input" />
+      <input
+        type="checkbox"
+        aria-label="Checkbox for following text input"
+      />
     </BInputGroupText>
     <BFormInput aria-label="Text input with checkbox" />
   </BInputGroup>
   <BInputGroup>
     <BInputGroupText>
-      <input type="radio" aria-label="Radio for following text input" />
+      <input
+        type="radio"
+        aria-label="Radio for following text input"
+      />
     </BInputGroupText>
     <BFormInput aria-label="Text input with radio input" />
   </BInputGroup>

--- a/apps/docs/src/docs/components/demo/InputGroupOverview.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupOverview.vue
@@ -1,7 +1,11 @@
 <template>
   <!-- #region template -->
   <!-- Using props -->
-  <BInputGroup size="lg" prepend="$" append=".00">
+  <BInputGroup
+    size="lg"
+    prepend="$"
+    append=".00"
+  >
     <BFormInput />
   </BInputGroup>
   <!-- Using slots -->
@@ -12,7 +16,10 @@
     <BFormInput />
   </BInputGroup>
   <!-- Using components -->
-  <BInputGroup prepend="Username" class="mt-3">
+  <BInputGroup
+    prepend="Username"
+    class="mt-3"
+  >
     <BFormInput />
     <BButton variant="outline-success">Button</BButton>
     <BButton variant="info">Button</BButton>

--- a/apps/docs/src/docs/components/demo/InputGroupSizing.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupSizing.vue
@@ -7,7 +7,12 @@
     prepend="Label"
   >
     <BFormInput />
-    <BButton size="sm" text="Button" variant="success">Button</BButton>
+    <BButton
+      size="sm"
+      text="Button"
+      variant="success"
+      >Button</BButton
+    >
   </BInputGroup>
 </template>
 

--- a/apps/docs/src/docs/components/demo/InputGroupSlots.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupSlots.vue
@@ -6,7 +6,10 @@
     </template>
     <BFormInput />
     <template #append>
-      <BDropdown text="Dropdown" variant="success">
+      <BDropdown
+        text="Dropdown"
+        variant="success"
+      >
         <BDropdownItem>Action A</BDropdownItem>
         <BDropdownItem>Action B</BDropdownItem>
       </BDropdown>

--- a/apps/docs/src/docs/components/demo/InputGroupText.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupText.vue
@@ -2,7 +2,10 @@
   <!-- #region template -->
   <BInputGroup>
     <BInputGroupText>$</BInputGroupText>
-    <BFormInput type="number" min="0.00" />
+    <BFormInput
+      type="number"
+      min="0.00"
+    />
     <BInputGroupText>.00</BInputGroupText>
   </BInputGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/InputGroupXPend.vue
+++ b/apps/docs/src/docs/components/demo/InputGroupXPend.vue
@@ -1,10 +1,21 @@
 <template>
   <!-- #region template -->
-  <BInputGroup prepend="$" append=".00">
+  <BInputGroup
+    prepend="$"
+    append=".00"
+  >
     <BFormInput />
   </BInputGroup>
-  <BInputGroup prepend="0" append="100" class="mt-3">
-    <BFormInput type="range" min="0" max="100" />
+  <BInputGroup
+    prepend="0"
+    append="100"
+    class="mt-3"
+  >
+    <BFormInput
+      type="range"
+      min="0"
+      max="100"
+    />
   </BInputGroup>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/LinkColors.vue
+++ b/apps/docs/src/docs/components/demo/LinkColors.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="color in variants" :key="color">
+  <p
+    v-for="color in variants"
+    :key="color"
+  >
     <BLink :variant="color"> {{ color }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/LinkDisabled.vue
+++ b/apps/docs/src/docs/components/demo/LinkDisabled.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BLink href="#foo" disabled>Disabled Link</BLink>
+  <BLink
+    href="#foo"
+    disabled
+    >Disabled Link</BLink
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/LinkExternal.vue
+++ b/apps/docs/src/docs/components/demo/LinkExternal.vue
@@ -1,9 +1,19 @@
 <template>
   <!-- #region template -->
-  <BLink href="https://getbootstrap.com/docs/5.3" target="_blank" rel="noopener" class="me-2">
+  <BLink
+    href="https://getbootstrap.com/docs/5.3"
+    target="_blank"
+    rel="noopener"
+    class="me-2"
+  >
     External Link to Bootstrap
   </BLink>
-  <BLink to="sample" class="me-2"> To page sample </BLink>
+  <BLink
+    to="sample"
+    class="me-2"
+  >
+    To page sample
+  </BLink>
   <BLink href="#comp-ref--props"> Jump to Properties </BLink>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/LinkOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacity.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="opacity in opacities" :key="opacity">
+  <p
+    v-for="opacity in opacities"
+    :key="opacity"
+  >
     <BLink :opacity="opacity"> {{ opacity }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
+++ b/apps/docs/src/docs/components/demo/LinkOpacityHover.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="opacity in opacities" :key="opacity">
+  <p
+    v-for="opacity in opacities"
+    :key="opacity"
+  >
     <BLink :opacity-hover="opacity"> {{ opacity }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineColors.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineColors.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="color in variants" :key="color">
+  <p
+    v-for="color in variants"
+    :key="color"
+  >
     <BLink :underline-variant="color"> {{ color }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOffsets.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="offset in offsets" :key="offset">
+  <p
+    v-for="offset in offsets"
+    :key="offset"
+  >
     <BLink :underline-offset="offset"> {{ offset }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
+++ b/apps/docs/src/docs/components/demo/LinkUnderlineOpacity.vue
@@ -1,5 +1,8 @@
 <template>
-  <p v-for="opacity in opacities" :key="opacity">
+  <p
+    v-for="opacity in opacities"
+    :key="opacity"
+  >
     <BLink :underline-opacity="opacity"> {{ opacity }} link </BLink>
   </p>
 </template>

--- a/apps/docs/src/docs/components/demo/ListGroupActionable.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupActionable.vue
@@ -2,9 +2,17 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem href="#some-link">Awesome link</BListGroupItem>
-    <BListGroupItem href="#" active>Link with active state</BListGroupItem>
+    <BListGroupItem
+      href="#"
+      active
+      >Link with active state</BListGroupItem
+    >
     <BListGroupItem href="#">Action links are easy</BListGroupItem>
-    <BListGroupItem href="#foobar" disabled>Disabled link</BListGroupItem>
+    <BListGroupItem
+      href="#foobar"
+      disabled
+      >Disabled link</BListGroupItem
+    >
   </BListGroup>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ListGroupActionableButton.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupActionableButton.vue
@@ -3,7 +3,11 @@
   <BListGroup>
     <BListGroupItem button>Button item</BListGroupItem>
     <BListGroupItem button>I am a button</BListGroupItem>
-    <BListGroupItem button disabled>Disabled button</BListGroupItem>
+    <BListGroupItem
+      button
+      disabled
+      >Disabled button</BListGroupItem
+    >
     <BListGroupItem button>This is a button too</BListGroupItem>
   </BListGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ListGroupActionableVariants.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupActionableVariants.vue
@@ -2,14 +2,46 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem href="#">Default list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="primary">Primary list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="secondary">Secondary list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="success">Success list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="danger">Danger list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="warning">Warning list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="info">Info list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="light">Light list group item</BListGroupItem>
-    <BListGroupItem href="#" variant="dark">Dark list group item</BListGroupItem>
+    <BListGroupItem
+      href="#"
+      variant="primary"
+      >Primary list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="secondary"
+      >Secondary list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="success"
+      >Success list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="danger"
+      >Danger list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="warning"
+      >Warning list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="info"
+      >Info list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="light"
+      >Light list group item</BListGroupItem
+    >
+    <BListGroupItem
+      href="#"
+      variant="dark"
+      >Dark list group item</BListGroupItem
+    >
   </BListGroup>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ListGroupBadges.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupBadges.vue
@@ -3,15 +3,27 @@
   <BListGroup>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
       Cras justo odio
-      <BBadge variant="primary" pill>14</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >14</BBadge
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
       Dapibus ac facilisis in
-      <BBadge variant="primary" pill>2</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >2</BBadge
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
       Morbi leo risus
-      <BBadge variant="primary" pill>1</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >1</BBadge
+      >
     </BListGroupItem>
   </BListGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ListGroupCard.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupCard.vue
@@ -13,7 +13,10 @@
         mollit voluptate est in duis laboris ad sit ipsum anim Lorem.
       </p>
     </BCard>
-    <BCard no-body header="Card with flush list group">
+    <BCard
+      no-body
+      header="Card with flush list group"
+    >
       <BListGroup flush>
         <BListGroupItem href="#">Cras justo odio</BListGroupItem>
         <BListGroupItem href="#">Dapibus ac facilisis in</BListGroupItem>

--- a/apps/docs/src/docs/components/demo/ListGroupCheckbox.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupCheckbox.vue
@@ -2,13 +2,25 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormCheckbox id="list-check-1" value="1">First checkbox</BFormCheckbox>
+      <BFormCheckbox
+        id="list-check-1"
+        value="1"
+        >First checkbox</BFormCheckbox
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormCheckbox id="list-check-2" value="2">Second checkbox</BFormCheckbox>
+      <BFormCheckbox
+        id="list-check-2"
+        value="2"
+        >Second checkbox</BFormCheckbox
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormCheckbox id="list-check-3" value="3">Third checkbox</BFormCheckbox>
+      <BFormCheckbox
+        id="list-check-3"
+        value="3"
+        >Third checkbox</BFormCheckbox
+      >
     </BListGroupItem>
   </BListGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ListGroupCustom.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupCustom.vue
@@ -1,7 +1,11 @@
 <template>
   <!-- #region template -->
   <BListGroup>
-    <BListGroupItem href="#" active class="flex-column align-items-start">
+    <BListGroupItem
+      href="#"
+      active
+      class="flex-column align-items-start"
+    >
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1">List Group item heading</h5>
         <small>3 days ago</small>
@@ -12,7 +16,10 @@
       </p>
       <small>Donec id elit non mi porta.</small>
     </BListGroupItem>
-    <BListGroupItem href="#" class="flex-column align-items-start">
+    <BListGroupItem
+      href="#"
+      class="flex-column align-items-start"
+    >
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1">List Group item heading</h5>
         <small class="text-body-secondary">3 days ago</small>
@@ -23,7 +30,11 @@
       </p>
       <small class="text-body-secondary">Donec id elit non mi porta.</small>
     </BListGroupItem>
-    <BListGroupItem href="#" disabled class="flex-column align-items-start">
+    <BListGroupItem
+      href="#"
+      disabled
+      class="flex-column align-items-start"
+    >
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1">Disabled List Group item</h5>
         <small class="text-body-secondary">3 days ago</small>

--- a/apps/docs/src/docs/components/demo/ListGroupNumberedCustom.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupNumberedCustom.vue
@@ -6,21 +6,33 @@
         <div class="fw-bold">Subheading</div>
         Cras justo odio
       </div>
-      <BBadge variant="primary" pill>14</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >14</BBadge
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-start">
       <div class="ms-2 me-auto">
         <div class="fw-bold">Subheading</div>
         Dapibus ac facilisis in
       </div>
-      <BBadge variant="primary" pill>2</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >2</BBadge
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-start">
       <div class="ms-2 me-auto">
         <div class="fw-bold">Subheading</div>
         Morbi leo risus
       </div>
-      <BBadge variant="primary" pill>1</BBadge>
+      <BBadge
+        variant="primary"
+        pill
+        >1</BBadge
+      >
     </BListGroupItem>
   </BListGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/ListGroupRadio.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupRadio.vue
@@ -2,13 +2,28 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormRadio id="list-radio-1" name="some-radios" value="1">First radio</BFormRadio>
+      <BFormRadio
+        id="list-radio-1"
+        name="some-radios"
+        value="1"
+        >First radio</BFormRadio
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormRadio id="list-radio-2" name="some-radios" value="2">Second radio</BFormRadio>
+      <BFormRadio
+        id="list-radio-2"
+        name="some-radios"
+        value="2"
+        >Second radio</BFormRadio
+      >
     </BListGroupItem>
     <BListGroupItem class="d-flex justify-content-between align-items-center">
-      <BFormRadio id="list-radio-3" name="some-radios" value="3">Third radio</BFormRadio>
+      <BFormRadio
+        id="list-radio-3"
+        name="some-radios"
+        value="3"
+        >Third radio</BFormRadio
+      >
     </BListGroupItem>
   </BListGroup>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/NavAlignment.vue
+++ b/apps/docs/src/docs/components/demo/NavAlignment.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BNav tabs align="center">
+  <BNav
+    tabs
+    align="center"
+  >
     <BNavItem active>Active</BNavItem>
     <BNavItem>Link</BNavItem>
     <BNavItem>Link with a long name </BNavItem>

--- a/apps/docs/src/docs/components/demo/NavDropdown.vue
+++ b/apps/docs/src/docs/components/demo/NavDropdown.vue
@@ -3,7 +3,12 @@
   <BNav pills>
     <BNavItem active>Active</BNavItem>
     <BNavItem>Link</BNavItem>
-    <BNavItemDropdown id="my-nav-dropdown" text="Dropdown" toggle-class="nav-link-custom" right>
+    <BNavItemDropdown
+      id="my-nav-dropdown"
+      text="Dropdown"
+      toggle-class="nav-link-custom"
+      right
+    >
       <BDropdownItem>One</BDropdownItem>
       <BDropdownItem>Two</BDropdownItem>
       <BDropdownDivider />

--- a/apps/docs/src/docs/components/demo/NavFill.vue
+++ b/apps/docs/src/docs/components/demo/NavFill.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BNav tabs fill>
+  <BNav
+    tabs
+    fill
+  >
     <BNavItem active>Active</BNavItem>
     <BNavItem>Link</BNavItem>
     <BNavItem>Link with a long name </BNavItem>

--- a/apps/docs/src/docs/components/demo/NavInlineForm.vue
+++ b/apps/docs/src/docs/components/demo/NavInlineForm.vue
@@ -1,10 +1,24 @@
 <template>
-  <BNav pills class="mb-1">
-    <BNavItem href="#1" active>Link 1</BNavItem>
+  <BNav
+    pills
+    class="mb-1"
+  >
+    <BNavItem
+      href="#1"
+      active
+      >Link 1</BNavItem
+    >
     <BNavItem href="#2">Link 2</BNavItem>
     <BNavForm @submit.stop.prevent="submitted = true">
-      <BFormInput aria-label="Input" class="mr-1" />
-      <BButton class="ms-2" type="submit">Ok</BButton>
+      <BFormInput
+        aria-label="Input"
+        class="mr-1"
+      />
+      <BButton
+        class="ms-2"
+        type="submit"
+        >Ok</BButton
+      >
     </BNavForm>
   </BNav>
   <span v-if="submitted">Form Submitted</span>

--- a/apps/docs/src/docs/components/demo/NavJustified.vue
+++ b/apps/docs/src/docs/components/demo/NavJustified.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BNav tabs justified>
+  <BNav
+    tabs
+    justified
+  >
     <BNavItem active>Active</BNavItem>
     <BNavItem>Link</BNavItem>
     <BNavItem>Link with a long name </BNavItem>

--- a/apps/docs/src/docs/components/demo/NavPillCard.vue
+++ b/apps/docs/src/docs/components/demo/NavPillCard.vue
@@ -1,8 +1,14 @@
 <template>
   <!-- #region template -->
-  <BCard title="Card Title" no-body>
+  <BCard
+    title="Card Title"
+    no-body
+  >
     <BCardHeader header-tag="nav">
-      <BNav card-header pills>
+      <BNav
+        card-header
+        pills
+      >
         <BNavItem active>Active</BNavItem>
         <BNavItem>Inactive</BNavItem>
         <BNavItem disabled>Disabled</BNavItem>

--- a/apps/docs/src/docs/components/demo/NavPlainCard.vue
+++ b/apps/docs/src/docs/components/demo/NavPlainCard.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BCard title="Card Title" no-body>
+  <BCard
+    title="Card Title"
+    no-body
+  >
     <BCardHeader header-tag="nav">
       <BNav>
         <BNavItem active>Active</BNavItem>

--- a/apps/docs/src/docs/components/demo/NavRouter.vue
+++ b/apps/docs/src/docs/components/demo/NavRouter.vue
@@ -1,13 +1,34 @@
 <template>
   <!-- #region template -->
   <!-- On page with route `/some/route` -->
-  <BCard title="Card Title" no-body>
+  <BCard
+    title="Card Title"
+    no-body
+  >
     <BCardHeader header-tag="nav">
-      <BNav card-header tabs>
+      <BNav
+        card-header
+        tabs
+      >
         <!-- <BNavItem>'s with child routes. Note the trailing slash on the first <BNavItem> -->
-        <BNavItem to="/some/route/" exact exact-active-class="active">Active</BNavItem>
-        <BNavItem to="/some/route/foo" exact exact-active-class="active">Foo</BNavItem>
-        <BNavItem to="/some/route/bar" exact exact-active-class="active">Bar</BNavItem>
+        <BNavItem
+          to="/some/route/"
+          exact
+          exact-active-class="active"
+          >Active</BNavItem
+        >
+        <BNavItem
+          to="/some/route/foo"
+          exact
+          exact-active-class="active"
+          >Foo</BNavItem
+        >
+        <BNavItem
+          to="/some/route/bar"
+          exact
+          exact-active-class="active"
+          >Bar</BNavItem
+        >
       </BNav>
     </BCardHeader>
 

--- a/apps/docs/src/docs/components/demo/NavTabCard.vue
+++ b/apps/docs/src/docs/components/demo/NavTabCard.vue
@@ -1,8 +1,14 @@
 <template>
   <!-- #region template -->
-  <BCard title="Card Title" no-body>
+  <BCard
+    title="Card Title"
+    no-body
+  >
     <BCardHeader header-tag="nav">
-      <BNav card-header tabs>
+      <BNav
+        card-header
+        tabs
+      >
         <BNavItem active>Active</BNavItem>
         <BNavItem>Inactive</BNavItem>
         <BNavItem disabled>Disabled</BNavItem>

--- a/apps/docs/src/docs/components/demo/NavVertical.vue
+++ b/apps/docs/src/docs/components/demo/NavVertical.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BNav vertical class="w-25">
+  <BNav
+    vertical
+    class="w-25"
+  >
     <BNavItem active>Active</BNavItem>
     <BNavItem>Link</BNavItem>
     <BNavItem>Another Link</BNavItem>

--- a/apps/docs/src/docs/components/demo/NavbarBrandHeading.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandHeading.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- #region template -->
   <!-- As a heading -->
-  <BNavbar v-b-color-mode="'dark'" variant="secondary">
-    <BNavbarBrand tag="h1" class="mb-0">BootstrapVueNext</BNavbarBrand>
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="secondary"
+  >
+    <BNavbarBrand
+      tag="h1"
+      class="mb-0"
+      >BootstrapVueNext</BNavbarBrand
+    >
   </BNavbar>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/NavbarBrandImage.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandImage.vue
@@ -1,9 +1,15 @@
 <template>
   <!-- #region template -->
   <!-- As a link -->
-  <BNavbar v-b-color-mode="'dark'" variant="success">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="success"
+  >
     <BNavbarBrand href="#">
-      <img src="https://picsum.photos/30/30/?image=40" alt="Kitten" />
+      <img
+        src="https://picsum.photos/30/30/?image=40"
+        alt="Kitten"
+      />
     </BNavbarBrand>
   </BNavbar>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/NavbarBrandImageText.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandImageText.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <!-- As a link -->
-  <BNavbar v-b-color-mode="'dark'" variant="success">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="success"
+  >
     <BNavbarBrand href="#">
       <img
         src="https://picsum.photos/30/30/?image=40"

--- a/apps/docs/src/docs/components/demo/NavbarBrandLink.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandLink.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <!-- As a link -->
-  <BNavbar v-b-color-mode="'dark'" variant="secondary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="secondary"
+  >
     <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
   </BNavbar>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/NavbarColorMode.vue
+++ b/apps/docs/src/docs/components/demo/NavbarColorMode.vue
@@ -1,7 +1,14 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" variant="primary">
-    <BNavbarBrand tag="h1" class="mb-0">BootstrapVue</BNavbarBrand>
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="primary"
+  >
+    <BNavbarBrand
+      tag="h1"
+      class="mb-0"
+      >BootstrapVue</BNavbarBrand
+    >
   </BNavbar>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/NavbarForm.vue
+++ b/apps/docs/src/docs/components/demo/NavbarForm.vue
@@ -1,9 +1,20 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" variant="primary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="primary"
+  >
     <BNavForm>
-      <BFormInput class="me-sm-2" placeholder="Search" />
-      <BButton variant="outline-success" class="my-2 my-sm-0" type="submit">Search</BButton>
+      <BFormInput
+        class="me-sm-2"
+        placeholder="Search"
+      />
+      <BButton
+        variant="outline-success"
+        class="my-2 my-sm-0"
+        type="submit"
+        >Search</BButton
+      >
     </BNavForm>
   </BNavbar>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/NavbarInlineGroup.vue
+++ b/apps/docs/src/docs/components/demo/NavbarInlineGroup.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" variant="primary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="primary"
+  >
     <BNavForm>
       <BInputGroup prepend="@">
         <BFormInput placeholder="Username" />

--- a/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
+++ b/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
@@ -1,15 +1,24 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" variant="dark">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="dark"
+  >
     <BNavbarNav>
       <BNavItem href="#">Home</BNavItem>
-      <BNavItemDropdown text="Lang" right>
+      <BNavItemDropdown
+        text="Lang"
+        right
+      >
         <BDropdownItem href="#">EN</BDropdownItem>
         <BDropdownItem href="#">ES</BDropdownItem>
         <BDropdownItem href="#">RU</BDropdownItem>
         <BDropdownItem href="#">FA</BDropdownItem>
       </BNavItemDropdown>
-      <BNavItemDropdown text="User" right>
+      <BNavItemDropdown
+        text="User"
+        right
+      >
         <BDropdownItem href="#">Account</BDropdownItem>
         <BDropdownItem href="#">Settings</BDropdownItem>
       </BNavItemDropdown>

--- a/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
@@ -1,16 +1,32 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" :toggleable="true" variant="primary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    :toggleable="true"
+    variant="primary"
+  >
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-offcanvas" />
-    <BOffcanvas id="nav-offcanvas" title="Offcanvas" placement="end" is-nav>
+    <BOffcanvas
+      id="nav-offcanvas"
+      title="Offcanvas"
+      placement="end"
+      is-nav
+    >
       <BNavbarNav>
         <BNavItem href="#">Link</BNavItem>
-        <BNavItem href="#" disabled>Disabled</BNavItem>
+        <BNavItem
+          href="#"
+          disabled
+          >Disabled</BNavItem
+        >
       </BNavbarNav>
       <!-- Right aligned nav items -->
       <BNavbarNav class="ms-auto mb-2 mb-lg-0">
-        <BNavItemDropdown text="Lang" right>
+        <BNavItemDropdown
+          text="Lang"
+          right
+        >
           <BDropdownItem href="#">EN</BDropdownItem>
           <BDropdownItem href="#">ES</BDropdownItem>
           <BDropdownItem href="#">RU</BDropdownItem>
@@ -26,8 +42,15 @@
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">
-        <BFormInput class="me-2" placeholder="Search" />
-        <BButton type="submit" variant="outline-success">Search</BButton>
+        <BFormInput
+          class="me-2"
+          placeholder="Search"
+        />
+        <BButton
+          type="submit"
+          variant="outline-success"
+          >Search</BButton
+        >
       </BNavForm>
     </BOffcanvas>
   </BNavbar>

--- a/apps/docs/src/docs/components/demo/NavbarOverview.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOverview.vue
@@ -1,16 +1,30 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" toggleable="lg" variant="primary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    toggleable="lg"
+    variant="primary"
+  >
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-collapse" />
-    <BCollapse id="nav-collapse" is-nav>
+    <BCollapse
+      id="nav-collapse"
+      is-nav
+    >
       <BNavbarNav>
         <BNavItem href="#">Link</BNavItem>
-        <BNavItem href="#" disabled>Disabled</BNavItem>
+        <BNavItem
+          href="#"
+          disabled
+          >Disabled</BNavItem
+        >
       </BNavbarNav>
       <!-- Right aligned nav items -->
       <BNavbarNav class="ms-auto mb-2 mb-lg-0">
-        <BNavItemDropdown text="Lang" right>
+        <BNavItemDropdown
+          text="Lang"
+          right
+        >
           <BDropdownItem href="#">EN</BDropdownItem>
           <BDropdownItem href="#">ES</BDropdownItem>
           <BDropdownItem href="#">RU</BDropdownItem>
@@ -26,8 +40,15 @@
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">
-        <BFormInput class="me-2" placeholder="Search" />
-        <BButton type="submit" variant="outline-success">Search</BButton>
+        <BFormInput
+          class="me-2"
+          placeholder="Search"
+        />
+        <BButton
+          type="submit"
+          variant="outline-success"
+          >Search</BButton
+        >
       </BNavForm>
     </BCollapse>
   </BNavbar>

--- a/apps/docs/src/docs/components/demo/NavbarScroll.vue
+++ b/apps/docs/src/docs/components/demo/NavbarScroll.vue
@@ -1,16 +1,31 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" :toggleable="true" variant="primary" class="navbar-nav-scroll">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    :toggleable="true"
+    variant="primary"
+    class="navbar-nav-scroll"
+  >
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-scroll" />
-    <BCollapse id="nav-scroll" is-nav>
+    <BCollapse
+      id="nav-scroll"
+      is-nav
+    >
       <BNavbarNav>
         <BNavItem href="#">Link</BNavItem>
-        <BNavItem href="#" disabled>Disabled</BNavItem>
+        <BNavItem
+          href="#"
+          disabled
+          >Disabled</BNavItem
+        >
       </BNavbarNav>
       <!-- Right aligned nav items -->
       <BNavbarNav class="ms-auto mb-2 mb-lg-0">
-        <BNavItemDropdown text="Lang" right>
+        <BNavItemDropdown
+          text="Lang"
+          right
+        >
           <BDropdownItem href="#">EN</BDropdownItem>
           <BDropdownItem href="#">ES</BDropdownItem>
           <BDropdownItem href="#">RU</BDropdownItem>
@@ -26,8 +41,15 @@
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">
-        <BFormInput class="me-2" placeholder="Search" />
-        <BButton type="submit" variant="outline-success">Search</BButton>
+        <BFormInput
+          class="me-2"
+          placeholder="Search"
+        />
+        <BButton
+          type="submit"
+          variant="outline-success"
+          >Search</BButton
+        >
       </BNavForm>
     </BCollapse>
   </BNavbar>

--- a/apps/docs/src/docs/components/demo/NavbarText.vue
+++ b/apps/docs/src/docs/components/demo/NavbarText.vue
@@ -1,9 +1,16 @@
 <template>
   <!-- #region template -->
-  <BNavbar v-b-color-mode="'dark'" toggleable="sm" variant="primary">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    toggleable="sm"
+    variant="primary"
+  >
     <BNavbarToggle target="nav-text-collapse" />
     <BNavbarBrand>BootstrapVue</BNavbarBrand>
-    <BCollapse id="nav-text-collapse" is-nav>
+    <BCollapse
+      id="nav-text-collapse"
+      is-nav
+    >
       <BNavbarNav>
         <BNavText>Navbar text</BNavText>
       </BNavbarNav>

--- a/apps/docs/src/docs/components/demo/NavbarToggle.vue
+++ b/apps/docs/src/docs/components/demo/NavbarToggle.vue
@@ -1,17 +1,31 @@
 <template>
-  <BNavbar v-b-color-mode="'dark'" toggleable variant="dark">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    toggleable
+    variant="dark"
+  >
     <BNavbarBrand href="#">NavBar</BNavbarBrand>
     <BNavbarToggle target="navbar-toggle-collapse">
       <template #default="{expanded}">
         <ChevronBarUpIcon v-if="expanded" />
-        <ChevronBarDownIcon v-else icon="chevron-bar-down" />
+        <ChevronBarDownIcon
+          v-else
+          icon="chevron-bar-down"
+        />
       </template>
     </BNavbarToggle>
-    <BCollapse id="navbar-toggle-collapse" is-nav>
+    <BCollapse
+      id="navbar-toggle-collapse"
+      is-nav
+    >
       <BNavbarNav class="ms-auto">
         <BNavItem href="#">Link 1</BNavItem>
         <BNavItem href="#">Link 2</BNavItem>
-        <BNavItem href="#" disabled>Disabled</BNavItem>
+        <BNavItem
+          href="#"
+          disabled
+          >Disabled</BNavItem
+        >
       </BNavbarNav>
     </BCollapse>
   </BNavbar>

--- a/apps/docs/src/docs/components/demo/OffcanvasLocations.vue
+++ b/apps/docs/src/docs/components/demo/OffcanvasLocations.vue
@@ -1,10 +1,29 @@
 <template>
-  <BButton class="m-2" @click="click('start')">Show start</BButton>
-  <BButton class="m-2" @click="click('end')">Show end</BButton>
-  <BButton class="m-2" @click="click('bottom')">Show bottom</BButton>
-  <BButton class="m-2" @click="click('top')">Show top</BButton>
+  <BButton
+    class="m-2"
+    @click="click('start')"
+    >Show start</BButton
+  >
+  <BButton
+    class="m-2"
+    @click="click('end')"
+    >Show end</BButton
+  >
+  <BButton
+    class="m-2"
+    @click="click('bottom')"
+    >Show bottom</BButton
+  >
+  <BButton
+    class="m-2"
+    @click="click('top')"
+    >Show top</BButton
+  >
 
-  <BOffcanvas v-model="show" :placement="placement" />
+  <BOffcanvas
+    v-model="show"
+    :placement="placement"
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/OffcanvasSidebar.vue
+++ b/apps/docs/src/docs/components/demo/OffcanvasSidebar.vue
@@ -2,21 +2,41 @@
   <BContainer fluid="xxl">
     <BRow class="d-md-none"
       ><BCol>
-        <BButton variant="link" underline-opacity="0" @click="showToc"
+        <BButton
+          variant="link"
+          underline-opacity="0"
+          @click="showToc"
           >&lt; Table of Contents</BButton
         > </BCol
       ><BCol
         ><div class="text-end">
-          <BButton variant="link" underline-opacity="0" @click="showOtp">On this page &gt;</BButton>
+          <BButton
+            variant="link"
+            underline-opacity="0"
+            @click="showOtp"
+            >On this page &gt;</BButton
+          >
         </div></BCol
       ></BRow
     >
     <BRow>
-      <BCol md="2" class="scrollable-column">
-        <BOffcanvas v-model="tocVisible" placement="start" responsive="md">
+      <BCol
+        md="2"
+        class="scrollable-column"
+      >
+        <BOffcanvas
+          v-model="tocVisible"
+          placement="start"
+          responsive="md"
+        >
           <ul>
             <ul>
-              <li v-for="item in toc" :key="item">{{ item }}</li>
+              <li
+                v-for="item in toc"
+                :key="item"
+              >
+                {{ item }}
+              </li>
               <li>A very large entry in table of contents</li>
             </ul>
           </ul>
@@ -57,10 +77,22 @@
         luctus id viverra porta. Habitasse lorem bibendum semper maecenas volutpat porta. Eros
         praesent duis odio sagittis metus montes interdum.
       </BCol>
-      <BCol md="2" class="scrollable-column">
-        <BOffcanvas v-model="otpVisible" placement="end" responsive="md">
+      <BCol
+        md="2"
+        class="scrollable-column"
+      >
+        <BOffcanvas
+          v-model="otpVisible"
+          placement="end"
+          responsive="md"
+        >
           <ul>
-            <li v-for="item in otp" :key="item">{{ item }}</li>
+            <li
+              v-for="item in otp"
+              :key="item"
+            >
+              {{ item }}
+            </li>
             <li>A very large entry in on this page</li>
           </ul>
         </BOffcanvas>

--- a/apps/docs/src/docs/components/demo/PaginationAlignment.vue
+++ b/apps/docs/src/docs/components/demo/PaginationAlignment.vue
@@ -1,19 +1,34 @@
 <template>
   <div>
     <h6>Left alignment (default)</h6>
-    <BPagination v-model="currentPage" :total-rows="rows" />
+    <BPagination
+      v-model="currentPage"
+      :total-rows="rows"
+    />
   </div>
   <div class="mt-3">
     <h6 class="text-center">Center alignment</h6>
-    <BPagination v-model="currentPage" :total-rows="rows" align="center" />
+    <BPagination
+      v-model="currentPage"
+      :total-rows="rows"
+      align="center"
+    />
   </div>
   <div class="mt-3">
     <h6 class="text-end">Right (end) alignment</h6>
-    <BPagination v-model="currentPage" :total-rows="rows" align="end" />
+    <BPagination
+      v-model="currentPage"
+      :total-rows="rows"
+      align="end"
+    />
   </div>
   <div class="mt-3">
     <h6 class="text-center">Fill alignment</h6>
-    <BPagination v-model="currentPage" :total-rows="rows" align="fill" />
+    <BPagination
+      v-model="currentPage"
+      :total-rows="rows"
+      align="fill"
+    />
   </div>
 </template>
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/PaginationButtonContent.vue
+++ b/apps/docs/src/docs/components/demo/PaginationButtonContent.vue
@@ -23,15 +23,29 @@
   />
 
   <!-- Use HTML and sub-components in slots -->
-  <BPagination v-model="currentPage" :total-rows="rows" :per-page="perPage" class="mt-4">
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+    :per-page="perPage"
+    class="mt-4"
+  >
     <template #first-text><span class="text-success">First</span></template>
     <template #prev-text><span class="text-danger">Prev</span></template>
     <template #next-text><span class="text-warning">Next</span></template>
     <template #last-text><span class="text-info">Last</span></template>
     <template #ellipsis-text>
-      <BSpinner small type="grow" />
-      <BSpinner small type="grow" />
-      <BSpinner small type="grow" />
+      <BSpinner
+        small
+        type="grow"
+      />
+      <BSpinner
+        small
+        type="grow"
+      />
+      <BSpinner
+        small
+        type="grow"
+      />
     </template>
     <template #page="{page, active}">
       <b v-if="active">{{ page }}</b>

--- a/apps/docs/src/docs/components/demo/PaginationButtonSize.vue
+++ b/apps/docs/src/docs/components/demo/PaginationButtonSize.vue
@@ -1,12 +1,23 @@
 <template>
   <h6>Small</h6>
-  <BPagination v-model="currentPage" :total-rows="rows" size="sm" />
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+    size="sm"
+  />
 
   <h6>Default</h6>
-  <BPagination v-model="currentPage" :total-rows="rows" />
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+  />
 
   <h6>Large</h6>
-  <BPagination v-model="currentPage" :total-rows="rows" size="lg" />
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+    size="lg"
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/PaginationFirstLast.vue
+++ b/apps/docs/src/docs/components/demo/PaginationFirstLast.vue
@@ -1,9 +1,19 @@
 <template>
   <h6>Goto first button number</h6>
-  <BPagination v-model="currentPage" :total-rows="rows" :per-page="perPage" first-number />
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+    :per-page="perPage"
+    first-number
+  />
 
   <h6>Goto last button number</h6>
-  <BPagination v-model="currentPage" :total-rows="rows" :per-page="perPage" last-number />
+  <BPagination
+    v-model="currentPage"
+    :total-rows="rows"
+    :per-page="perPage"
+    last-number
+  />
 
   <h6>Goto first and last button number</h6>
   <BPagination

--- a/apps/docs/src/docs/components/demo/PaginationPillStyle.vue
+++ b/apps/docs/src/docs/components/demo/PaginationPillStyle.vue
@@ -1,12 +1,26 @@
 <template>
   <h6>Small Pills</h6>
-  <BPagination v-model="currentPage" pills :total-rows="rows" size="sm" />
+  <BPagination
+    v-model="currentPage"
+    pills
+    :total-rows="rows"
+    size="sm"
+  />
 
   <h6>Default Pills</h6>
-  <BPagination v-model="currentPage" pills :total-rows="rows" />
+  <BPagination
+    v-model="currentPage"
+    pills
+    :total-rows="rows"
+  />
 
   <h6>Large Pills</h6>
-  <BPagination v-model="currentPage" pills :total-rows="rows" size="lg" />
+  <BPagination
+    v-model="currentPage"
+    pills
+    :total-rows="rows"
+    size="lg"
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/PopoverCloseOnHide.vue
+++ b/apps/docs/src/docs/components/demo/PopoverCloseOnHide.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="d-flex gap-2">
-    <BPopover :click="true" :close-on-hide="true" :delay="{show: 0, hide: 0}">
+    <BPopover
+      :click="true"
+      :close-on-hide="true"
+      :delay="{show: 0, hide: 0}"
+    >
       <template #target>
         <BButton>Click me. Popover closes when clipped</BButton>
       </template>

--- a/apps/docs/src/docs/components/demo/PopoverContent.vue
+++ b/apps/docs/src/docs/components/demo/PopoverContent.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <div class="d-flex gap-2">
-    <BPopover title="Prop Examples" body="Embedding content using properties is easy">
+    <BPopover
+      title="Prop Examples"
+      body="Embedding content using properties is easy"
+    >
       <template #target>
         <BButton variant="primary">Using properties</BButton>
       </template>

--- a/apps/docs/src/docs/components/demo/PopoverCustomClass.vue
+++ b/apps/docs/src/docs/components/demo/PopoverCustomClass.vue
@@ -1,9 +1,16 @@
 <template>
   <!-- #region template -->
   <div class="d-flex gap-2">
-    <BPopover title-class="my-popover-title-class" body-class="my-popover-body-class">
+    <BPopover
+      title-class="my-popover-title-class"
+      body-class="my-popover-body-class"
+    >
       <template #target>
-        <BButton href="#" tabindex="0">Button</BButton>
+        <BButton
+          href="#"
+          tabindex="0"
+          >Button</BButton
+        >
       </template>
       <template #title>Popover Title</template>
       Popover content

--- a/apps/docs/src/docs/components/demo/PopoverExposed.vue
+++ b/apps/docs/src/docs/components/demo/PopoverExposed.vue
@@ -1,15 +1,36 @@
 <template>
   <div class="d-flex flex-column text-md-center">
     <div class="p-2">
-      <BButton id="popover-expose" variant="primary">I have a popover</BButton>
+      <BButton
+        id="popover-expose"
+        variant="primary"
+        >I have a popover</BButton
+      >
     </div>
 
     <div class="p-2">
-      <BButton class="mx-2" @click="show">Show</BButton>
-      <BButton class="mx-2" @click="hide">Hide</BButton>
-      <BButton class="mx-2" @click="toggle">Toggle</BButton>
+      <BButton
+        class="mx-2"
+        @click="show"
+        >Show</BButton
+      >
+      <BButton
+        class="mx-2"
+        @click="hide"
+        >Hide</BButton
+      >
+      <BButton
+        class="mx-2"
+        @click="toggle"
+        >Toggle</BButton
+      >
 
-      <BPopover ref="myPopover" v-model="model" target="popover-expose" title="Popover">
+      <BPopover
+        ref="myPopover"
+        v-model="model"
+        target="popover-expose"
+        title="Popover"
+      >
         Hello <strong>World!</strong>
       </BPopover>
     </div>

--- a/apps/docs/src/docs/components/demo/PopoverModel.vue
+++ b/apps/docs/src/docs/components/demo/PopoverModel.vue
@@ -5,9 +5,17 @@
     </div>
 
     <div class="p-2">
-      <BPopover v-model="model" placement="right" title="Popover">
+      <BPopover
+        v-model="model"
+        placement="right"
+        title="Popover"
+      >
         <template #target>
-          <BButton class="mx-2" @click="model = !model">Toggle Popover</BButton>
+          <BButton
+            class="mx-2"
+            @click="model = !model"
+            >Toggle Popover</BButton
+          >
         </template>
         Hello <strong>World!</strong>
       </BPopover>

--- a/apps/docs/src/docs/components/demo/PopoverOverview.vue
+++ b/apps/docs/src/docs/components/demo/PopoverOverview.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <div class="d-flex gap-2">
-    <BButton v-b-popover.focus.top="'I am popover directive content!'" title="Popover Title">
+    <BButton
+      v-b-popover.focus.top="'I am popover directive content!'"
+      title="Popover Title"
+    >
       Hover Me
     </BButton>
 

--- a/apps/docs/src/docs/components/demo/PopoverPositioning.vue
+++ b/apps/docs/src/docs/components/demo/PopoverPositioning.vue
@@ -89,7 +89,10 @@
         </BPopover>
       </BCol>
       <BCol class="d-grid gap-2">
-        <BPopover target="popover-target-autoend" placement="auto-end">
+        <BPopover
+          target="popover-target-autoend"
+          placement="auto-end"
+        >
           <template #target><BButton>Auto End</BButton></template>
           <template #title>Popover Auto End</template>
           I am popover <b>component</b> content!

--- a/apps/docs/src/docs/components/demo/PopoverStartOpen.vue
+++ b/apps/docs/src/docs/components/demo/PopoverStartOpen.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="text-center">
-    <BPopover show title="Popover">
+    <BPopover
+      show
+      title="Popover"
+    >
       <template #target>
         <BButton variant="primary">Button</BButton>
       </template>

--- a/apps/docs/src/docs/components/demo/PopoverTriggers.vue
+++ b/apps/docs/src/docs/components/demo/PopoverTriggers.vue
@@ -1,12 +1,19 @@
 <template>
   <!-- #region template -->
   <div class="d-flex gap-2">
-    <BPopover placement="top" body="Default Trigger">
+    <BPopover
+      placement="top"
+      body="Default Trigger"
+    >
       <template #target>
         <BButton> Default Trigger </BButton>
       </template>
     </BPopover>
-    <BPopover click placement="top" body="Click Trigger">
+    <BPopover
+      click
+      placement="top"
+      body="Click Trigger"
+    >
       <template #target>
         <BButton> Click Trigger </BButton>
       </template>

--- a/apps/docs/src/docs/components/demo/ProgressAnimated.vue
+++ b/apps/docs/src/docs/components/demo/ProgressAnimated.vue
@@ -1,8 +1,31 @@
 <template>
   <!-- #region template -->
-  <BProgress variant="success" :value="25" striped animated />
-  <BProgress class="mt-3" variant="info" :value="50" striped animated />
-  <BProgress class="mt-3" variant="warning" :value="75" striped animated />
-  <BProgress class="mt-3" variant="danger" :value="100" striped animated />
+  <BProgress
+    variant="success"
+    :value="25"
+    striped
+    animated
+  />
+  <BProgress
+    class="mt-3"
+    variant="info"
+    :value="50"
+    striped
+    animated
+  />
+  <BProgress
+    class="mt-3"
+    variant="warning"
+    :value="75"
+    striped
+    animated
+  />
+  <BProgress
+    class="mt-3"
+    variant="danger"
+    :value="100"
+    striped
+    animated
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressBackgrounds.vue
+++ b/apps/docs/src/docs/components/demo/ProgressBackgrounds.vue
@@ -1,8 +1,23 @@
 <template>
   <!-- #region template -->
-  <BProgress variant="success" :value="25" />
-  <BProgress class="mt-3" variant="info" :value="50" />
-  <BProgress class="mt-3" variant="warning" :value="75" />
-  <BProgress class="mt-3" variant="danger" :value="100" />
+  <BProgress
+    variant="success"
+    :value="25"
+  />
+  <BProgress
+    class="mt-3"
+    variant="info"
+    :value="50"
+  />
+  <BProgress
+    class="mt-3"
+    variant="warning"
+    :value="75"
+  />
+  <BProgress
+    class="mt-3"
+    variant="danger"
+    :value="100"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressBasic.vue
+++ b/apps/docs/src/docs/components/demo/ProgressBasic.vue
@@ -1,9 +1,21 @@
 <template>
   <!-- #region template -->
   <BProgress :value="0" />
-  <BProgress class="mt-3" :value="25" />
-  <BProgress class="mt-3" :value="50" />
-  <BProgress class="mt-3" :value="75" />
-  <BProgress class="mt-3" :value="100" />
+  <BProgress
+    class="mt-3"
+    :value="25"
+  />
+  <BProgress
+    class="mt-3"
+    :value="50"
+  />
+  <BProgress
+    class="mt-3"
+    :value="75"
+  />
+  <BProgress
+    class="mt-3"
+    :value="100"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressCustomLabels.vue
+++ b/apps/docs/src/docs/components/demo/ProgressCustomLabels.vue
@@ -1,7 +1,10 @@
 <template>
   <!-- #region template -->
   <h5>Custom label via default slot</h5>
-  <BProgress :max="50" height="2rem">
+  <BProgress
+    :max="50"
+    height="2rem"
+  >
     <BProgressBar :value="33.333333">
       <span
         >Progress: <strong>{{ (33.333333).toFixed(2) }} / {{ 50 }}</strong></span
@@ -11,7 +14,10 @@
 
   <h5 class="mt-3">Custom label via property</h5>
   <BProgress :max="50">
-    <BProgressBar :value="33.333333" :label="`${((33.333333 / 50) * 100).toFixed(2)}%`" />
+    <BProgressBar
+      :value="33.333333"
+      :label="`${((33.333333 / 50) * 100).toFixed(2)}%`"
+    />
   </BProgress>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressHeight.vue
+++ b/apps/docs/src/docs/components/demo/ProgressHeight.vue
@@ -1,6 +1,13 @@
 <template>
   <!-- #region template -->
-  <BProgress :value="25" height="1px" />
-  <BProgress class="mt-3" :value="25" height="20px" />
+  <BProgress
+    :value="25"
+    height="1px"
+  />
+  <BProgress
+    class="mt-3"
+    :value="25"
+    height="20px"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressLabels.vue
+++ b/apps/docs/src/docs/components/demo/ProgressLabels.vue
@@ -1,14 +1,35 @@
 <template>
   <!-- #region template -->
   <h5>No label</h5>
-  <BProgress :value="33.3333" :max="50" />
+  <BProgress
+    :value="33.3333"
+    :max="50"
+  />
   <h5>Value label</h5>
-  <BProgress :value="33.3333" :max="50" show-value />
+  <BProgress
+    :value="33.3333"
+    :max="50"
+    show-value
+  />
   <h5>Progress label</h5>
-  <BProgress :value="33.3333" :max="50" show-progress />
+  <BProgress
+    :value="33.3333"
+    :max="50"
+    show-progress
+  />
   <h5>Value label with precision</h5>
-  <BProgress :value="33.3333" :max="50" :precision="2" show-value />
+  <BProgress
+    :value="33.3333"
+    :max="50"
+    :precision="2"
+    show-value
+  />
   <h5>Progress label with precision</h5>
-  <BProgress :value="33.3333" :max="50" :precision="2" show-progress />
+  <BProgress
+    :value="33.3333"
+    :max="50"
+    :precision="2"
+    show-progress
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressMultipleBars.vue
+++ b/apps/docs/src/docs/components/demo/ProgressMultipleBars.vue
@@ -2,8 +2,14 @@
   <!-- #region template -->
   <BProgress>
     <BProgressBar :value="15" />
-    <BProgressBar :value="30" variant="success" />
-    <BProgressBar :value="20" variant="info" />
+    <BProgressBar
+      :value="30"
+      variant="success"
+    />
+    <BProgressBar
+      :value="20"
+      variant="info"
+    />
   </BProgress>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressStriped.vue
+++ b/apps/docs/src/docs/components/demo/ProgressStriped.vue
@@ -1,9 +1,32 @@
 <template>
   <!-- #region template -->
-  <BProgress striped :value="10" />
-  <BProgress striped class="mt-3" variant="success" :value="25" />
-  <BProgress striped class="mt-3" variant="info" :value="50" />
-  <BProgress striped class="mt-3" variant="warning" :value="75" />
-  <BProgress striped class="mt-3" variant="danger" :value="100" />
+  <BProgress
+    striped
+    :value="10"
+  />
+  <BProgress
+    striped
+    class="mt-3"
+    variant="success"
+    :value="25"
+  />
+  <BProgress
+    striped
+    class="mt-3"
+    variant="info"
+    :value="50"
+  />
+  <BProgress
+    striped
+    class="mt-3"
+    variant="warning"
+    :value="75"
+  />
+  <BProgress
+    striped
+    class="mt-3"
+    variant="danger"
+    :value="100"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ProgressWidth.vue
+++ b/apps/docs/src/docs/components/demo/ProgressWidth.vue
@@ -1,11 +1,23 @@
 <template>
   <!-- #region template -->
   <h5>Default width</h5>
-  <BProgress :value="75" class="mb-3" />
+  <BProgress
+    :value="75"
+    class="mb-3"
+  />
 
   <h5>Custom widths</h5>
-  <BProgress :value="75" class="w-75 mb-2" />
-  <BProgress :value="75" class="w-50 mb-2" />
-  <BProgress :value="75" class="w-25" />
+  <BProgress
+    :value="75"
+    class="w-75 mb-2"
+  />
+  <BProgress
+    :value="75"
+    class="w-50 mb-2"
+  />
+  <BProgress
+    :value="75"
+    class="w-25"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/RadioButtons.vue
+++ b/apps/docs/src/docs/components/demo/RadioButtons.vue
@@ -4,7 +4,12 @@
   </div>
 
   <div>
-    <BFormRadioGroup v-model="selected" :options="options" name="radios-btn-default" buttons />
+    <BFormRadioGroup
+      v-model="selected"
+      :options="options"
+      name="radios-btn-default"
+      buttons
+    />
   </div>
 
   <div class="my-2">

--- a/apps/docs/src/docs/components/demo/RadioFeedback.vue
+++ b/apps/docs/src/docs/components/demo/RadioFeedback.vue
@@ -6,8 +6,18 @@
     name="radio-validation"
   />
 
-  <div v-if="!state" class="text-danger">Please select one</div>
-  <div v-if="state" class="text-success">Thank you</div>
+  <div
+    v-if="!state"
+    class="text-danger"
+  >
+    Please select one
+  </div>
+  <div
+    v-if="state"
+    class="text-success"
+  >
+    Thank you
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/RadioGroup.vue
+++ b/apps/docs/src/docs/components/demo/RadioGroup.vue
@@ -17,10 +17,18 @@
   </div>
 
   <div>
-    <BFormRadioGroup id="radio-group-2" v-model="selected" name="radio-sub-component">
+    <BFormRadioGroup
+      id="radio-group-2"
+      v-model="selected"
+      name="radio-sub-component"
+    >
       <BFormRadio value="first">Toggle this custom radio</BFormRadio>
       <BFormRadio value="second">Or toggle this other custom radio</BFormRadio>
-      <BFormRadio value="third" disabled>This one is Disabled</BFormRadio>
+      <BFormRadio
+        value="third"
+        disabled
+        >This one is Disabled</BFormRadio
+      >
       <BFormRadio :value="{fourth: 4}">This is the 4th radio</BFormRadio>
     </BFormRadioGroup>
   </div>

--- a/apps/docs/src/docs/components/demo/RadioIndividual.vue
+++ b/apps/docs/src/docs/components/demo/RadioIndividual.vue
@@ -4,8 +4,18 @@
   </div>
 
   <div>
-    <BFormRadio v-model="selected" name="some-radios" value="A">Option A </BFormRadio>
-    <BFormRadio v-model="selected" name="some-radios" value="B">Option B </BFormRadio>
+    <BFormRadio
+      v-model="selected"
+      name="some-radios"
+      value="A"
+      >Option A
+    </BFormRadio>
+    <BFormRadio
+      v-model="selected"
+      name="some-radios"
+      value="B"
+      >Option B
+    </BFormRadio>
   </div>
 
   <div class="mt-3">

--- a/apps/docs/src/docs/components/demo/RadioInline.vue
+++ b/apps/docs/src/docs/components/demo/RadioInline.vue
@@ -4,7 +4,11 @@
   </div>
 
   <div>
-    <BFormRadioGroup v-model="selected" :options="options" name="radio-inline" />
+    <BFormRadioGroup
+      v-model="selected"
+      :options="options"
+      name="radio-inline"
+    />
   </div>
 
   <div class="my-2">
@@ -12,7 +16,12 @@
   </div>
 
   <div>
-    <BFormRadioGroup v-model="selected" :options="options" name="radio-stacked" stacked />
+    <BFormRadioGroup
+      v-model="selected"
+      :options="options"
+      name="radio-stacked"
+      stacked
+    />
   </div>
 
   <div class="mt-3">

--- a/apps/docs/src/docs/components/demo/RadioPlain.vue
+++ b/apps/docs/src/docs/components/demo/RadioPlain.vue
@@ -4,7 +4,12 @@
   </div>
 
   <div>
-    <BFormRadioGroup v-model="selected" :options="plainOptions" name="plain-inline" plain />
+    <BFormRadioGroup
+      v-model="selected"
+      :options="plainOptions"
+      name="plain-inline"
+      plain
+    />
   </div>
 
   <div class="my-2">
@@ -12,7 +17,12 @@
   </div>
 
   <div>
-    <BFormRadioGroup v-model="selected" :options="plainOptions" name="plain-stacked" plain />
+    <BFormRadioGroup
+      v-model="selected"
+      :options="plainOptions"
+      name="plain-stacked"
+      plain
+    />
   </div>
 
   <div class="mt-3">

--- a/apps/docs/src/docs/components/demo/RadioReverse.vue
+++ b/apps/docs/src/docs/components/demo/RadioReverse.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
   <BFormRadio reverse>Reverse checkbox</BFormRadio>
-  <BFormRadio reverse disabled>Disabled reverse checkbox</BFormRadio>
+  <BFormRadio
+    reverse
+    disabled
+    >Disabled reverse checkbox</BFormRadio
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/RadioSizing.vue
+++ b/apps/docs/src/docs/components/demo/RadioSizing.vue
@@ -1,7 +1,15 @@
 <template>
   <!-- #region template -->
-  <BFormRadio name="radio-size" size="sm">Small</BFormRadio>
+  <BFormRadio
+    name="radio-size"
+    size="sm"
+    >Small</BFormRadio
+  >
   <BFormRadio name="radio-size">Default</BFormRadio>
-  <BFormRadio name="radio-size" size="lg">Large</BFormRadio>
+  <BFormRadio
+    name="radio-size"
+    size="lg"
+    >Large</BFormRadio
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/RowColResponsive.vue
+++ b/apps/docs/src/docs/components/demo/RowColResponsive.vue
@@ -1,7 +1,12 @@
 <template>
   <!-- #region template -->
   <BContainer class="bv-example-row">
-    <BRow cols="1" cols-sm="2" cols-md="4" cols-lg="6">
+    <BRow
+      cols="1"
+      cols-sm="2"
+      cols-md="4"
+      cols-lg="6"
+    >
       <BCol>Column</BCol>
       <BCol>Column</BCol>
       <BCol>Column</BCol>

--- a/apps/docs/src/docs/components/demo/SelectMultiValue.vue
+++ b/apps/docs/src/docs/components/demo/SelectMultiValue.vue
@@ -1,5 +1,10 @@
 <template>
-  <BFormSelect v-model="selected" :options="exMultiOptions" multiple :select-size="4" />
+  <BFormSelect
+    v-model="selected"
+    :options="exMultiOptions"
+    multiple
+    :select-size="4"
+  />
 
   <div class="mt-3">
     Selected: <strong>{{ selected }}</strong>

--- a/apps/docs/src/docs/components/demo/SelectOptionsGroup.vue
+++ b/apps/docs/src/docs/components/demo/SelectOptionsGroup.vue
@@ -1,5 +1,8 @@
 <template>
-  <BFormSelect v-model="selected" :options="ex1GroupOptions" />
+  <BFormSelect
+    v-model="selected"
+    :options="ex1GroupOptions"
+  />
 
   <div class="mt-3">
     Selected: <strong>{{ selected }}</strong>

--- a/apps/docs/src/docs/components/demo/SelectOptionsManual.vue
+++ b/apps/docs/src/docs/components/demo/SelectOptionsManual.vue
@@ -2,7 +2,11 @@
   <BFormSelect v-model="selected">
     <BFormSelectOption :value="null">Please select an option</BFormSelectOption>
     <BFormSelectOption value="a">Option A</BFormSelectOption>
-    <BFormSelectOption value="b" disabled>Option B (disabled)</BFormSelectOption>
+    <BFormSelectOption
+      value="b"
+      disabled
+      >Option B (disabled)</BFormSelectOption
+    >
     <BFormSelectOptionGroup label="Grouped options">
       <BFormSelectOption :value="{C: '3PO'}">Option with object value</BFormSelectOption>
       <BFormSelectOption :value="{R: '2D2'}">Another option with object value</BFormSelectOption>

--- a/apps/docs/src/docs/components/demo/SelectOptionsMixed.vue
+++ b/apps/docs/src/docs/components/demo/SelectOptionsMixed.vue
@@ -1,8 +1,16 @@
 <template>
-  <BFormSelect v-model="selected" :options="exFirstSlotOptions" class="mb-3">
+  <BFormSelect
+    v-model="selected"
+    :options="exFirstSlotOptions"
+    class="mb-3"
+  >
     <!-- This slot appears above the options from 'options' prop -->
     <template #first>
-      <BFormSelectOption :value="null" disabled>-- Please select an option --</BFormSelectOption>
+      <BFormSelectOption
+        :value="null"
+        disabled
+        >-- Please select an option --</BFormSelectOption
+      >
     </template>
 
     <!-- These options will appear after the ones from 'options' prop -->

--- a/apps/docs/src/docs/components/demo/SelectOverview.vue
+++ b/apps/docs/src/docs/components/demo/SelectOverview.vue
@@ -1,8 +1,16 @@
 ```vue
 <template>
-  <BFormSelect v-model="selected" :options="ex1Options" />
+  <BFormSelect
+    v-model="selected"
+    :options="ex1Options"
+  />
 
-  <BFormSelect v-model="selected" :options="ex1Options" size="sm" class="mt-3" />
+  <BFormSelect
+    v-model="selected"
+    :options="ex1Options"
+    size="sm"
+    class="mt-3"
+  />
 
   <div class="mt-3">
     Selected: <strong>{{ selected }}</strong>

--- a/apps/docs/src/docs/components/demo/SelectSingleValue.vue
+++ b/apps/docs/src/docs/components/demo/SelectSingleValue.vue
@@ -1,5 +1,8 @@
 <template>
-  <BFormSelect v-model="selected" :options="ex1Options" />
+  <BFormSelect
+    v-model="selected"
+    :options="ex1Options"
+  />
 
   <div class="mt-3">
     Selected: <strong>{{ selected }}</strong>

--- a/apps/docs/src/docs/components/demo/SelectSizing.vue
+++ b/apps/docs/src/docs/components/demo/SelectSizing.vue
@@ -1,5 +1,9 @@
 <template>
-  <BFormSelect v-model="selected" :options="ex1Options" :select-size="4" />
+  <BFormSelect
+    v-model="selected"
+    :options="ex1Options"
+    :select-size="4"
+  />
 
   <div class="mt-3">
     Selected: <strong>{{ selected }}</strong>

--- a/apps/docs/src/docs/components/demo/SpinnerButtons.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerButtons.vue
@@ -1,10 +1,17 @@
 <template>
   <!-- #region template -->
-  <BButton variant="primary" disabled class="me-2">
+  <BButton
+    variant="primary"
+    disabled
+    class="me-2"
+  >
     <BSpinner small />
     <span class="visually-hidden">Loading...</span>
   </BButton>
-  <BButton variant="primary" disabled>
+  <BButton
+    variant="primary"
+    disabled
+  >
     <BSpinner small />
     Loading...
   </BButton>

--- a/apps/docs/src/docs/components/demo/SpinnerColors.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerColors.vue
@@ -1,11 +1,20 @@
 <template>
   <div>
     <div class="text-center mb-3 d-flex justify-content-between">
-      <BSpinner v-for="variant in variants" :key="variant" :variant="variant" />
+      <BSpinner
+        v-for="variant in variants"
+        :key="variant"
+        :variant="variant"
+      />
     </div>
 
     <div class="text-center d-flex justify-content-between">
-      <BSpinner v-for="variant in variants" :key="variant" :variant="variant" type="grow" />
+      <BSpinner
+        v-for="variant in variants"
+        :key="variant"
+        :variant="variant"
+        type="grow"
+      />
     </div>
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/SpinnerGrowButtons.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerGrowButtons.vue
@@ -1,11 +1,24 @@
 <template>
   <!-- #region template -->
-  <BButton variant="primary" disabled class="me-2">
-    <BSpinner small type="grow" />
+  <BButton
+    variant="primary"
+    disabled
+    class="me-2"
+  >
+    <BSpinner
+      small
+      type="grow"
+    />
     <span class="visually-hidden">Loading...</span>
   </BButton>
-  <BButton variant="primary" disabled>
-    <BSpinner small type="grow" />
+  <BButton
+    variant="primary"
+    disabled
+  >
+    <BSpinner
+      small
+      type="grow"
+    />
     Loading...
   </BButton>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/SpinnerMargin.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerMargin.vue
@@ -1,5 +1,8 @@
 <template>
   <!-- #region template -->
-  <BSpinner class="m-5" label="Busy" />
+  <BSpinner
+    class="m-5"
+    label="Busy"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/SpinnerOverview.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerOverview.vue
@@ -1,12 +1,37 @@
 <template>
   <!-- #region template -->
   <div class="text-center">
-    <BSpinner label="Spinning" class="mx-1" />
-    <BSpinner type="grow" label="Spinning" class="mx-1" />
-    <BSpinner variant="primary" label="Spinning" class="mx-1" />
-    <BSpinner variant="primary" type="grow" label="Spinning" class="mx-1" />
-    <BSpinner variant="success" label="Spinning" class="mx-1" />
-    <BSpinner variant="success" type="grow" label="Spinning" class="mx-1" />
+    <BSpinner
+      label="Spinning"
+      class="mx-1"
+    />
+    <BSpinner
+      type="grow"
+      label="Spinning"
+      class="mx-1"
+    />
+    <BSpinner
+      variant="primary"
+      label="Spinning"
+      class="mx-1"
+    />
+    <BSpinner
+      variant="primary"
+      type="grow"
+      label="Spinning"
+      class="mx-1"
+    />
+    <BSpinner
+      variant="success"
+      label="Spinning"
+      class="mx-1"
+    />
+    <BSpinner
+      variant="success"
+      type="grow"
+      label="Spinning"
+      class="mx-1"
+    />
   </div>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/SpinnerSize.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerSize.vue
@@ -1,6 +1,14 @@
 <template>
   <!-- #region template -->
-  <BSpinner style="width: 3rem; height: 3rem" class="me-2" label="Large Spinner" />
-  <BSpinner style="width: 3rem; height: 3rem" label="Large Spinner" type="grow" />
+  <BSpinner
+    style="width: 3rem; height: 3rem"
+    class="me-2"
+    label="Large Spinner"
+  />
+  <BSpinner
+    style="width: 3rem; height: 3rem"
+    label="Large Spinner"
+    type="grow"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/SpinnerSmall.vue
+++ b/apps/docs/src/docs/components/demo/SpinnerSmall.vue
@@ -1,6 +1,12 @@
 <template>
   <!-- #region template -->
-  <BSpinner small class="me-2" />
-  <BSpinner small type="grow" />
+  <BSpinner
+    small
+    class="me-2"
+  />
+  <BSpinner
+    small
+    type="grow"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TableBasicStyles.vue
+++ b/apps/docs/src/docs/components/demo/TableBasicStyles.vue
@@ -1,57 +1,123 @@
 <template>
   <div>
-    <BFormGroup v-slot="{ariaDescribedby}" label="Table Options" label-cols-lg="2">
-      <BFormCheckbox v-model="striped" :aria-describedby="ariaDescribedby" inline
+    <BFormGroup
+      v-slot="{ariaDescribedby}"
+      label="Table Options"
+      label-cols-lg="2"
+    >
+      <BFormCheckbox
+        v-model="striped"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Striped</BFormCheckbox
       >
-      <BFormCheckbox v-model="stripedColumns" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="stripedColumns"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Striped Columns</BFormCheckbox
       >
-      <BFormCheckbox v-model="bordered" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="bordered"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Bordered</BFormCheckbox
       >
-      <BFormCheckbox v-model="borderless" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="borderless"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Borderless</BFormCheckbox
       >
-      <BFormCheckbox v-model="outlined" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="outlined"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Outlined</BFormCheckbox
       >
-      <BFormCheckbox v-model="small" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="small"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Small</BFormCheckbox
       >
-      <BFormCheckbox v-model="hover" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="hover"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Hover</BFormCheckbox
       >
-      <BFormCheckbox v-model="dark" :aria-describedby="ariaDescribedby" inline>Dark</BFormCheckbox>
-      <BFormCheckbox v-model="fixed" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="dark"
+        :aria-describedby="ariaDescribedby"
+        inline
+        >Dark</BFormCheckbox
+      >
+      <BFormCheckbox
+        v-model="fixed"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Fixed</BFormCheckbox
       >
-      <BFormCheckbox v-model="footClone" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="footClone"
+        :aria-describedby="ariaDescribedby"
+        inline
         >Foot Clone</BFormCheckbox
       >
-      <BFormCheckbox v-model="noCollapse" :aria-describedby="ariaDescribedby" inline
+      <BFormCheckbox
+        v-model="noCollapse"
+        :aria-describedby="ariaDescribedby"
+        inline
         >No border collapse</BFormCheckbox
       >
     </BFormGroup>
 
-    <BFormGroup label="Variant" label-for="table-style-variant" label-cols-lg="2" class="my-2">
-      <BFormSelect id="table-style-variant" v-model="variant" :options="variants">
+    <BFormGroup
+      label="Variant"
+      label-for="table-style-variant"
+      label-cols-lg="2"
+      class="my-2"
+    >
+      <BFormSelect
+        id="table-style-variant"
+        v-model="variant"
+        :options="variants"
+      >
         <template #first>
           <option :value="null">-- None --</option>
         </template>
       </BFormSelect>
     </BFormGroup>
 
-    <BFormGroup label="Head Variant" label-for="head-style-variant" label-cols-lg="2" class="my-2">
-      <BFormSelect id="head-style-variant" v-model="headVariant" :options="variants">
+    <BFormGroup
+      label="Head Variant"
+      label-for="head-style-variant"
+      label-cols-lg="2"
+      class="my-2"
+    >
+      <BFormSelect
+        id="head-style-variant"
+        v-model="headVariant"
+        :options="variants"
+      >
         <template #first>
           <option :value="null">-- None --</option>
         </template>
       </BFormSelect>
     </BFormGroup>
 
-    <BFormGroup label="Foot Variant" label-for="foot-style-variant" label-cols-lg="2" class="my-2">
-      <BFormSelect id="foot-style-variant" v-model="footVariant" :options="variants">
+    <BFormGroup
+      label="Foot Variant"
+      label-for="foot-style-variant"
+      label-cols-lg="2"
+      class="my-2"
+    >
+      <BFormSelect
+        id="foot-style-variant"
+        v-model="footVariant"
+        :options="variants"
+      >
         <template #first>
           <option :value="null">-- None --</option>
         </template>

--- a/apps/docs/src/docs/components/demo/TableBusy.vue
+++ b/apps/docs/src/docs/components/demo/TableBusy.vue
@@ -2,7 +2,12 @@
   <div>
     <BButton @click="toggleBusy">Toggle Busy State</BButton>
 
-    <BTable :items="items" :busy="isBusy" class="mt-3" outlined>
+    <BTable
+      :items="items"
+      :busy="isBusy"
+      class="mt-3"
+      outlined
+    >
       <!-- <template #table-busy>
         <div class="text-center text-danger my-2">
           <BSpinner class="align-middle" />

--- a/apps/docs/src/docs/components/demo/TableCaption.vue
+++ b/apps/docs/src/docs/components/demo/TableCaption.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields">
+    <BTable
+      :items="items"
+      :fields="fields"
+    >
       <template #table-caption>This is a table caption.</template>
     </BTable>
   </div>

--- a/apps/docs/src/docs/components/demo/TableCaptionTop.vue
+++ b/apps/docs/src/docs/components/demo/TableCaptionTop.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields" caption-top>
+    <BTable
+      :items="items"
+      :fields="fields"
+      caption-top
+    >
       <template #table-caption>This is a table caption at the top.</template>
     </BTable>
   </div>

--- a/apps/docs/src/docs/components/demo/TableCellVariants.vue
+++ b/apps/docs/src/docs/components/demo/TableCellVariants.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable hover :items="items" />
+    <BTable
+      hover
+      :items="items"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableColgroup.vue
+++ b/apps/docs/src/docs/components/demo/TableColgroup.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields">
+    <BTable
+      :items="items"
+      :fields="fields"
+    >
       <template #table-colgroup>
         <col style="width: 30%" />
         <col style="width: 45%" />

--- a/apps/docs/src/docs/components/demo/TableComplete.vue
+++ b/apps/docs/src/docs/components/demo/TableComplete.vue
@@ -2,7 +2,10 @@
   <BContainer class="py-5">
     <!-- User Interface controls -->
     <BRow>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           v-slot="{ariaDescribedby}"
           label="Sort"
@@ -12,8 +15,16 @@
           label-size="sm"
           class="mb-0"
         >
-          <BButton size="sm" @click="onAddSort">Add Sort...</BButton>
-          <BInputGroup v-for="sort in sortBy" :key="sort.key" size="sm">
+          <BButton
+            size="sm"
+            @click="onAddSort"
+            >Add Sort...</BButton
+          >
+          <BInputGroup
+            v-for="sort in sortBy"
+            :key="sort.key"
+            size="sm"
+          >
             <BFormSelect
               id="sort-by-select"
               v-model="sort.key"
@@ -38,7 +49,10 @@
           </BInputGroup>
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Filter"
           label-for="filter-input"
@@ -55,12 +69,19 @@
               placeholder="Type to Search"
             />
             <BInputGroupText>
-              <BButton :disabled="!filter" @click="filter = ''">Clear</BButton>
+              <BButton
+                :disabled="!filter"
+                @click="filter = ''"
+                >Clear</BButton
+              >
             </BInputGroupText>
           </BInputGroup>
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           v-slot="{ariaDescribedby}"
           v-model="sortDirection"
@@ -72,19 +93,32 @@
           class="mb-0"
         >
           <div class="d-flex gap-2">
-            <BFormCheckbox v-model="filterOn" value="name" :aria-describedby="ariaDescribedby"
+            <BFormCheckbox
+              v-model="filterOn"
+              value="name"
+              :aria-describedby="ariaDescribedby"
               >Name</BFormCheckbox
             >
-            <BFormCheckbox v-model="filterOn" value="age" :aria-describedby="ariaDescribedby"
+            <BFormCheckbox
+              v-model="filterOn"
+              value="age"
+              :aria-describedby="ariaDescribedby"
               >Age</BFormCheckbox
             >
-            <BFormCheckbox v-model="filterOn" value="isActive" :aria-describedby="ariaDescribedby"
+            <BFormCheckbox
+              v-model="filterOn"
+              value="isActive"
+              :aria-describedby="ariaDescribedby"
               >Active</BFormCheckbox
             >
           </div>
         </BFormGroup>
       </BCol>
-      <BCol sm="5" md="6" class="my-1">
+      <BCol
+        sm="5"
+        md="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Per page"
           label-for="per-page-select"
@@ -95,10 +129,19 @@
           label-size="sm"
           class="mb-0"
         >
-          <BFormSelect id="per-page-select" v-model="perPage" :options="pageOptions" size="sm" />
+          <BFormSelect
+            id="per-page-select"
+            v-model="perPage"
+            :options="pageOptions"
+            size="sm"
+          />
         </BFormGroup>
       </BCol>
-      <BCol sm="7" md="6" class="my-1">
+      <BCol
+        sm="7"
+        md="6"
+        class="my-1"
+      >
         <BPagination
           v-model="currentPage"
           :total-rows="totalRows"
@@ -130,16 +173,35 @@
         {{ (row.value as PersonName).last }}
       </template>
       <template #cell(actions)="row">
-        <BButton size="sm" class="me-1" @click="info(row.item, row.index)"> Info modal </BButton>
-        <BButton size="sm" @click="row.toggleDetails">
+        <BButton
+          size="sm"
+          class="me-1"
+          @click="info(row.item, row.index)"
+        >
+          Info modal
+        </BButton>
+        <BButton
+          size="sm"
+          @click="row.toggleDetails"
+        >
           {{ row.detailsShowing ? 'Hide' : 'Show' }} Details
         </BButton>
       </template>
       <template #row-details="row">
         <BCard>
           <ul>
-            <li v-for="(value, key) in row.item" :key="key">{{ key }}: {{ value }}</li>
-            <BButton size="sm" @click="row.toggleDetails"> Toggle Details </BButton>
+            <li
+              v-for="(value, key) in row.item"
+              :key="key"
+            >
+              {{ key }}: {{ value }}
+            </li>
+            <BButton
+              size="sm"
+              @click="row.toggleDetails"
+            >
+              Toggle Details
+            </BButton>
           </ul>
         </BCard>
       </template>

--- a/apps/docs/src/docs/components/demo/TableCustomData.vue
+++ b/apps/docs/src/docs/components/demo/TableCustomData.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <BTable small :fields="fields" :items="items" responsive="sm">
+    <BTable
+      small
+      :fields="fields"
+      :items="items"
+      responsive="sm"
+    >
       <!-- A virtual column -->
       <template #cell(index)="data">
         {{ data.index + 1 }}

--- a/apps/docs/src/docs/components/demo/TableEmpty.vue
+++ b/apps/docs/src/docs/components/demo/TableEmpty.vue
@@ -1,6 +1,10 @@
 <template>
   <!-- #region template -->
-  <BTable :fields="fields" :items="items" show-empty>
+  <BTable
+    :fields="fields"
+    :items="items"
+    show-empty
+  >
     <template #empty="scope">
       <h4>{{ scope.emptyText }}</h4>
     </template>

--- a/apps/docs/src/docs/components/demo/TableFieldArray.vue
+++ b/apps/docs/src/docs/components/demo/TableFieldArray.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <BTable striped hover :items="items" :fields="fields" />
+    <BTable
+      striped
+      hover
+      :items="items"
+      :fields="fields"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableFieldObjects.vue
+++ b/apps/docs/src/docs/components/demo/TableFieldObjects.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <BTable striped hover :items="items" :fields="fields" />
+    <BTable
+      striped
+      hover
+      :items="items"
+      :fields="fields"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableFormatter.vue
+++ b/apps/docs/src/docs/components/demo/TableFormatter.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable :fields="fields" :items="items">
+    <BTable
+      :fields="fields"
+      :items="items"
+    >
       <template #cell(name)="data">
         <!-- `data.value` is the value after formatted by the Formatter -->
         <a :href="`#${(data.value as any as string).replace(/[^a-z]+/i, '-').toLowerCase()}`">{{

--- a/apps/docs/src/docs/components/demo/TableHeadSlot.vue
+++ b/apps/docs/src/docs/components/demo/TableHeadSlot.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BTable :fields="fields" :items="items" foot-clone>
+    <BTable
+      :fields="fields"
+      :items="items"
+      foot-clone
+    >
       <!-- A custom formatted data column cell -->
       <template #cell(name)="data">
         {{ (data.value as any as Name).first }} {{ (data.value as any as Name).last }}

--- a/apps/docs/src/docs/components/demo/TableHeaderRows.vue
+++ b/apps/docs/src/docs/components/demo/TableHeaderRows.vue
@@ -1,11 +1,19 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields" responsive="sm">
+    <BTable
+      :items="items"
+      :fields="fields"
+      responsive="sm"
+    >
       <template #thead-top>
         <BTr>
           <BTh colspan="2"><span class="visually-hidden">Name and ID</span></BTh>
           <BTh variant="secondary">Type 1</BTh>
-          <BTh variant="primary" colspan="3">Type 2</BTh>
+          <BTh
+            variant="primary"
+            colspan="3"
+            >Type 2</BTh
+          >
           <BTh variant="danger">Type 3</BTh>
         </BTr>
       </template>

--- a/apps/docs/src/docs/components/demo/TableOverview.vue
+++ b/apps/docs/src/docs/components/demo/TableOverview.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BTable striped hover :items="items" />
+    <BTable
+      striped
+      hover
+      :items="items"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableProvider.vue
+++ b/apps/docs/src/docs/components/demo/TableProvider.vue
@@ -2,7 +2,10 @@
   <BContainer class="py-5">
     <!-- User Interface controls -->
     <BRow>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Filter"
           label-for="filter-input"
@@ -19,12 +22,19 @@
               placeholder="Type to Search"
             />
             <BInputGroupText>
-              <BButton :disabled="!filter" @click="filter = ''">Clear</BButton>
+              <BButton
+                :disabled="!filter"
+                @click="filter = ''"
+                >Clear</BButton
+              >
             </BInputGroupText>
           </BInputGroup>
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Per page"
           label-for="per-page-select"
@@ -35,10 +45,18 @@
           label-size="sm"
           class="mb-0"
         >
-          <BFormSelect id="per-page-select" v-model="perPage" :options="pageOptions" size="sm" />
+          <BFormSelect
+            id="per-page-select"
+            v-model="perPage"
+            :options="pageOptions"
+            size="sm"
+          />
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BPagination
           v-model="currentPage"
           :total-rows="totalRows"

--- a/apps/docs/src/docs/components/demo/TableProviderAsync.vue
+++ b/apps/docs/src/docs/components/demo/TableProviderAsync.vue
@@ -2,7 +2,10 @@
   <BContainer class="py-5">
     <!-- User Interface controls -->
     <BRow>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Filter"
           label-for="filter-input"
@@ -19,12 +22,19 @@
               placeholder="Type to Search"
             />
             <BInputGroupText>
-              <BButton :disabled="!filter" @click="filter = ''">Clear</BButton>
+              <BButton
+                :disabled="!filter"
+                @click="filter = ''"
+                >Clear</BButton
+              >
             </BInputGroupText>
           </BInputGroup>
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BFormGroup
           label="Per page"
           label-for="per-page-select"
@@ -35,10 +45,18 @@
           label-size="sm"
           class="mb-0"
         >
-          <BFormSelect id="per-page-select" v-model="perPage" :options="pageOptions" size="sm" />
+          <BFormSelect
+            id="per-page-select"
+            v-model="perPage"
+            :options="pageOptions"
+            size="sm"
+          />
         </BFormGroup>
       </BCol>
-      <BCol lg="6" class="my-1">
+      <BCol
+        lg="6"
+        class="my-1"
+      >
         <BPagination
           v-model="currentPage"
           :total-rows="totalRows"

--- a/apps/docs/src/docs/components/demo/TableResponsive.vue
+++ b/apps/docs/src/docs/components/demo/TableResponsive.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable responsive :items="items" />
+    <BTable
+      responsive
+      :items="items"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableRowDetails.vue
+++ b/apps/docs/src/docs/components/demo/TableRowDetails.vue
@@ -1,13 +1,25 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields" striped responsive="sm">
+    <BTable
+      :items="items"
+      :fields="fields"
+      striped
+      responsive="sm"
+    >
       <template #cell(show_details)="row">
-        <BButton size="sm" class="mr-2" @click="row.toggleDetails">
+        <BButton
+          size="sm"
+          class="mr-2"
+          @click="row.toggleDetails"
+        >
           {{ row.detailsShowing ? 'Hide' : 'Show' }} Details
         </BButton>
 
         <!-- As `row.showDetails` is one-way, we call the toggleDetails function on @change -->
-        <BFormCheckbox v-model="row.detailsShowing" @change="row.toggleDetails">
+        <BFormCheckbox
+          v-model="row.detailsShowing"
+          @change="row.toggleDetails"
+        >
           Details via check
         </BFormCheckbox>
       </template>
@@ -15,16 +27,28 @@
       <template #row-details="row">
         <BCard>
           <BRow class="mb-2">
-            <BCol sm="3" class="text-sm-right"><b>Age:</b></BCol>
+            <BCol
+              sm="3"
+              class="text-sm-right"
+              ><b>Age:</b></BCol
+            >
             <BCol>{{ row.item.age }}</BCol>
           </BRow>
 
           <BRow class="mb-2">
-            <BCol sm="3" class="text-sm-right"><b>Is Active:</b></BCol>
+            <BCol
+              sm="3"
+              class="text-sm-right"
+              ><b>Is Active:</b></BCol
+            >
             <BCol>{{ row.item.isActive }}</BCol>
           </BRow>
 
-          <BButton size="sm" @click="row.toggleDetails">Hide Details</BButton>
+          <BButton
+            size="sm"
+            @click="row.toggleDetails"
+            >Hide Details</BButton
+          >
         </BCard>
       </template>
     </BTable>

--- a/apps/docs/src/docs/components/demo/TableRowSelect.vue
+++ b/apps/docs/src/docs/components/demo/TableRowSelect.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BFormGroup label="Selection mode:" label-for="table-select-mode-select" label-cols-md="4">
+    <BFormGroup
+      label="Selection mode:"
+      label-for="table-select-mode-select"
+      label-cols-md="4"
+    >
       <BFormSelect
         id="table-select-mode-select"
         v-model="selectMode"
@@ -31,10 +35,29 @@
       </template>
     </BTable>
     <p>
-      <BButton size="sm" class="me-2" @click="selectAllRows">Select all</BButton>
-      <BButton size="sm" class="me-2" @click="clearSelected">Clear selected</BButton>
-      <BButton size="sm" class="me-2" @click="selectThirdRow">Select 3rd row</BButton>
-      <BButton size="sm" @click="unselectThirdRow">Unselect 3rd row</BButton>
+      <BButton
+        size="sm"
+        class="me-2"
+        @click="selectAllRows"
+        >Select all</BButton
+      >
+      <BButton
+        size="sm"
+        class="me-2"
+        @click="clearSelected"
+        >Clear selected</BButton
+      >
+      <BButton
+        size="sm"
+        class="me-2"
+        @click="selectThirdRow"
+        >Select 3rd row</BButton
+      >
+      <BButton
+        size="sm"
+        @click="unselectThirdRow"
+        >Unselect 3rd row</BButton
+      >
     </p>
     <p>
       Selected Rows:<br />

--- a/apps/docs/src/docs/components/demo/TableRowStyles.vue
+++ b/apps/docs/src/docs/components/demo/TableRowStyles.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BTable :items="items" :fields="fields" :tbody-tr-class="rowClass" />
+    <BTable
+      :items="items"
+      :fields="fields"
+      :tbody-tr-class="rowClass"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableSimpleOverview.vue
+++ b/apps/docs/src/docs/components/demo/TableSimpleOverview.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BTableSimple hover small caption-top responsive>
+  <BTableSimple
+    hover
+    small
+    caption-top
+    responsive
+  >
     <caption>
       Items sold in August, grouped by Country and City:
     </caption>
@@ -79,7 +84,13 @@
     </BTbody>
     <BTfoot>
       <BTr>
-        <BTd colspan="7" variant="secondary" class="text-end"> Total Rows: <b>5</b> </BTd>
+        <BTd
+          colspan="7"
+          variant="secondary"
+          class="text-end"
+        >
+          Total Rows: <b>5</b>
+        </BTd>
       </BTr>
     </BTfoot>
   </BTableSimple>

--- a/apps/docs/src/docs/components/demo/TableSimpleStacked.vue
+++ b/apps/docs/src/docs/components/demo/TableSimpleStacked.vue
@@ -1,6 +1,11 @@
 <template>
   <!-- #region template -->
-  <BTableSimple hover small caption-top stacked>
+  <BTableSimple
+    hover
+    small
+    caption-top
+    stacked
+  >
     <caption>
       Items sold in August, grouped by Country and City:
     </caption>
@@ -35,21 +40,41 @@
     </BThead>
     <BTbody>
       <BTr>
-        <BTh rowspan="3" class="text-center">Belgium (3 Cities)</BTh>
-        <BTh stacked-heading="City" class="text-start">Antwerp</BTh>
+        <BTh
+          rowspan="3"
+          class="text-center"
+          >Belgium (3 Cities)</BTh
+        >
+        <BTh
+          stacked-heading="City"
+          class="text-start"
+          >Antwerp</BTh
+        >
         <BTd stacked-heading="Clothes: Trousers">56</BTd>
         <BTd stacked-heading="Clothes: Skirts">22</BTd>
         <BTd stacked-heading="Clothes: Dresses">43</BTd>
-        <BTd stacked-heading="Accessories: Bracelets" variant="success">72</BTd>
+        <BTd
+          stacked-heading="Accessories: Bracelets"
+          variant="success"
+          >72</BTd
+        >
         <BTd stacked-heading="Accessories: Rings">23</BTd>
       </BTr>
       <BTr>
         <BTh stacked-heading="City">Gent</BTh>
         <BTd stacked-heading="Clothes: Trousers">46</BTd>
-        <BTd stacked-heading="Clothes: Skirts" variant="warning">18</BTd>
+        <BTd
+          stacked-heading="Clothes: Skirts"
+          variant="warning"
+          >18</BTd
+        >
         <BTd stacked-heading="Clothes: Dresses">50</BTd>
         <BTd stacked-heading="Accessories: Bracelets">61</BTd>
-        <BTd stacked-heading="Accessories: Rings" variant="danger">15</BTd>
+        <BTd
+          stacked-heading="Accessories: Rings"
+          variant="danger"
+          >15</BTd
+        >
       </BTr>
       <BTr>
         <BTh stacked-heading="City">Brussels</BTh>
@@ -60,9 +85,17 @@
         <BTd stacked-heading="Accessories: Rings">28</BTd>
       </BTr>
       <BTr>
-        <BTh rowspan="2" class="text-center">The Netherlands (2 Cities)</BTh>
+        <BTh
+          rowspan="2"
+          class="text-center"
+          >The Netherlands (2 Cities)</BTh
+        >
         <BTh stacked-heading="City">Amsterdam</BTh>
-        <BTd stacked-heading="Clothes: Trousers" variant="success">89</BTd>
+        <BTd
+          stacked-heading="Clothes: Trousers"
+          variant="success"
+          >89</BTd
+        >
         <BTd stacked-heading="Clothes: Skirts">34</BTd>
         <BTd stacked-heading="Clothes: Dresses">69</BTd>
         <BTd stacked-heading="Accessories: Bracelets">85</BTd>
@@ -71,15 +104,29 @@
       <BTr>
         <BTh stacked-heading="City">Utrecht</BTh>
         <BTd stacked-heading="Clothes: Trousers">80</BTd>
-        <BTd stacked-heading="Clothes: Skirts" variant="danger">12</BTd>
+        <BTd
+          stacked-heading="Clothes: Skirts"
+          variant="danger"
+          >12</BTd
+        >
         <BTd stacked-heading="Clothes: Dresses">43</BTd>
         <BTd stacked-heading="Accessories: Bracelets">36</BTd>
-        <BTd stacked-heading="Accessories: Rings" variant="warning">19</BTd>
+        <BTd
+          stacked-heading="Accessories: Rings"
+          variant="warning"
+          >19</BTd
+        >
       </BTr>
     </BTbody>
     <BTfoot>
       <BTr>
-        <BTd colspan="7" variant="secondary" class="text-end"> Total Rows: <b>5</b> </BTd>
+        <BTd
+          colspan="7"
+          variant="secondary"
+          class="text-end"
+        >
+          Total Rows: <b>5</b>
+        </BTd>
       </BTr>
     </BTfoot>
   </BTableSimple>

--- a/apps/docs/src/docs/components/demo/TableSort.vue
+++ b/apps/docs/src/docs/components/demo/TableSort.vue
@@ -1,5 +1,9 @@
 <template>
-  <BTable :sort-by="[{key: 'first_name', order: 'desc'}]" :items="items" :fields="fields" />
+  <BTable
+    :sort-by="[{key: 'first_name', order: 'desc'}]"
+    :items="items"
+    :fields="fields"
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/TableSortBy.vue
+++ b/apps/docs/src/docs/components/demo/TableSortBy.vue
@@ -1,5 +1,9 @@
 <template>
-  <BTable v-model:sort-by="sortBy" :items="items" :fields="fields" />
+  <BTable
+    v-model:sort-by="sortBy"
+    :items="items"
+    :fields="fields"
+  />
   <div>sortBy = {{ JSON.stringify(sortBy) }}</div>
   <div>singleSortBy = {{ JSON.stringify(singleSortBy) }}</div>
 </template>

--- a/apps/docs/src/docs/components/demo/TableSortByCustom.vue
+++ b/apps/docs/src/docs/components/demo/TableSortByCustom.vue
@@ -4,7 +4,12 @@
     <BFormRadio value="lower">Lowercase First</BFormRadio>
     <BFormRadio value="upper">Uppercase First</BFormRadio>
   </BFormRadioGroup>
-  <BTable ref="my-table" v-model:sort-by="sortBy" :items="items" :fields="fields" />
+  <BTable
+    ref="my-table"
+    v-model:sort-by="sortBy"
+    :items="items"
+    :fields="fields"
+  />
   <div>sortBy = {{ JSON.stringify(sortBy) }}</div>
   <div>singleSortBy = {{ JSON.stringify(singleSortBy) }}</div>
 </template>

--- a/apps/docs/src/docs/components/demo/TableSortByMulti.vue
+++ b/apps/docs/src/docs/components/demo/TableSortByMulti.vue
@@ -1,5 +1,10 @@
 <template>
-  <BTable v-model:sort-by="multiSortBy" :items="sortItems" :fields="sortFields" :multisort="true" />
+  <BTable
+    v-model:sort-by="multiSortBy"
+    :items="sortItems"
+    :fields="sortFields"
+    :multisort="true"
+  />
   <div>sortBy = {{ JSON.stringify(multiSortBy) }}</div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableStacked.vue
+++ b/apps/docs/src/docs/components/demo/TableStacked.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BTable stacked :items="items" />
+    <BTable
+      stacked
+      :items="items"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TableStickyColumns.vue
+++ b/apps/docs/src/docs/components/demo/TableStickyColumns.vue
@@ -1,8 +1,16 @@
 <template>
   <div>
     <div class="mb-2">
-      <b-form-checkbox v-model="stickyHeader" inline>Sticky header</b-form-checkbox>
-      <b-form-checkbox v-model="noCollapse" inline>No border collapse</b-form-checkbox>
+      <b-form-checkbox
+        v-model="stickyHeader"
+        inline
+        >Sticky header</b-form-checkbox
+      >
+      <b-form-checkbox
+        v-model="noCollapse"
+        inline
+        >No border collapse</b-form-checkbox
+      >
     </div>
     <b-table
       :sticky-header="stickyHeader"

--- a/apps/docs/src/docs/components/demo/TableStickyHeaders.vue
+++ b/apps/docs/src/docs/components/demo/TableStickyHeaders.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
-    <BTable sticky-header :items="items" head-variant="light" />
+    <BTable
+      sticky-header
+      :items="items"
+      head-variant="light"
+    />
   </div>
 </template>
 

--- a/apps/docs/src/docs/components/demo/TabsActive.vue
+++ b/apps/docs/src/docs/components/demo/TabsActive.vue
@@ -5,9 +5,17 @@
     active-tab-class="font-weight-bold text-success"
     content-class="mt-3"
   >
-    <BTab title="First" active><p>I'm the first tab</p></BTab>
+    <BTab
+      title="First"
+      active
+      ><p>I'm the first tab</p></BTab
+    >
     <BTab title="Second"><p>I'm the second tab</p></BTab>
-    <BTab title="Disabled" disabled><p>I'm a disabled tab!</p></BTab>
+    <BTab
+      title="Disabled"
+      disabled
+      ><p>I'm a disabled tab!</p></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsAlignment.vue
+++ b/apps/docs/src/docs/components/demo/TabsAlignment.vue
@@ -1,9 +1,20 @@
 <template>
   <!-- #region template -->
-  <BTabs content-class="mt-3" align="center">
-    <BTab title="First" active><p>I'm the first tab</p></BTab>
+  <BTabs
+    content-class="mt-3"
+    align="center"
+  >
+    <BTab
+      title="First"
+      active
+      ><p>I'm the first tab</p></BTab
+    >
     <BTab title="Second"><p>I'm the second tab</p></BTab>
-    <BTab title="Disabled" disabled><p>I'm a disabled tab!</p></BTab>
+    <BTab
+      title="Disabled"
+      disabled
+      ><p>I'm a disabled tab!</p></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsBottom.vue
+++ b/apps/docs/src/docs/components/demo/TabsBottom.vue
@@ -1,8 +1,16 @@
 <template>
   <!-- #region template -->
   <BCard no-body>
-    <BTabs pills card end>
-      <BTab title="Tab 1" active><BCardText>Tab contents 1</BCardText></BTab>
+    <BTabs
+      pills
+      card
+      end
+    >
+      <BTab
+        title="Tab 1"
+        active
+        ><BCardText>Tab contents 1</BCardText></BTab
+      >
       <BTab title="Tab 2"><BCardText>Tab contents 2</BCardText></BTab>
     </BTabs>
   </BCard>

--- a/apps/docs/src/docs/components/demo/TabsCards.vue
+++ b/apps/docs/src/docs/components/demo/TabsCards.vue
@@ -2,7 +2,10 @@
   <!-- #region template -->
   <BCard no-body>
     <BTabs card>
-      <BTab title="Tab 1" active>
+      <BTab
+        title="Tab 1"
+        active
+      >
         <BCardText>Tab contents 1</BCardText>
       </BTab>
       <BTab title="Tab 2">

--- a/apps/docs/src/docs/components/demo/TabsCustom.vue
+++ b/apps/docs/src/docs/components/demo/TabsCustom.vue
@@ -3,13 +3,23 @@
   <BTabs>
     <BTab active>
       <template #title>
-        <BSpinner type="grow" small /> I'm <i>custom</i> <strong>title</strong>
+        <BSpinner
+          type="grow"
+          small
+        />
+        I'm <i>custom</i> <strong>title</strong>
       </template>
       <p class="p-3">Tab contents 1</p>
     </BTab>
 
     <BTab>
-      <template #title> <BSpinner type="border" small /> Tab 2 </template>
+      <template #title>
+        <BSpinner
+          type="border"
+          small
+        />
+        Tab 2
+      </template>
       <p class="p-3">Tab contents 2</p>
     </BTab>
   </BTabs>

--- a/apps/docs/src/docs/components/demo/TabsCustomLinks.vue
+++ b/apps/docs/src/docs/components/demo/TabsCustomLinks.vue
@@ -1,9 +1,24 @@
 <template>
   <BCard no-body>
-    <BTabs v-model:index="tabIndex" card>
-      <BTab title="Tab 1" :title-link-class="linkClass[0]">Tab contents 1</BTab>
-      <BTab title="Tab 2" :title-link-class="linkClass[1]">Tab contents 2</BTab>
-      <BTab title="Tab 3" :title-link-class="linkClass[2]">Tab contents 3</BTab>
+    <BTabs
+      v-model:index="tabIndex"
+      card
+    >
+      <BTab
+        title="Tab 1"
+        :title-link-class="linkClass[0]"
+        >Tab contents 1</BTab
+      >
+      <BTab
+        title="Tab 2"
+        :title-link-class="linkClass[1]"
+        >Tab contents 2</BTab
+      >
+      <BTab
+        title="Tab 3"
+        :title-link-class="linkClass[2]"
+        >Tab contents 3</BTab
+      >
     </BTabs>
   </BCard>
 </template>

--- a/apps/docs/src/docs/components/demo/TabsDynamic.vue
+++ b/apps/docs/src/docs/components/demo/TabsDynamic.vue
@@ -3,7 +3,11 @@
     <BCard no-body>
       <BTabs card>
         <!-- Render Tabs, supply a unique `key` to each tab -->
-        <BTab v-for="i in tabs" :key="'dyn-tab-' + i" :title="'Tab ' + i">
+        <BTab
+          v-for="i in tabs"
+          :key="'dyn-tab-' + i"
+          :title="'Tab ' + i"
+        >
           <template #title>
             {{ 'Tab ' + i }}
             <BButton

--- a/apps/docs/src/docs/components/demo/TabsEmpty.vue
+++ b/apps/docs/src/docs/components/demo/TabsEmpty.vue
@@ -3,8 +3,18 @@
   <BTabs>
     <!-- Add your b-tab components here -->
     <template #tabs-end>
-      <BNavItem href="#" role="presentation" @click="() => {}">Another tab</BNavItem>
-      <li role="presentation" class="nav-item align-self-center">Plain text</li>
+      <BNavItem
+        href="#"
+        role="presentation"
+        @click="() => {}"
+        >Another tab</BNavItem
+      >
+      <li
+        role="presentation"
+        class="nav-item align-self-center"
+      >
+        Plain text
+      </li>
     </template>
   </BTabs>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/TabsExternalControls.vue
+++ b/apps/docs/src/docs/components/demo/TabsExternalControls.vue
@@ -2,13 +2,21 @@
   <div>
     <!-- Tabs with card integration -->
     <BCard no-body>
-      <BTabs v-model:index="tabIndex" small card>
+      <BTabs
+        v-model:index="tabIndex"
+        small
+        card
+      >
         <BTab title="General">I'm the first fading tab</BTab>
         <BTab title="Edit profile">
           I'm the second tab
           <BCard>I'm the card in tab</BCard>
         </BTab>
-        <BTab title="Premium Plan" disabled>Sibzamini!</BTab>
+        <BTab
+          title="Premium Plan"
+          disabled
+          >Sibzamini!</BTab
+        >
         <BTab title="Info">I'm the last tab</BTab>
       </BTabs>
     </BCard>

--- a/apps/docs/src/docs/components/demo/TabsFill.vue
+++ b/apps/docs/src/docs/components/demo/TabsFill.vue
@@ -1,10 +1,21 @@
 <template>
   <!-- #region template -->
-  <BTabs content-class="mt-3" fill>
-    <BTab title="First" active><p>I'm the first tab</p></BTab>
+  <BTabs
+    content-class="mt-3"
+    fill
+  >
+    <BTab
+      title="First"
+      active
+      ><p>I'm the first tab</p></BTab
+    >
     <BTab title="Second"><p>I'm the second tab</p></BTab>
     <BTab title="Very, very long title"><p>I'm the tab with the very, very long title</p></BTab>
-    <BTab title="Disabled" disabled><p>I'm a disabled tab!</p></BTab>
+    <BTab
+      title="Disabled"
+      disabled
+      ><p>I'm a disabled tab!</p></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsJustified.vue
+++ b/apps/docs/src/docs/components/demo/TabsJustified.vue
@@ -1,10 +1,21 @@
 <template>
   <!-- #region template -->
-  <BTabs content-class="mt-3" justified>
-    <BTab title="First" active><p>I'm the first tab</p></BTab>
+  <BTabs
+    content-class="mt-3"
+    justified
+  >
+    <BTab
+      title="First"
+      active
+      ><p>I'm the first tab</p></BTab
+    >
     <BTab title="Second"><p>I'm the second tab</p></BTab>
     <BTab title="Very, very long title"><p>I'm the tab with the very, very long title</p></BTab>
-    <BTab title="Disabled" disabled><p>I'm a disabled tab!</p></BTab>
+    <BTab
+      title="Disabled"
+      disabled
+      ><p>I'm a disabled tab!</p></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsLazy.vue
+++ b/apps/docs/src/docs/components/demo/TabsLazy.vue
@@ -6,7 +6,11 @@
 
     <!-- This tabs content will not be mounted until the tab is shown -->
     <!-- and will be un-mounted when hidden -->
-    <BTab title="Lazy tab" lazy><BAlert :model-value="true">I'm lazy mounted!</BAlert></BTab>
+    <BTab
+      title="Lazy tab"
+      lazy
+      ><BAlert :model-value="true">I'm lazy mounted!</BAlert></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsLazyAll.vue
+++ b/apps/docs/src/docs/components/demo/TabsLazyAll.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BTabs content-class="mt-3" lazy>
+  <BTabs
+    content-class="mt-3"
+    lazy
+  >
     <BTab title="Tab 1"><BAlert :model-value="true">I'm lazy mounted!</BAlert></BTab>
     <BTab title="Tab 2"><BAlert :model-value="true">I'm lazy mounted too!</BAlert></BTab>
   </BTabs>

--- a/apps/docs/src/docs/components/demo/TabsOverview.vue
+++ b/apps/docs/src/docs/components/demo/TabsOverview.vue
@@ -1,9 +1,17 @@
 <template>
   <!-- #region template -->
   <BTabs content-class="mt-3">
-    <BTab title="First" active><p>I'm the first tab</p></BTab>
+    <BTab
+      title="First"
+      active
+      ><p>I'm the first tab</p></BTab
+    >
     <BTab title="Second"><p>I'm the second tab</p></BTab>
-    <BTab title="Disabled" disabled><p>I'm a disabled tab!</p></BTab>
+    <BTab
+      title="Disabled"
+      disabled
+      ><p>I'm a disabled tab!</p></BTab
+    >
   </BTabs>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TabsPictures.vue
+++ b/apps/docs/src/docs/components/demo/TabsPictures.vue
@@ -2,18 +2,39 @@
   <!-- #region template -->
   <BCard no-body>
     <BTabs card>
-      <BTab no-body title="Picture 1">
-        <BCardImg bottom src="https://picsum.photos/600/200/?image=21" alt="Image 21" />
+      <BTab
+        no-body
+        title="Picture 1"
+      >
+        <BCardImg
+          bottom
+          src="https://picsum.photos/600/200/?image=21"
+          alt="Image 21"
+        />
         <BCardFooter>Picture 1 footer</BCardFooter>
       </BTab>
 
-      <BTab no-body title="Picture 2">
-        <BCardImg bottom src="https://picsum.photos/600/200/?image=25" alt="Image 25" />
+      <BTab
+        no-body
+        title="Picture 2"
+      >
+        <BCardImg
+          bottom
+          src="https://picsum.photos/600/200/?image=25"
+          alt="Image 25"
+        />
         <BCardFooter>Picture 2 footer</BCardFooter>
       </BTab>
 
-      <BTab no-body title="Picture 3">
-        <BCardImg bottom src="https://picsum.photos/600/200/?image=26" alt="Image 26" />
+      <BTab
+        no-body
+        title="Picture 3"
+      >
+        <BCardImg
+          bottom
+          src="https://picsum.photos/600/200/?image=26"
+          alt="Image 26"
+        />
         <BCardFooter>Picture 3 footer</BCardFooter>
       </BTab>
 

--- a/apps/docs/src/docs/components/demo/TabsPills.vue
+++ b/apps/docs/src/docs/components/demo/TabsPills.vue
@@ -1,8 +1,15 @@
 <template>
   <!-- #region template -->
   <BCard no-body>
-    <BTabs pills card>
-      <BTab title="Tab 1" active><BCardText>Tab contents 1</BCardText></BTab>
+    <BTabs
+      pills
+      card
+    >
+      <BTab
+        title="Tab 1"
+        active
+        ><BCardText>Tab contents 1</BCardText></BTab
+      >
       <BTab title="Tab 2"><BCardText>Tab contents 2</BCardText></BTab>
     </BTabs>
   </BCard>

--- a/apps/docs/src/docs/components/demo/TabsVertical.vue
+++ b/apps/docs/src/docs/components/demo/TabsVertical.vue
@@ -1,8 +1,16 @@
 <template>
   <!-- #region template -->
   <BCard no-body>
-    <BTabs pills card vertical>
-      <BTab title="Tab 1" active><BCardText>Tab contents 1</BCardText></BTab>
+    <BTabs
+      pills
+      card
+      vertical
+    >
+      <BTab
+        title="Tab 1"
+        active
+        ><BCardText>Tab contents 1</BCardText></BTab
+      >
       <BTab title="Tab 2"><BCardText>Tab contents 2</BCardText></BTab>
       <BTab title="Tab 3"><BCardText>Tab contents 3</BCardText></BTab>
     </BTabs>

--- a/apps/docs/src/docs/components/demo/TabsVerticalEnd.vue
+++ b/apps/docs/src/docs/components/demo/TabsVerticalEnd.vue
@@ -1,8 +1,17 @@
 <template>
   <!-- #region template -->
   <BCard no-body>
-    <BTabs pills card vertical end>
-      <BTab title="Tab 1" active><BCardText>Tab contents 1</BCardText></BTab>
+    <BTabs
+      pills
+      card
+      vertical
+      end
+    >
+      <BTab
+        title="Tab 1"
+        active
+        ><BCardText>Tab contents 1</BCardText></BTab
+      >
       <BTab title="Tab 2"><BCardText>Tab contents 2</BCardText></BTab>
       <BTab title="Tab 3"><BCardText>Tab contents 3</BCardText></BTab>
     </BTabs>

--- a/apps/docs/src/docs/components/demo/TabsVerticalWidth.vue
+++ b/apps/docs/src/docs/components/demo/TabsVerticalWidth.vue
@@ -1,8 +1,17 @@
 <template>
   <!-- #region template -->
   <BCard no-body>
-    <BTabs pills card vertical nav-wrapper-class="w-50">
-      <BTab title="Tab 1" active><BCardText>Tab contents 1</BCardText></BTab>
+    <BTabs
+      pills
+      card
+      vertical
+      nav-wrapper-class="w-50"
+    >
+      <BTab
+        title="Tab 1"
+        active
+        ><BCardText>Tab contents 1</BCardText></BTab
+      >
       <BTab title="Tab 2"><BCardText>Tab contents 2</BCardText></BTab>
       <BTab title="Tab 3"><BCardText>Tab contents 3</BCardText></BTab>
     </BTabs>

--- a/apps/docs/src/docs/components/demo/TextareaDebounce.vue
+++ b/apps/docs/src/docs/components/demo/TextareaDebounce.vue
@@ -1,5 +1,10 @@
 <template>
-  <BFormTextarea id="textarea-debounce" v-model="textDebounce" rows="3" debounce="500" />
+  <BFormTextarea
+    id="textarea-debounce"
+    v-model="textDebounce"
+    rows="3"
+    debounce="500"
+  />
 
   <pre class="mt-3 mb-0">{{ textDebounce }}</pre>
 </template>

--- a/apps/docs/src/docs/components/demo/TextareaDisplayedRows.vue
+++ b/apps/docs/src/docs/components/demo/TextareaDisplayedRows.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BFormTextarea id="textarea-rows" placeholder="Tall textarea" rows="8" />
+  <BFormTextarea
+    id="textarea-rows"
+    placeholder="Tall textarea"
+    rows="8"
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TextareaFloatingLabels.vue
+++ b/apps/docs/src/docs/components/demo/TextareaFloatingLabels.vue
@@ -1,5 +1,8 @@
 <template>
-  <BFormFloatingLabel label="type something" label-for="textarea-floatinglabel">
+  <BFormFloatingLabel
+    label="type something"
+    label-for="textarea-floatinglabel"
+  >
     <BFormTextarea
       id="textarea-floatinglabel"
       v-model="textFloatingLabel"

--- a/apps/docs/src/docs/components/demo/TextareaFormatter.vue
+++ b/apps/docs/src/docs/components/demo/TextareaFormatter.vue
@@ -30,7 +30,12 @@
     />
   </BFormGroup>
 
-  <p class="mb-0" style="white-space: pre-line"><b>Value:</b> {{ textFormatter2 }}</p>
+  <p
+    class="mb-0"
+    style="white-space: pre-line"
+  >
+    <b>Value:</b> {{ textFormatter2 }}
+  </p>
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/TextareaOverview.vue
+++ b/apps/docs/src/docs/components/demo/TextareaOverview.vue
@@ -1,5 +1,9 @@
 <template>
-  <BFormTextarea v-model="textEx" placeholder="Enter something..." rows="3" />
+  <BFormTextarea
+    v-model="textEx"
+    placeholder="Enter something..."
+    rows="3"
+  />
 
   <pre class="mt-3 mb-0">{{ textEx }}</pre>
 </template>

--- a/apps/docs/src/docs/components/demo/TextareaProperties.vue
+++ b/apps/docs/src/docs/components/demo/TextareaProperties.vue
@@ -7,7 +7,12 @@
     rows="3"
   />
 
-  <button class="btn btn-primary mt-1" @click="selectText">Select text</button>
+  <button
+    class="btn btn-primary mt-1"
+    @click="selectText"
+  >
+    Select text
+  </button>
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/TextareaReadonly.vue
+++ b/apps/docs/src/docs/components/demo/TextareaReadonly.vue
@@ -1,5 +1,9 @@
 <template>
-  <BFormTextarea id="textarea-plaintext" plaintext :model-value="textReadOnly" />
+  <BFormTextarea
+    id="textarea-plaintext"
+    plaintext
+    :model-value="textReadOnly"
+  />
 </template>
 
 <script setup lang="ts">

--- a/apps/docs/src/docs/components/demo/TextareaResizeHandle.vue
+++ b/apps/docs/src/docs/components/demo/TextareaResizeHandle.vue
@@ -1,5 +1,10 @@
 <template>
   <!-- #region template -->
-  <BFormTextarea id="textarea-no-resize" placeholder="Fixed height textarea" rows="3" no-resize />
+  <BFormTextarea
+    id="textarea-no-resize"
+    placeholder="Fixed height textarea"
+    rows="3"
+    no-resize
+  />
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/TextareaSizing.vue
+++ b/apps/docs/src/docs/components/demo/TextareaSizing.vue
@@ -5,7 +5,11 @@
       <label for="textarea-small">Small:</label>
     </BCol>
     <BCol sm="10">
-      <BFormTextarea id="textarea-small" size="sm" placeholder="Small textarea" />
+      <BFormTextarea
+        id="textarea-small"
+        size="sm"
+        placeholder="Small textarea"
+      />
     </BCol>
   </BRow>
   <BRow class="mt-2">
@@ -13,7 +17,10 @@
       <label for="textarea-default">Default:</label>
     </BCol>
     <BCol sm="10">
-      <BFormTextarea id="textarea-default" placeholder="Default textarea" />
+      <BFormTextarea
+        id="textarea-default"
+        placeholder="Default textarea"
+      />
     </BCol>
   </BRow>
   <BRow class="mt-2">
@@ -21,7 +28,11 @@
       <label for="textarea-large">Large:</label>
     </BCol>
     <BCol sm="10">
-      <BFormTextarea id="textarea-large" size="lg" placeholder="Large textarea" />
+      <BFormTextarea
+        id="textarea-large"
+        size="lg"
+        placeholder="Large textarea"
+      />
     </BCol>
   </BRow>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/demo/AlertAfter.vue
+++ b/apps/docs/src/docs/demo/AlertAfter.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BAlert :model-value="true" variant="primary">A simple primary alert—check it out!</BAlert>
+  <BAlert
+    :model-value="true"
+    variant="primary"
+    >A simple primary alert—check it out!</BAlert
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/demo/AlertBefore.vue
+++ b/apps/docs/src/docs/demo/AlertBefore.vue
@@ -1,5 +1,9 @@
 <template>
   <!-- #region template -->
-  <BAlert variant="primary" show>A simple primary alert—check it out!</BAlert>
+  <BAlert
+    variant="primary"
+    show
+    >A simple primary alert—check it out!</BAlert
+  >
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/demo/CheckboxGroupMigration.vue
+++ b/apps/docs/src/docs/demo/CheckboxGroupMigration.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <BFormCheckboxGroup v-model="model" :options="options">
+    <BFormCheckboxGroup
+      v-model="model"
+      :options="options"
+    >
       <template #option="{value}">
         {{ (value as Name).first }} <b>{{ (value as Name).last }}</b>
       </template>

--- a/apps/docs/src/docs/demo/RadioGroupMigration.vue
+++ b/apps/docs/src/docs/demo/RadioGroupMigration.vue
@@ -1,7 +1,12 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <div>
-    <BFormGroup class="form-group" label="Color" label-for="color-group" label-class="mb-1">
+    <BFormGroup
+      class="form-group"
+      label="Color"
+      label-for="color-group"
+      label-class="mb-1"
+    >
       <BFormRadioGroup
         id="color-group"
         v-model="model"

--- a/apps/docs/src/docs/demo/SyncAfter.vue
+++ b/apps/docs/src/docs/demo/SyncAfter.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- #region template -->
-  <BFormCheckbox v-model="checked" v-model:indeterminate="indeterminate">
+  <BFormCheckbox
+    v-model="checked"
+    v-model:indeterminate="indeterminate"
+  >
     Click me to see what happens
   </BFormCheckbox>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/demo/SyncBefore.vue
+++ b/apps/docs/src/docs/demo/SyncBefore.vue
@@ -1,7 +1,9 @@
 <!-- eslint-disable vue/no-deprecated-v-bind-sync -->
 <template>
   <!-- #region template -->
-  <BFormCheckbox v-model="checked" :indeterminate.sync="indeterminate"
+  <BFormCheckbox
+    v-model="checked"
+    :indeterminate.sync="indeterminate"
     >Click me to see what happens</BFormCheckbox
   >
   <!-- #endregion template -->

--- a/apps/docs/src/docs/reference/demo/VariantInteractions.vue
+++ b/apps/docs/src/docs/reference/demo/VariantInteractions.vue
@@ -15,13 +15,24 @@
   <BRow
     ><BCol
       >Set 'text-variant' and 'bg-variant':
-      <BBadge text-variant="primary" bg-variant="danger"> testing </BBadge></BCol
+      <BBadge
+        text-variant="primary"
+        bg-variant="danger"
+      >
+        testing
+      </BBadge></BCol
     ></BRow
   >
   <BRow
     ><BCol
       >Set all three - 'variant' is overridden by 'bg-variant' and 'text-variant':
-      <BBadge text-variant="primary" bg-variant="danger" variant="success"> testing </BBadge></BCol
+      <BBadge
+        text-variant="primary"
+        bg-variant="danger"
+        variant="success"
+      >
+        testing
+      </BBadge></BCol
     ></BRow
   >
   <!-- #endregion template -->


### PR DESCRIPTION
# Describe the PR

Change the prettier settings for the examples to enforce single-attribute-per-line. This is generally more readable for examples. It also narrows most of the examples to make them more readable on small screens. I opted for not changing the print-width in prettier, since it didn't do a lot for the smaller screens and tended to make the example less readable on even medium sized-screens (like a laptop screen). But I can do that easily if we want to give it a shot.

Normally I have a high bar for formatting changes, but since I've already done a refactor on all of the affected examples, it doesn't affect who gets pointed to with git blame.

## Small replication

Most of the examples in the docs that have been refactored into their own files. Fixes #2717

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
