### PR TITLE
docs: fix on-this-page for composable and directives pages

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -203,7 +203,7 @@ const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
 const target = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_target')
 
 const {current: activeId, list: items} = useScrollspy(content, target, {
-  contentQuery: ':scope > div > [id], #component-reference, .component-reference h3',
+  contentQuery: ':scope h1, :scope > div > [id], #component-reference, .component-reference h3',
   targetQuery: ':scope [href]',
   rootMargin: '0px 0px -25%',
   manual: true,


### PR DESCRIPTION
# Describe the PR

When I wrote the code to drive the OTP sidebar off of the scrollSpy results, I missed the fact that the directives and composible pages "hid" the `H1` header in a couple of layers of divs. This broke the whole thing for those pages. I'm going to spend some time soon cleaning up (and hopefully unifying and simplifying) how we handle the docs for components, directives, and composables, but this fixes the immediate bug.

## Small replication

Directive and composable document pages.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
