### PR TITLE
docs: fix on-this-page when examples use header tags

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -203,7 +203,13 @@ const content = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_content')
 const target = useTemplateRef<ComponentPublicInstance<HTMLElement>>('_target')
 
 const {current: activeId, list: items} = useScrollspy(content, target, {
-  contentQuery: ':scope h1, :scope > div > [id], #component-reference, .component-reference h3',
+  // Select headings and elements for the table of contents:
+  // - h1-h6 headings (excluding those inside demo examples or card bodies)
+  // - div elements with IDs (for component reference sections)
+  // - #component-reference and .component-reference h3 elements
+  // This creates the hierarchical structure for the "On this page" navigation
+  contentQuery:
+    ':scope h1:not([class*="demo"] h1):not(.card-body h1), :scope > div > [id], #component-reference, .component-reference h3, :scope h2:not([class*="demo"] h2):not(.card-body h2), :scope h3:not([class*="demo"] h3):not(.card-body h3), :scope h4:not([class*="demo"] h4):not(.card-body h4), :scope h5:not([class*="demo"] h5):not(.card-body h5), :scope h6:not([class*="demo"] h6):not(.card-body h6)',
   targetQuery: ':scope [href]',
   rootMargin: '0px 0px -25%',
   manual: true,

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -208,8 +208,17 @@ const {current: activeId, list: items} = useScrollspy(content, target, {
   // - div elements with IDs (for component reference sections)
   // - #component-reference and .component-reference h3 elements
   // This creates the hierarchical structure for the "On this page" navigation
-  contentQuery:
-    ':scope h1:not([class*="demo"] h1):not(.card-body h1), :scope > div > [id], #component-reference, .component-reference h3, :scope h2:not([class*="demo"] h2):not(.card-body h2), :scope h3:not([class*="demo"] h3):not(.card-body h3), :scope h4:not([class*="demo"] h4):not(.card-body h4), :scope h5:not([class*="demo"] h5):not(.card-body h5), :scope h6:not([class*="demo"] h6):not(.card-body h6)',
+  contentQuery: [
+    ':scope h1:not([class*="demo"] *):not(.card-body *)',
+    ':scope h2:not([class*="demo"] *):not(.card-body *)',
+    ':scope h3:not([class*="demo"] *):not(.card-body *)',
+    ':scope h4:not([class*="demo"] *):not(.card-body *)',
+    ':scope h5:not([class*="demo"] *):not(.card-body *)',
+    ':scope h6:not([class*="demo"] *):not(.card-body *)',
+    ':scope > div > [id]',
+    '#component-reference',
+    '.component-reference h3',
+  ].join(', '),
   targetQuery: ':scope [href]',
   rootMargin: '0px 0px -25%',
   manual: true,


### PR DESCRIPTION
# Describe the PR

When examples used header tags broke the way that we determine the hierarchy for on-this-page. This PR scopes the query to exclude demos from the hierarchy search.

fixes #2782 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the "On this page" navigation to include all heading levels for a more detailed and hierarchical overview.

* **Refactor**
  * Improved navigation tracking by excluding headings within demo and card-body sections, resulting in a cleaner and more relevant navigation panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->