### PR TITLE
Remove lazy-modifier warning on FormInput docs

### DIFF
--- a/apps/docs/src/docs/components/form-input.md
+++ b/apps/docs/src/docs/components/form-input.md
@@ -31,8 +31,6 @@ If the `type` prop is set to an input type that is not supported (see above), a 
 - For date and time style inputs, where supported, the displayed value in the GUI may be different
   from what is returned by its value (i.e. ordering of year-month-date)
 - Regardless of input type, the value is **always** returned as a string representation
-- `v-model.lazy` is not supported by `BFormInput` (nor any custom Vue component). Use the `lazy`
-  prop instead
 - Older version of Firefox may not support `readonly` for `range` type inputs
 - Input types that do not support `min`, `max` and `step` (i.e. `text`, `password`, `tel`, `email`,
   `url`, etc.) will silently ignore these values (although they will still be rendered on the input


### PR DESCRIPTION
# Describe the PR

The warning: 
```
v-model.lazy is not supported by BFormInput (nor any custom Vue component). Use the lazy prop instead
```

in the Form Input docs is inaccurate. The lazy modifier does work (as stated later in the docs) and the lazy prop does not exist.


## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [X] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the form input guide by removing the note that v-model.lazy is not supported by BFormInput and the suggestion to use a lazy prop.
  * Streamlined the “Caveats with input types” section while keeping existing guidance on input values, formatting, and min/max/step behavior unchanged.
  * Improves clarity and accuracy of documentation; no changes to application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->