### PR TITLE
feat(BDropdown): allow setting icon prop on nested BButton

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/BDropdown.vue
@@ -16,6 +16,7 @@
       :aria-expanded="props.split ? undefined : showRef"
       :aria-haspopup="props.split ? undefined : 'menu'"
       :href="props.split ? props.splitHref : undefined"
+      :icon="props.icon"
       :to="props.split && props.splitTo ? props.splitTo : undefined"
       @click="onSplitClick"
     >
@@ -115,6 +116,7 @@ const _props = withDefaults(defineProps<Omit<BDropdownProps, 'modelValue'>>(), {
   teleportDisabled: false,
   disabled: false,
   floatingMiddleware: undefined,
+  icon: false,
   id: undefined,
   initialAnimation: false,
   isNav: false,

--- a/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BDropdown/dropdown.spec.ts
@@ -254,6 +254,20 @@ describe('dropdown', () => {
     expect($bbutton.props('href')).toBe('/abc')
   })
 
+  it('first child BButton prop icon is false by default', () => {
+    const wrapper = mount(BDropdown)
+    const $bbutton = wrapper.getComponent(BButton)
+    expect($bbutton.props('icon')).toBe(false)
+  })
+
+  it('first child BButton prop icon is true when prop icon is true', () => {
+    const wrapper = mount(BDropdown, {
+      props: {icon: true},
+    })
+    const $bbutton = wrapper.getComponent(BButton)
+    expect($bbutton.props('icon')).toBe(true)
+  })
+
   it('first child BButton renders button-content slot', () => {
     const wrapper = mount(BDropdown, {
       slots: {'button-content': 'foobar'},

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -1202,6 +1202,7 @@ export interface BDropdownProps extends TeleporterProps, ShowHideProps {
   boundaryPadding?: Padding
   disabled?: boolean
   floatingMiddleware?: Middleware[]
+  icon?: boolean
   id?: string
   isNav?: boolean
   menuClass?: ClassValue


### PR DESCRIPTION
# Describe the PR

BLink and BButton have an `icon` prop which adds an `icon-link` class onto the element, enhancing their appearance when an icon is present ([docs](https://getbootstrap.com/docs/5.3/helpers/icon-link/)). BDropdown (and components that extend it, such as BNavItemDropdown) wraps a BButton but provides no way to set the icon prop on it nor add custom classes. This PR adds the `icon` prop to BDropdown (and by extension BNavItemDropdown), allowing the icon prop to be set on the nested BButton.

## Small replication

```html
    <BNavbarNav>
      <BNavItemDropdown :icon="true">
        <template #button-content>
          <svg
            xmlns="http://www.w3.org/2000/svg"
            width="16"
            height="16"
            fill="currentColor"
            class="bi bi-person-circle"
            viewBox="0 0 16 16"
          >
            <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0" />
            <path
              fill-rule="evenodd"
              d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"
            />
          </svg>
          <span>User</span>
        </template>
        <BDropdownItem>Logout</BDropdownItem>
      </BNavItemDropdown>
    </BNavbarNav>
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [x] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
