### PR TITLE
docs(BFormRating): Parity pass

### DIFF
--- a/apps/docs/src/data/components/FormRating.data.ts
+++ b/apps/docs/src/data/components/FormRating.data.ts
@@ -15,10 +15,21 @@ export default {
             description:
               'CSS color to use instead of variant. Accepts either a HEX or RGB/RGBA string',
           },
+          inline: {
+            type: 'boolean',
+            default: 'false',
+            description:
+              'When `true` renders as an inline element rather than a block (100% width) element',
+          },
           modelValue: {
             type: 'number',
             default: 0,
             description: 'The current rating value (supports v-model two-way binding).',
+          },
+          noBorder: {
+            type: 'boolean',
+            default: 'false',
+            description: 'When `true`, removes the border around the rating component',
           },
           precision: {
             type: 'number',
@@ -31,7 +42,12 @@ export default {
             default: 'false',
             description:
               'When `true` makes the rating readonly. When `true`, fractional ratings values are allowed (half icons will be shown)',
-          }, //
+          },
+          showClear: {
+            type: 'boolean',
+            default: 'false',
+            description: 'When `true`, shows a clear button to reset the rating',
+          },
           showValue: {
             type: 'boolean',
             default: 'false',
@@ -43,57 +59,18 @@ export default {
             description:
               'When set to `true` and prop `show-value` is `true`, includes the maximum star rating possible in the formatted value',
           },
+          size: {
+            type: "'sm' | 'lg' | string",
+            default: '1rem',
+            description:
+              "Icon size: accepts CSS units (e.g. '1.5rem', '24px') or the presets 'sm' (.875rem) and 'lg' (1.25rem); defaults to 1rem.",
+          },
           stars: {
             type: 'number',
             default: '5',
             description: 'The number of stars to show. Minimum value is `3`, default is `5`',
           },
-          variant: {
-            type: 'string',
-            default: undefined,
-            description: 'Applies one of the Bootstrap theme color variants to the component',
-          },
-          size: {
-            type: 'string',
-            default: '1rem',
-            description:
-              "Icon size: accepts CSS units (e.g. '1.5rem', '24px') or the presets 'sm' (.875rem) and 'lg' (1.25rem); defaults to 1rem.",
-          },
-          noBorder: {
-            type: 'boolean',
-            default: 'false',
-            description: 'When `true`, removes the border around the rating component',
-          },
-          showClear: {
-            type: 'boolean',
-            default: 'false',
-            description: 'When `true`, shows a clear button to reset the rating',
-          },
-          iconFull: {
-            type: 'string',
-            default: undefined,
-            description:
-              'Icon name or component to use for filled stars when using custom slot rendering',
-          },
-          iconHalf: {
-            type: 'string',
-            default: undefined,
-            description:
-              'Icon name or component to use for half-filled stars when using custom slot rendering',
-          },
-          iconEmpty: {
-            type: 'string',
-            default: undefined,
-            description:
-              'Icon name or component to use for empty stars when using custom slot rendering',
-          },
-          inline: {
-            type: 'boolean',
-            default: 'false',
-            description:
-              'When `true` renders as an inline element rather than a block (100% width) element',
-          },
-          ...pick(buildCommonProps(), ['form', 'id', 'name']),
+          ...pick(buildCommonProps(), ['id', 'variant']),
         } satisfies Record<keyof BvnComponentProps['BFormRating'], PropertyReference>,
       },
       emits: [
@@ -115,6 +92,23 @@ export default {
           name: 'default',
           description:
             'Custom renderer for each star. Receives `starIndex`, `isFilled`, `isHalf`, `iconFull`, `iconHalf`, and `iconEmpty` as slot-scope props.',
+          scope: [
+            {
+              prop: 'starIndex',
+              type: 'number',
+              description: 'The index of the star being rendered (0-based index)',
+            },
+            {
+              prop: 'isFilled',
+              type: 'boolean',
+              description: 'When `true`, the star is filled (selected)',
+            },
+            {
+              prop: 'isHalf',
+              type: 'boolean',
+              description: 'When `true`, the star is half-filled (partially selected)',
+            },
+          ],
         },
       ],
     },

--- a/apps/docs/src/data/components/FormRating.data.ts
+++ b/apps/docs/src/data/components/FormRating.data.ts
@@ -67,7 +67,7 @@ export default {
           },
           stars: {
             type: 'number',
-            default: '5',
+            default: 5,
             description: 'The number of stars to show. Minimum value is `3`, default is `5`',
           },
           ...pick(buildCommonProps(), ['id', 'variant']),
@@ -90,8 +90,7 @@ export default {
       slots: [
         {
           name: 'default',
-          description:
-            'Custom renderer for each star. Receives `starIndex`, `isFilled`, `isHalf`, `iconFull`, `iconHalf`, and `iconEmpty` as slot-scope props.',
+          description: 'Custom renderer for each star.',
           scope: [
             {
               prop: 'starIndex',

--- a/apps/docs/src/docs/components/form-rating.md
+++ b/apps/docs/src/docs/components/form-rating.md
@@ -169,10 +169,10 @@ optional displayed value and the left-to-right or right-to-left orientation of t
 
 ## Implementation notes
 
-The ratings control uses the Bootstrap v4 `form-control*`, `d-*` (display), `border-*` and
+The ratings control uses the Bootstrap v5 `form-control*`, `d-*` (display), and
 `text-{variant}` classes, as well as BootstrapVue's custom CSS for proper styling.
 
-The root element of the control is an `<output>` element, which allows a `<label>` element to be
+<NotYetImplemented/>The root element of the control is an `<output>` element, which allows a `<label>` element to be
 associated with it.
 
 ## Accessibility

--- a/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
@@ -96,7 +96,7 @@ const _props = withDefaults(defineProps<Omit<BFormRatingProps, 'modelValue'>>(),
 })
 const props = useDefaults(_props, 'BFormRating')
 
-const computedId = useId(() => props.id, 'input')
+const computedId = useId(() => props.id, 'form-rating')
 
 const computedClasses = computed(() => ({
   'is-readonly': props.readonly,

--- a/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormRating/BFormRating.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    :id="computedId"
     :class="computedClasses"
     role="slider"
     :aria-valuemin="0"
@@ -77,21 +78,25 @@
 import {computed, defineSlots, ref} from 'vue'
 import {useDefaults} from '../../composables/useDefaults'
 import type {BFormRatingProps} from '../../types/ComponentProps'
+import {useId} from '../../composables/useId'
 
 const _props = withDefaults(defineProps<Omit<BFormRatingProps, 'modelValue'>>(), {
-  readonly: false,
-  variant: '',
   color: '',
-  stars: 5,
+  id: undefined,
+  inline: false,
+  noBorder: false,
   precision: 0,
+  readonly: false,
   showClear: false,
   showValue: false,
   showValueMax: false,
   size: '1rem',
-  noBorder: false,
-  inline: false,
+  stars: 5,
+  variant: undefined,
 })
 const props = useDefaults(_props, 'BFormRating')
+
+const computedId = useId(() => props.id, 'input')
 
 const computedClasses = computed(() => ({
   'is-readonly': props.readonly,

--- a/packages/bootstrap-vue-next/src/types/ComponentProps.ts
+++ b/packages/bootstrap-vue-next/src/types/ComponentProps.ts
@@ -355,6 +355,8 @@ export interface BFormRadioGroupProps {
 }
 export interface BFormRatingProps {
   color?: string
+  id?: string
+  inline?: boolean
   modelValue?: number
   noBorder?: boolean
   precision?: number
@@ -374,10 +376,6 @@ export interface BFormRatingProps {
     | 'light'
     | 'dark'
     | string
-  iconFull?: string
-  iconHalf?: string
-  iconEmpty?: string
-  inline?: boolean
 }
 
 export interface BFormSelectProps {


### PR DESCRIPTION
# Describe the PR

Parity pass for BFormRating
- Corrected small issues in docs
- Updated parity spreadsheet
- Added `id` prop
- Sorted props and defaults alphabetically
- Removed deprecated `icon*` props

## Small replication

See the docs

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new options to the rating component, including support for inline display, borderless style, and a clear button.
	- Introduced the ability to assign a custom ID and variant to the rating component.

- **Improvements**
	- Enhanced documentation to reflect usage of Bootstrap 5 classes and provided more detailed slot property descriptions.
	- Improved accessibility by ensuring the component root has a stable and consistent ID.

- **Removals**
	- Removed icon customization options for the rating component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->