### PR TITLE
docs: fix typo in breadcrumb documentation

### DIFF
--- a/apps/docs/src/docs/composables/useBreadcrumb.md
+++ b/apps/docs/src/docs/composables/useBreadcrumb.md
@@ -2,7 +2,7 @@
 
 <div class="lead mb-5">
 
-`useBreadcrumb` is a helper utility for the `BBreadcrumb` component. It provides a **globally** changable context so you can modify a breadcrumb. It should be noted that the breacrumb component will automatically use the global context by default. `useBreadcrumb` is shared globally, one modification to the state will be recognized throughout the app. As noted in the BBreadcrumb documentation, the items prop for the component takes precedence over `useBreadcrumb`
+`useBreadcrumb` is a helper utility for the `BBreadcrumb` component. It provides a **globally** changable context so you can modify a breadcrumb. It should be noted that the breadcrumb component will automatically use the global context by default. `useBreadcrumb` is shared globally, one modification to the state will be recognized throughout the app. As noted in the BBreadcrumb documentation, the items prop for the component takes precedence over `useBreadcrumb`
 
 </div>
 


### PR DESCRIPTION
# Describe the PR

Fix a small typo.

**What kind of change does this PR introduce?** (check at least one)

- [x] Documentation update - `docs(...)`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the documentation for the `useBreadcrumb` utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->