### PR TITLE
fix(BToggle): stop looking for missing targets after directive is unmounted

### DIFF
--- a/packages/bootstrap-vue-next/src/directives/BToggle/index.ts
+++ b/packages/bootstrap-vue-next/src/directives/BToggle/index.ts
@@ -62,7 +62,8 @@ const handleUpdate = (
 
   targets.forEach(async (targetId) => {
     let count = 0
-    while (count < 5) {
+    // Keep looking until showHide is found, giving up after 400ms or directive is unmounted
+    while (count < 5 && (el as HTMLElement).dataset.bvtoggle) {
       const showHide = showHideMap?.value.get(targetId)
       if (!showHide) {
         count++


### PR DESCRIPTION
# Describe the PR

The BToggle directive searches for targets in its mounted hook. If a target isn't immediately found, it calls setTimeout and keeps looking for it for 400ms. If the directive is unmounted before that 400ms is up, it still keeps looking even though there's no point anymore. This PR adds a check on that loop that exits it if the directive has been unmounted.

## Small replication

```ts
    const App = {
      directives: {
        bToggle: VBToggle,
      },
      components: {BCollapse},
      template: `<button v-if="show" v-b-toggle="'missing'">button</button>`,
      setup: () => {
        const show = ref(true)
        onMounted(() => {
          show.value = false
        })
        return {
          show,
        }
      },
    }

    // When mounted will produce a console warn with text "[v-b-toggle] Target with ID missing not found". After this change it won't.
```

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
