### PR TITLE
feat: export useScrollLock() to make it available to the entire application

### DIFF
--- a/packages/bootstrap-vue-next/src/composables/index.ts
+++ b/packages/bootstrap-vue-next/src/composables/index.ts
@@ -1,6 +1,7 @@
 export {useBreadcrumb} from './useBreadcrumb'
 export {useColorMode} from './useColorMode'
 export {useModal, useModalController} from './useModal'
+export {useScrollLock} from './useScrollLock'
 export {useScrollspy} from './useScrollspy'
 export {useToast, useToastController} from './useToast'
 export {useToggle} from './useToggle'

--- a/packages/bootstrap-vue-next/src/types/BootstrapVueOptions.ts
+++ b/packages/bootstrap-vue-next/src/types/BootstrapVueOptions.ts
@@ -140,6 +140,7 @@ export const composablesWithExternalPath = {
   useColorMode: '/composables/useColorMode',
   useModal: '/composables/useModal',
   useModalController: '/composables/useModal',
+  useScrollLock: '/composables/useScrollLock',
   useScrollspy: '/composables/useScrollspy',
   useToast: '/composables/useToast',
   useToastController: '/composables/useToast',


### PR DESCRIPTION
Hello,
Would it be possible to make the `useScrollLock()` function available/visible outside of the bootstrap-vue-next library, please?

I've implemented my own full-screen overlays (as loading indicators) and I'm using `createSharedComposable(useScrollLock)` from the `@vueuse/core` library to disable page scrolling when the full-screen overlays are visible.
Since the bootstrap-vue-next library uses the same technique when modals are visible, it would be nice for me to be able to use a single instance of `createSharedComposable(useScrollLock)` throughout the entire Vue application.

Also note that since my apps have 2 instances of scroll lock (because I can't access the one in bootstrap-vue-next), I need to check if the one in bootstrap-vue-next is active (before it conflicts with mine) by testing `document.body.style.overflow === 'hidden'`. Using a single instance of scroll lock would eliminate the need for this kind of hack.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [X] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [X] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
