### PR TITLE
docs: Fixed typo in tabs.md

### DIFF
--- a/apps/docs/src/docs/components/tabs.md
+++ b/apps/docs/src/docs/components/tabs.md
@@ -17,7 +17,7 @@ For navigation based tabs (i.e. tabs that would change the URL), use the
 ::: info
 You should supply each child `<BTab>` component a unique `key` value if dynamically adding
 or removing `<BTab>` components (i.e. `v-if` or for loops). The `key` attribute is a special Vue
-attribute, see the [Vue doce](https://vuejs.org/api/built-in-special-attributes.html#key) for details.
+attribute, see the [Vue docs](https://vuejs.org/api/built-in-special-attributes.html#key) for details.
 :::
 
 ## Cards integration


### PR DESCRIPTION
# Describe the PR

Fixed typo in tabs.md: `doce` => `docs`

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [x] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in a tabs information callout: changed "Vue doce" to "Vue docs" and updated the anchor text. Link target unchanged. Improves clarity and polish for readers; no behavioral or navigation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->