### PR TITLE
docs: Fix navbar collapse behavior

### DIFF
--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -1,95 +1,118 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <template>
-  <BNavbar v-b-color-mode="'dark'" variant="primary" sticky="top" toggleable="lg" :container="true">
+  <BNavbar
+    v-b-color-mode="'dark'"
+    variant="primary"
+    sticky="top"
+    toggleable="lg"
+    :container="isLargeScreen ? true : 'fluid'"
+  >
     <BToastOrchestrator />
     <BModalOrchestrator />
     <BPopoverOrchestrator />
-    <div class="d-flex gap-2 align-items-center">
-      <BNavbarToggle v-b-toggle.sidebar-menu />
-      <BNavbarBrand :to="withBase('/')" class="p-0 me-0 me-lg-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 953 953"
-          width="32"
-          height="32"
-          version="1.1"
-          shape-rendering="geometricPrecision"
-          fill-rule="evenodd"
-          clip-rule="evenodd"
-          focusable="false"
-          role="img"
-          class="d-block"
-        >
-          <title>BootstrapVueNext</title>
-          <path
-            fill="currentColor"
-            d="M92 0h769c50 0 92 42 92 92v769c0 50-42 92-92 92H92c-50 0-92-42-92-92V92C0 42 42 0 92 0zm216 710c100 0 160-50 160-133 0-62-44-107-108-113v-3c48-8 86-52 86-102 0-71-55-117-140-117H111v468h197zM195 307h90c50 0 78 23 78 64 0 44-33 68-91 68h-77V307zm0 338V499h90c64 0 98 25 98 73s-33 73-94 73h-94zm503 65l163-468h-90L652 621h-2L531 242h-92l163 468h96z"
-          />
-        </svg>
-      </BNavbarBrand>
-    </div>
-    <BCollapse is-nav>
+    <BNavbarBrand :to="withBase('/')" class="p-0 me-0 me-lg-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 953 953"
+        width="32"
+        height="32"
+        version="1.1"
+        shape-rendering="geometricPrecision"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        focusable="false"
+        role="img"
+        class="d-block"
+      >
+        <title>BootstrapVueNext</title>
+        <path
+          fill="currentColor"
+          d="M92 0h769c50 0 92 42 92 92v769c0 50-42 92-92 92H92c-50 0-92-42-92-92V92C0 42 42 0 92 0zm216 710c100 0 160-50 160-133 0-62-44-107-108-113v-3c48-8 86-52 86-102 0-71-55-117-140-117H111v468h197zM195 307h90c50 0 78 23 78 64 0 44-33 68-91 68h-77V307zm0 338V499h90c64 0 98 25 98 73s-33 73-94 73h-94zm503 65l163-468h-90L652 621h-2L531 242h-92l163 468h96z"
+        />
+      </svg>
+    </BNavbarBrand>
+    <BNavbarToggle target="nav-collapse" />
+    <BCollapse id="nav-collapse" is-nav>
       <BNavbarNav>
-        <BNav>
-          <BNavItem
-            v-for="link in headerLinks"
-            :key="link.route"
-            :to="link.route"
-            :active="route.path === `${link.route}.html`"
-            class="py-2"
-            active-class="active fw-bold"
-            >{{ link.label }}</BNavItem
-          >
-        </BNav>
+        <BNavItem
+          v-for="link in headerLinks"
+          :key="link.route"
+          :to="link.route"
+          :active="route.path === `${link.route}.html`"
+          active-class="active fw-bold"
+          >{{ link.label }}</BNavItem
+        >
+      </BNavbarNav>
+      <BNavbarNav class="ms-auto">
+        <div class="d-flex align-items-center gap-2">
+          <VPNavBarSearch :class="{dark: colorMode === 'dark'}" />
+          <div class="d-flex gap-2 flex-wrap socials">
+            <BNav class="d-flex">
+              <BNavItem
+                v-for="link in headerExternalLinks"
+                :key="link.url"
+                :href="link.url"
+                :link-attrs="{'aria-label': link.label}"
+                target="_blank"
+                rel="noopener"
+                link-classes="py-1 px-0"
+              >
+                <component :is="link.icon()" height="1.1em" aria-hidden />
+              </BNavItem>
+              <div class="border border-secondary ms-2 me-3" />
+              <ClientOnly>
+                <BNavItemDropdown toggle-class="px-0">
+                  <!-- TODO there is no way to adjust these options, say if you wanted to remove the padding -->
+                  <template #button-content>
+                    <component
+                      :is="currentIcon"
+                      height="1.1em"
+                      :aria-label="`Toggle theme (${colorMode})`"
+                      class="d-inline-block"
+                    />
+                  </template>
+                  <BDropdownItem
+                    v-for="el in options"
+                    :key="el"
+                    :active="colorMode === el"
+                    @click="set(el)"
+                  >
+                    <component :is="map[el]" /> {{ el }}
+                  </BDropdownItem>
+                </BNavItemDropdown>
+              </ClientOnly>
+            </BNav>
+          </div>
+        </div>
       </BNavbarNav>
     </BCollapse>
-    <div class="d-flex align-items-center gap-2">
-      <VPNavBarSearch :class="{dark: colorMode === 'dark'}" />
-      <div class="d-flex gap-2 flex-wrap socials">
-        <BNav class="d-flex">
-          <BNavItem
-            v-for="link in headerExternalLinks"
-            :key="link.url"
-            :href="link.url"
-            :link-attrs="{'aria-label': link.label}"
-            target="_blank"
-            rel="noopener"
-            link-classes="py-1 px-0"
-          >
-            <component :is="link.icon()" height="1.1em" aria-hidden />
-          </BNavItem>
-          <div class="border border-secondary ms-2 me-3" />
-          <ClientOnly>
-            <BNavItemDropdown toggle-class="px-0">
-              <!-- TODO there is no way to adjust these options, say if you wanted to remove the padding -->
-              <template #button-content>
-                <component
-                  :is="currentIcon"
-                  height="1.1em"
-                  :aria-label="`Toggle theme (${colorMode})`"
-                  class="d-inline-block"
-                />
-              </template>
-              <BDropdownItem
-                v-for="el in options"
-                :key="el"
-                :active="colorMode === el"
-                @click="set(el)"
-              >
-                <component :is="map[el]" /> {{ el }}
-              </BDropdownItem>
-            </BNavItemDropdown>
-          </ClientOnly>
-        </BNav>
-      </div>
-    </div>
   </BNavbar>
   <ClientOnly>
-    <div v-if="!isLargeScreen" class="py-4 px-3 text-end">
-      <BNavbarToggle v-b-toggle.otp-menu class="otp-menu-toggle">
-        On this page
-        <ChevronRight aria-hidden />
-      </BNavbarToggle>
+    <div v-if="!isLargeScreen && !page.isNotFound" class="d-flex border-bottom">
+      <div class="px-3">
+        <BButton
+          v-b-toggle.sidebar-menu
+          class="otp-menu-toggle"
+          variant="link"
+          size="sm"
+          underline-opacity="0"
+        >
+          <List aria-hidden />
+          Browse docs
+        </BButton>
+      </div>
+      <div class="px-3 ms-auto">
+        <BButton
+          v-b-toggle.otp-menu
+          class="otp-menu-toggle"
+          variant="link"
+          size="sm"
+          underline-opacity="0"
+        >
+          On this page
+          <ChevronRight aria-hidden />
+        </BButton>
+      </div>
     </div>
   </ClientOnly>
   <BContainer fluid class="container-lg mt-3 my-md-4 bd-layout">
@@ -188,6 +211,7 @@ import MoonStarsFill from '~icons/bi/moon-stars-fill'
 import SunFill from '~icons/bi/sun-fill'
 import ChevronRight from '~icons/bi/chevron-right'
 import CircleHalf from '~icons/bi/circle-half'
+import List from '~icons/bi/list'
 import {useData, useRoute, withBase} from 'vitepress'
 import {VPNavBarSearch} from 'vitepress/theme'
 import {appInfoKey} from './keys'
@@ -236,7 +260,7 @@ const globalData = inject(appInfoKey, {
   githubDocsDirectory: '',
 })
 
-const isLargeScreen = useMediaQuery('(min-width: 992px)')
+const isLargeScreen = useMediaQuery('(min-width: 992px)', {ssrWidth: 1024})
 const sidebar = ref(false)
 const onThisPage = ref(false)
 

--- a/apps/docs/src/components/TableOfContentsNav.vue
+++ b/apps/docs/src/components/TableOfContentsNav.vue
@@ -2,7 +2,7 @@
   <nav class="bd-links-nav">
     <BListGroup v-if="!isLargeScreen">
       <strong :class="headerClasses">
-        <span :class="headerInsideClasses"> <GearIcon aria-hidden /> General</span>
+        <span :class="headerInsideClasses"><GearIcon aria-hidden class="me-2" />General </span>
       </strong>
       <BListGroupItem v-for="link in headerLinks" :key="link.label" :class="listGroupItemClasses">
         <BLink :to="link.route" :class="linkClasses">
@@ -13,7 +13,7 @@
     <BListGroup v-for="group in groupComputedList" :key="group.label">
       <strong :class="headerClasses">
         <BLink :to="withBase(group.uri)" :class="headerInsideClasses">
-          <component :is="group.icon()" /> {{ group.label }}
+          <component :is="group.icon()" class="me-2" /> {{ group.label }}
         </BLink>
       </strong>
       <BListGroupItem
@@ -74,7 +74,13 @@ const routeLocationDirectives = (name: string): string =>
 const headerClasses = ['py-2', 'text-primary-emphasis'] as const
 const linkClasses = ['px-2', 'ms-2', 'text-decoration-none', 'text-body', 'fs-7'] as const
 const listGroupItemClasses = ['border-0', 'px-0', 'py-0-5', 'ms-2'] as const
-const headerInsideClasses = ['px-2', 'ms-2', 'text-decoration-none'] as const
+const headerInsideClasses = [
+  'd-inline-flex',
+  'align-items-center',
+  'px-2',
+  'ms-2',
+  'text-decoration-none',
+] as const
 
 const headerLinks = [
   {


### PR DESCRIPTION
# Describe the PR

Clean up how navbar collapse/table of contents/on this page interact. Move it closer to how vite does things where on smaller screens the toc and top offcanvas components are controlled by link-style buttons below the navbar and the hamburger on the navbar controls the collapsed part of that component.

Also fix several marginally related esthetic issues that I ran across while doing the functional work above.

closes #2797 

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
