### PR TITLE
docs: prevent href=# links from scrolling to top

### DIFF
--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -47,12 +47,9 @@ export default {
 
         // Watch for Vue updates that might add new links
         const observer = new MutationObserver((mutations) => {
-          let shouldReplace = false
-          mutations.forEach((mutation) => {
-            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
-              shouldReplace = true
-            }
-          })
+          const shouldReplace = mutations.some(
+            (mutation) => mutation.type === 'childList' && mutation.addedNodes.length > 0
+          )
           if (shouldReplace) {
             replaceHashHrefs()
           }

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import Layout from './Layout.vue'
 import type {EnhanceAppContext, Theme} from 'vitepress'
 import DefaultTheme from 'vitepress/theme-without-fonts'
 import {appInfoKey} from './keys'
+import {nextTick} from 'vue'
 
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
@@ -30,5 +31,38 @@ export default {
       discordUrl: 'https://discord.gg/j2Mtcny',
       opencollectiveUrl: 'https://opencollective.com/bootstrap-vue-next',
     })
+
+    // Prevent href="#" links from scrolling to top in documentation examples
+    if (typeof window !== 'undefined') {
+      // Replace href="#" with href="javascript:void(0)" to prevent scrolling
+      const replaceHashHrefs = () => {
+        document.querySelectorAll('a[href="#"]').forEach((link) => {
+          link.setAttribute('href', 'javascript:void(0)')
+        })
+      }
+
+      // Replace immediately after DOM is ready
+      nextTick(() => {
+        replaceHashHrefs()
+
+        // Watch for Vue updates that might add new links
+        const observer = new MutationObserver((mutations) => {
+          let shouldReplace = false
+          mutations.forEach((mutation) => {
+            if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+              shouldReplace = true
+            }
+          })
+          if (shouldReplace) {
+            replaceHashHrefs()
+          }
+        })
+
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+        })
+      })
+    }
   },
 } satisfies Theme

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -575,6 +575,14 @@ Bootstrap Vue used `Vue Router 3`, BootstrapVueNext uses [`Vue Router 4`](https:
 
 `BLink` no longer supresses the scroll to top default behavior when `href='#'`.
 
+::: tip Documentation Site Workaround
+This documentation site implements a workaround to prevent `href="#"` links from scrolling to the top for a better user experience when viewing component examples. The workaround replaces `href="#"` with `href="javascript:void(0)"` automatically. In your own applications, you may want to:
+
+- Add your own click event handlers with `preventDefault()` if needed
+- Use `href="javascript:void(0)"` instead of `href="#"` for non-navigating links
+- Consider using `role="button"` with `tabindex="0"` for non-link interactive elements
+  :::
+
 #### append
 
 Vue router deprecated the `append` prop in `<router-link>`, BootstrapVueNext has followed suit and deprecated the `append`

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -578,9 +578,10 @@ Bootstrap Vue used `Vue Router 3`, BootstrapVueNext uses [`Vue Router 4`](https:
 ::: tip Documentation Site Workaround
 This documentation site implements a workaround to prevent `href="#"` links from scrolling to the top for a better user experience when viewing component examples. The workaround replaces `href="#"` with `href="javascript:void(0)"` automatically. In your own applications, you may want to:
 
-- Add your own click event handlers with `preventDefault()` if needed
-- Use `href="javascript:void(0)"` instead of `href="#"` for non-navigating links
+- Add your own click event handlers with `.prevent` or `preventDefault()` if needed
+- Prefer a `<button type="button">` for non‑navigation actions.
 - Consider using `role="button"` with `tabindex="0"` for non-link interactive elements
+- Use `href="javascript:void(0)"` instead of `href="#"` for non-navigating links
   :::
 
 #### append


### PR DESCRIPTION
# Describe the PR

Fixes #2796 

We’re using `href=”#”` throughout the docs. This causes the page to scroll to the top - see #2796 for details.

I’m not thrilled with this fix - perhaps the “right” way to do this is to explicitly change the docs to replace `href=”#”` with `href="javasript:void(0)"`?

## Small replication

Easily replicated anywhere this pattern is used in the docs. BDropdown is a good example.

## PR checklist

<!-- (Update “[ ]“ to “[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(…)`
- [ ] Feature - `feat(…)`
- [ ] ARIA accessibility - `fix(…)`
- [x] Documentation update - `docs(…)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unexpected page scroll to top when clicking placeholder “#” links across the documentation site, including content added or updated at runtime.

* **Documentation**
  * Added a “Documentation Site Workaround” note to the migration guide (duplicated in two nearby spots) with recommendations for handling non‑navigational links (preventDefault, prefer buttons, role/tabindex, or use javascript:void(0)).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->