### PR TITLE
docs(migration): add component aliases guidelines

### DIFF
--- a/apps/docs/src/data/components/tabs.data.ts
+++ b/apps/docs/src/data/components/tabs.data.ts
@@ -85,7 +85,7 @@ export default {
             type: 'boolean',
             default: false,
             description:
-              "When set to true, renders the tabs the the appropriate styles to be placed into a 'b-card'",
+              "When set to true, renders the tabs with the appropriate styles to be placed into a 'b-card'",
           },
           contentClass: {
             type: 'ClassValue',

--- a/apps/docs/src/docs/components/form-spinbutton.md
+++ b/apps/docs/src/docs/components/form-spinbutton.md
@@ -122,7 +122,7 @@ The following keyboard controls are available when the spin button is focused:
 - <kbd>PageUp</kbd> Increases the value by the step amount times the `repeat-step-multiplier` amount
 - <kbd>PageDown</kbd> Decreases the value by the step amount times the `repeat-step-multiplier` amount
 
-Note the the `repeat-delay`, `repeat-threshold` and `repeat-interval` only applies to the <kbd>ArrowUp</kbd> or <kbd>ArrowDown</kbd> keys
+Note that the `repeat-delay`, `repeat-threshold` and `repeat-interval` only apply to the <kbd>ArrowUp</kbd> or <kbd>ArrowDown</kbd> keys
 
 <ComponentReference :data="data" />
 

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -49,9 +49,9 @@ For any deprecated feature, especially the last case listed above, please feel f
 ## Sync modifier
 
 A number of components in `bootstrap-vue` use `v-bind`'s `.sync` modifier. This modifier has been replaced by properties
-on the the model (generally named models).
+on the model (generally named models).
 
-For instance, in order to two-way bind to the `indeterminate` property in `BFormCheckBox` you `v-bind` to the the model
+For instance, in order to two-way bind to the `indeterminate` property in `BFormCheckBox` you `v-bind` to the model
 named `indeterminate` rather than adding the sync modifier to the `indeterminate` property:
 
 <<< FRAGMENT ./demo/SyncBefore.vue#template{vue-html}
@@ -146,6 +146,47 @@ If you're passing user data, this still opens your code uop to <a class="alert-l
 user supplied string, but the BootstrapVueNext library isn't adding an extra layer of abstraction to this vulnerability.
 
 <<< DEMO ./demo/RadioGroupMigration.vue
+
+## Component aliases
+
+BootstrapVue had a number of component aliases — for instance, `<b-btn>` was an alias for `<b-button>`.
+BootstrapVueNext does not support these aliases by default, so you must use the canonical component names.
+
+To define aliases, you can use the [`BootstrapVueNextResolver`'s `aliases` option](/docs#aliasing).
+
+The table below lists each BootstrapVue alias and its BootstrapVueNext replacement:
+
+| BootstrapVue                                               | BootstrapVueNext      |
+| ---------------------------------------------------------- | --------------------- |
+| `b-btn`                                                    | `BButton`             |
+| `b-btn-group`                                              | `BButtonGroup`        |
+| `b-btn-toolbar`                                            | `BButtonToolbar`      |
+| `b-dd`                                                     | `BDropdown`           |
+| `b-dd-item`                                                | `BDropdownItem`       |
+| `b-dropdown-item-btn`, `b-dd-item-button`, `b-dd-item-btn` | `BDropdownItemButton` |
+| `b-dd-divider`                                             | `BDropdownDivider`    |
+| `b-dd-text`                                                | `BDropdownText`       |
+| `b-dd-form`                                                | `BDropdownForm`       |
+| `b-dd-group`                                               | `BDropdownGroup`      |
+| `b-dd-header`                                              | `BDropdownHeader`     |
+| `b-datalist`                                               | `BFormDatalist`       |
+| `b-checkbox`, `b-check`                                    | `BFormCheckbox`       |
+| `b-datepicker`                                             | `BFormDatepicker`     |
+| `b-file`                                                   | `BFormFile`           |
+| `b-input`                                                  | `BFormInput`          |
+| `b-radio-group`                                            | `BFormRadioGroup`     |
+| `b-rating`                                                 | `BFormRating`         |
+| `b-select`                                                 | `BFormSelect`         |
+| `b-select-option`                                          | `BFormSelectOption`   |
+| `b-option-group`                                           | `BFormOptionGroup`    |
+| `b-tags`                                                   | `BFormTags`           |
+| `b-tag`                                                    | `BFormTag`            |
+| `b-textarea`                                               | `BFormTextarea`       |
+| `b-timepicker`                                             | `BFormTimepicker`     |
+| `b-nav-item-dd`, `b-nav-dropdown`, `b-nav-dd`              | `BNavItemDropdown`    |
+| `b-nav-toggle`                                             | `BNavbarToggle`       |
+
+Note: While BootstrapVueNext recommends using Vue 3 naming convention `BButton` it is still possible to use `b-button`.
 
 ## Components
 
@@ -308,7 +349,7 @@ The `html` prop has been deprecated, use the `button-content`.
 
 `$root` instance events `bv::dropdown::hide` and `bv::dropdown::show` are deprecated.
 
-The the boolean argument to control returning focus to the toggle button on the `hide` scoped property of the default slot is deprecated.
+The boolean argument to control returning focus to the toggle button on the `hide` scoped property of the default slot is deprecated.
 It is less important in BootstrapVueNext since bootstrap v5 by default doesn't have the focus ring that v4 has.
 
 See [Show and Hide](#show-and-hide) shared properties.
@@ -374,7 +415,7 @@ documentation for more info.
 
 #### BForm Components
 
-`Vue 3` changed the the way that `v-model` binding works and in the process changed the guidance
+`Vue 3` changed the way that `v-model` binding works and in the process changed the guidance
 when naming the main model property and events for the primary model. `bootstrap-vue-next` follows
 this guidance, which affects all of the wrappers for form input. If you're looking for the `value`
 property or the `change` and `input` events, you'll find that functionality in the `modelValue`
@@ -618,7 +659,7 @@ See the [v-html](#v-html) section for information on deprecation of the `html` p
 
 ### BNavbar
 
-The `type` prop is deprecated. Use the the `v-b-color-mode` directive or `useColorMode` composable instead. Details in our [docs](/components/navbar#color-scheme)
+The `type` prop is deprecated. Use the `v-b-color-mode` directive or `useColorMode` composable instead. Details in our [docs](/components/navbar#color-scheme)
 
 #### BNavbarNav
 
@@ -690,7 +731,7 @@ See the [v-html](#v-html) section for information on deprecation of the `label-h
 
 `<BSkeleton*>` components have been replaced by the more appropriately named `<BPlaceholder*>` components.
 
-`<BSkeletonIcon>` is deprecated along with the rest of the the BootstrapVue icon support. See our
+`<BSkeletonIcon>` is deprecated along with the rest of the BootstrapVue icon support. See our
 [icon documentation](/docs/icons) for details. This functionality can be replicated by using
 `<BPlaceholderWrapper>` with your choice of icon replacement in the `loading` slot.
 

--- a/apps/docs/src/utils/image-props.ts
+++ b/apps/docs/src/utils/image-props.ts
@@ -26,7 +26,7 @@ export const imageProps = {
     type: 'boolean',
     default: false,
     description:
-      "Makes the image responsive. The image will shrink as needed or grow up the the image's native width",
+      "Makes the image responsive. The image will shrink as needed or grow up to the image's native width",
   },
   fluidGrow: {
     type: 'boolean',


### PR DESCRIPTION
# Describe the PR

Add section in migration guide about removal of component aliases.

Also fix "the the" typos (I can extract this in another pull request if necessary).

Note that I built (manually) the list of aliases from BootstrapVue's documentation, but maybe some of them do not exist on BootstrapVueNext.

## Small replication

NA

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [-] Bugfix :bug: - `fix(...)`
- [-] Feature - `feat(...)`
- [-] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [-] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed typographical errors and improved clarity in component descriptions and documentation.
  * Updated the migration guide with a new section on component aliases, including a comprehensive comparison table between BootstrapVue and BootstrapVueNext.
  * Enhanced overall readability and accuracy of documentation content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->