### PR TITLE
feat(input fields): expose method onBlur to be able to manually stop debouncing (draft)

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
@@ -101,6 +101,7 @@ const computedClasses = computed(() => {
 defineExpose({
   blur,
   element: input,
+  flushDebounce: onBlur,
   focus,
 })
 </script>

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
@@ -114,6 +114,7 @@ const computedStyles = computed<CSSProperties>(() => ({
 defineExpose({
   blur,
   element: input,
+  flushDebounce: onBlur,
   focus,
 })
 </script>


### PR DESCRIPTION
Now that issue #2721 has been merged, I've been thinking about situations where it would be useful to be able to manually stop debouncing (while editing a field's contents).
Let's say we're using a b-form-input field with a high debounce value (e.g. 2 seconds, to make it easier to observe the issue) and we want to be able to submit a form by pressing Enter in that active field.
In this case, the value sent by the form might be incomplete due to the debounce delay on the field's model value.

## Small replication

You can observe the problem in this [demo](https://stackblitz.com/edit/github-huqpsoqb-m4undscv).

![chrome-capture-2025-6-23](https://github.com/user-attachments/assets/6d3f80cb-c599-464b-9b6a-aa2ace3dde05)

The simplest fix is to expose the "onBlur" method (calling it "flushDebounce" for example) and add the following code to the b-form-input field:
```
<form ref="myForm" @submit.stop.prevent="...">
    <b-form-input ref="myInput" :debounce="2000" v-model="inputValue"
      @keydown.enter.prevent="
          $refs.myInput.flushDebounce($event);
          $refs.myForm.dispatchEvent(new Event('submit', { cancelable: true }));
      "
     />
</form>
```

You can try the fix in this [demo](https://stackblitz.com/edit/github-huqpsoqb-m4undscv) (using a patched version of bootstrap-vue-next).

I'm leaving this issue as a draft for now, as I'm not sure if my patch is the ideal solution to this type of problem. Any suggestions are welcome.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [X] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
