### PR TITLE
Docs prevent scroll manual

### DIFF
--- a/apps/docs/.vitepress/plugins/demo-container.ts
+++ b/apps/docs/.vitepress/plugins/demo-container.ts
@@ -41,10 +41,14 @@ export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
     const {filepath, extension, region, lines, lang, title} = rawPathToToken(rawPath)
     const component = isDemo ? `<${title.substring(0, title.indexOf('.'))}/>` : ''
 
+    // Generate kebab-case ID from filename (without extension)
+    const filename = title.substring(0, title.lastIndexOf('.') || title.length)
+    const kebabCaseId = filename.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+
     state.line += 1
 
     const prefixToken = state.push('html_block', '', 0)
-    prefixToken.content = `<HighlightCard>${component}<template #html>`
+    prefixToken.content = `<HighlightCard id="${kebabCaseId}">${component}<template #html>`
 
     const codeToken = state.push('fence', 'code', 0)
     codeToken.info = `${lang || extension}${lines ? `{${lines}}` : ''}${title ? `[${title}]` : ''}`
@@ -52,7 +56,7 @@ export const demoContainer = (md: MarkdownRenderer, srcDir: string) => {
     const {realPath, path: _path} = state.env as MarkdownEnv
     const resolvedPath = path.resolve(path.dirname(realPath ?? _path), filepath)
 
-    // @ts-ignore
+    // @ts-expect-error - property 'src' does not exist on type 'Token'
     codeToken.src = [resolvedPath, region.slice(1)]
     codeToken.markup = '```'
     codeToken.map = [startLine, startLine + 1]

--- a/apps/docs/.vitepress/theme/Layout.vue
+++ b/apps/docs/.vitepress/theme/Layout.vue
@@ -220,7 +220,7 @@ const {current: activeId, list: items} = useScrollspy(content, target, {
     ':scope h4:not([class*="demo"] *):not(.card-body *)',
     ':scope h5:not([class*="demo"] *):not(.card-body *)',
     ':scope h6:not([class*="demo"] *):not(.card-body *)',
-    ':scope > div > [id]',
+    ':scope > div > [id]:not(.card)',
     '#component-reference',
     '.component-reference h3',
   ].join(', '),

--- a/apps/docs/src/docs/components/demo/AlertLinkColors.vue
+++ b/apps/docs/src/docs/components/demo/AlertLinkColors.vue
@@ -4,7 +4,7 @@
     :model-value="true"
     variant="primary"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Primary Alert</a
     ></BAlert
@@ -13,7 +13,7 @@
     :model-value="true"
     variant="secondary"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Secondary Alert</a
     ></BAlert
@@ -22,7 +22,7 @@
     :model-value="true"
     variant="success"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Success Alert</a
     ></BAlert
@@ -31,7 +31,7 @@
     :model-value="true"
     variant="danger"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Danger Alert</a
     ></BAlert
@@ -40,7 +40,7 @@
     :model-value="true"
     variant="warning"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Warning Alert</a
     ></BAlert
@@ -49,7 +49,7 @@
     :model-value="true"
     variant="info"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Info Alert</a
     ></BAlert
@@ -58,7 +58,7 @@
     :model-value="true"
     variant="light"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Light Alert</a
     ></BAlert
@@ -67,7 +67,7 @@
     :model-value="true"
     variant="dark"
     ><a
-      href="#"
+      href="#alert-link-colors"
       class="alert-link"
       >Dark Alert</a
     ></BAlert

--- a/apps/docs/src/docs/components/demo/ButtonElementType.vue
+++ b/apps/docs/src/docs/components/demo/ButtonElementType.vue
@@ -2,7 +2,7 @@
   <div class="d-flex gap-2">
     <!-- #region template -->
     <BButton>I am a Button</BButton>
-    <BButton href="#">I am a Link</BButton>
+    <BButton href="#button-element-type">I am a Link</BButton>
     <!-- #endregion template -->
   </div>
 </template>

--- a/apps/docs/src/docs/components/demo/CardHeaderFooter.vue
+++ b/apps/docs/src/docs/components/demo/CardHeaderFooter.vue
@@ -10,7 +10,7 @@
     >
       <BCardText>Header and footers using props.</BCardText>
       <BButton
-        href="#"
+        href="#card-header-footer"
         variant="primary"
         >Go somewhere</BButton
       >
@@ -25,7 +25,7 @@
       </template>
       <BCardText>Header and footers using slots.</BCardText>
       <BButton
-        href="#"
+        href="#card-header-footer"
         variant="primary"
         >Go somewhere</BButton
       >

--- a/apps/docs/src/docs/components/demo/CardKitchenSink.vue
+++ b/apps/docs/src/docs/components/demo/CardKitchenSink.vue
@@ -25,12 +25,12 @@
     </BListGroup>
     <BCardBody>
       <a
-        href="#"
+        href="#card-kitchen-sink"
         class="card-link"
         >Card link</a
       >
       <a
-        href="#"
+        href="#card-kitchen-sink"
         class="card-link"
         >Another link</a
       >

--- a/apps/docs/src/docs/components/demo/CardOverview.vue
+++ b/apps/docs/src/docs/components/demo/CardOverview.vue
@@ -12,7 +12,7 @@
       Some quick example text to build on the card title and make up the bulk of the card's content.
     </BCardText>
     <BButton
-      href="#"
+      href="#card-overview"
       variant="primary"
       >Go somewhere</BButton
     >

--- a/apps/docs/src/docs/components/demo/CardParts.vue
+++ b/apps/docs/src/docs/components/demo/CardParts.vue
@@ -12,7 +12,7 @@
       Some quick example text to build on the card title and make up the bulk of the card's content.
     </BCardText>
     <BButton
-      href="#"
+      href="#card-parts"
       variant="primary"
       >Go somewhere</BButton
     >

--- a/apps/docs/src/docs/components/demo/CardTextVariants.vue
+++ b/apps/docs/src/docs/components/demo/CardTextVariants.vue
@@ -7,7 +7,7 @@
   >
     <BCardText> With supporting text below as a natural lead-in to additional content. </BCardText>
     <BButton
-      href="#"
+      href="#card-text-variants"
       variant="primary"
       >Go somewhere</BButton
     >

--- a/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockMenu.vue
@@ -6,9 +6,9 @@
     variant="primary"
     menu-class="w-100"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
+++ b/apps/docs/src/docs/components/demo/DropdownBlockToggle.vue
@@ -5,9 +5,9 @@
     variant="primary"
     class="d-grid gap-2 mb-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here</BDropdownItem>
   </BDropdown>
   <div class="d-grid gap-2">
     <BDropdown
@@ -17,9 +17,9 @@
       variant="primary"
       split-class="w-100"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here...</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here...</BDropdownItem>
     </BDropdown>
   </div>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
+++ b/apps/docs/src/docs/components/demo/DropdownButtonContent.vue
@@ -5,15 +5,15 @@
       text="Button text via Prop"
       class="me-2"
     >
-      <BDropdownItem href="#">An item</BDropdownItem>
-      <BDropdownItem href="#">Another item</BDropdownItem>
+      <BDropdownItem>An item</BDropdownItem>
+      <BDropdownItem>Another item</BDropdownItem>
     </BDropdown>
     <BDropdown class="me-2">
       <template #button-content>
         Custom <strong>Content</strong> with <em>HTML</em> via Slot
       </template>
-      <BDropdownItem href="#">An item</BDropdownItem>
-      <BDropdownItem href="#">Another item</BDropdownItem>
+      <BDropdownItem>An item</BDropdownItem>
+      <BDropdownItem>Another item</BDropdownItem>
     </BDropdown>
   </div>
   <!-- #endregion template -->

--- a/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
+++ b/apps/docs/src/docs/components/demo/DropdownColorVariants.vue
@@ -6,27 +6,27 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       text="Success"
       variant="success"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       text="Outline Danger"
       variant="outline-danger"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <!-- #endregion template -->
   </div>

--- a/apps/docs/src/docs/components/demo/DropdownDropup.vue
+++ b/apps/docs/src/docs/components/demo/DropdownDropup.vue
@@ -6,9 +6,9 @@
     variant="primary"
     class="me-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownFloating.vue
+++ b/apps/docs/src/docs/components/demo/DropdownFloating.vue
@@ -5,9 +5,9 @@
     strategy="fixed"
     class="me-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
+++ b/apps/docs/src/docs/components/demo/DropdownHiddenCaret.vue
@@ -7,9 +7,9 @@
     no-caret
   >
     <template #button-content> &#x1f50d;<span class="visually-hidden">Search</span> </template>
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here...</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuAlignment.vue
@@ -6,9 +6,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       start
@@ -16,9 +16,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       end
@@ -26,9 +26,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       center
@@ -36,9 +36,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <!-- #endregion template -->
   </div>

--- a/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
+++ b/apps/docs/src/docs/components/demo/DropdownMenuOffset.vue
@@ -6,18 +6,18 @@
       text="Offset Dropdown"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       :offset="{alignmentAxis: 50, crossAxis: 60, mainAxis: 70}"
       text="Offset Dropdown 2 dimensions"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <!-- #endregion template -->
   </div>

--- a/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
+++ b/apps/docs/src/docs/components/demo/DropdownNoFlip.vue
@@ -5,9 +5,9 @@
     no-flip
     class="me-2"
   >
-    <BDropdownItem href="#">An item</BDropdownItem>
-    <BDropdownItem href="#">Another item</BDropdownItem>
-    <BDropdownItem href="#">Yet Another item</BDropdownItem>
+    <BDropdownItem>An item</BDropdownItem>
+    <BDropdownItem>Another item</BDropdownItem>
+    <BDropdownItem>Yet Another item</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownPlacement.vue
+++ b/apps/docs/src/docs/components/demo/DropdownPlacement.vue
@@ -7,9 +7,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       placement="left"
@@ -17,9 +17,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       placement="right-start"
@@ -27,9 +27,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <BDropdown
       placement="left-end"
@@ -37,9 +37,9 @@
       variant="primary"
       class="me-2"
     >
-      <BDropdownItem href="#">Action</BDropdownItem>
-      <BDropdownItem href="#">Another action</BDropdownItem>
-      <BDropdownItem href="#">Something else here</BDropdownItem>
+      <BDropdownItem>Action</BDropdownItem>
+      <BDropdownItem>Another action</BDropdownItem>
+      <BDropdownItem>Something else here</BDropdownItem>
     </BDropdown>
     <!-- #endregion template -->
   </div>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButton.vue
@@ -5,9 +5,9 @@
     text="Split Dropdown"
     class="me-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here...</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButtonLink.vue
@@ -6,9 +6,9 @@
     text="Split Link"
     class="me-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here...</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/DropdownSplitButtonVariant.vue
+++ b/apps/docs/src/docs/components/demo/DropdownSplitButtonVariant.vue
@@ -7,9 +7,9 @@
     text="Split Variant Dropdown"
     class="me-2"
   >
-    <BDropdownItem href="#">Action</BDropdownItem>
-    <BDropdownItem href="#">Another action</BDropdownItem>
-    <BDropdownItem href="#">Something else here...</BDropdownItem>
+    <BDropdownItem>Action</BDropdownItem>
+    <BDropdownItem>Another action</BDropdownItem>
+    <BDropdownItem>Something else here...</BDropdownItem>
   </BDropdown>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/ListGroupActionable.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupActionable.vue
@@ -3,11 +3,11 @@
   <BListGroup>
     <BListGroupItem href="#some-link">Awesome link</BListGroupItem>
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable"
       active
       >Link with active state</BListGroupItem
     >
-    <BListGroupItem href="#">Action links are easy</BListGroupItem>
+    <BListGroupItem href="#list-group-actionable">Action links are easy</BListGroupItem>
     <BListGroupItem
       href="#foobar"
       disabled

--- a/apps/docs/src/docs/components/demo/ListGroupActionableVariants.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupActionableVariants.vue
@@ -1,44 +1,44 @@
 <template>
   <!-- #region template -->
   <BListGroup>
-    <BListGroupItem href="#">Default list group item</BListGroupItem>
+    <BListGroupItem href="#list-group-actionable-variants">Default list group item</BListGroupItem>
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="primary"
       >Primary list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="secondary"
       >Secondary list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="success"
       >Success list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="danger"
       >Danger list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="warning"
       >Warning list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="info"
       >Info list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="light"
       >Light list group item</BListGroupItem
     >
     <BListGroupItem
-      href="#"
+      href="#list-group-actionable-variants"
       variant="dark"
       >Dark list group item</BListGroupItem
     >

--- a/apps/docs/src/docs/components/demo/ListGroupCard.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupCard.vue
@@ -3,9 +3,9 @@
   <BCardGroup deck>
     <BCard header="Card with list group">
       <BListGroup>
-        <BListGroupItem href="#">Cras justo odio</BListGroupItem>
-        <BListGroupItem href="#">Dapibus ac facilisis in</BListGroupItem>
-        <BListGroupItem href="#">Vestibulum at eros</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Cras justo odio</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Dapibus ac facilisis in</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Vestibulum at eros</BListGroupItem>
       </BListGroup>
       <p class="card-text mt-2">
         Quis magna Lorem anim amet ipsum do mollit sit cillum voluptate ex nulla tempor. Laborum
@@ -18,9 +18,9 @@
       header="Card with flush list group"
     >
       <BListGroup flush>
-        <BListGroupItem href="#">Cras justo odio</BListGroupItem>
-        <BListGroupItem href="#">Dapibus ac facilisis in</BListGroupItem>
-        <BListGroupItem href="#">Vestibulum at eros</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Cras justo odio</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Dapibus ac facilisis in</BListGroupItem>
+        <BListGroupItem href="#list-group-card">Vestibulum at eros</BListGroupItem>
       </BListGroup>
       <BCardBody>
         Quis magna Lorem anim amet ipsum do mollit sit cillum voluptate ex nulla tempor. Laborum

--- a/apps/docs/src/docs/components/demo/ListGroupCustom.vue
+++ b/apps/docs/src/docs/components/demo/ListGroupCustom.vue
@@ -2,7 +2,7 @@
   <!-- #region template -->
   <BListGroup>
     <BListGroupItem
-      href="#"
+      href="#list-group-custom"
       active
       class="flex-column align-items-start"
     >
@@ -17,7 +17,7 @@
       <small>Donec id elit non mi porta.</small>
     </BListGroupItem>
     <BListGroupItem
-      href="#"
+      href="#list-group-custom"
       class="flex-column align-items-start"
     >
       <div class="d-flex w-100 justify-content-between">
@@ -31,7 +31,7 @@
       <small class="text-body-secondary">Donec id elit non mi porta.</small>
     </BListGroupItem>
     <BListGroupItem
-      href="#"
+      href="#list-group-custom"
       disabled
       class="flex-column align-items-start"
     >

--- a/apps/docs/src/docs/components/demo/NavbarBrandImage.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandImage.vue
@@ -5,7 +5,7 @@
     v-b-color-mode="'dark'"
     variant="success"
   >
-    <BNavbarBrand href="#">
+    <BNavbarBrand href="#navbar-brand-image">
       <img
         src="https://picsum.photos/30/30/?image=40"
         alt="Kitten"

--- a/apps/docs/src/docs/components/demo/NavbarBrandImageText.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandImageText.vue
@@ -5,7 +5,7 @@
     v-b-color-mode="'dark'"
     variant="success"
   >
-    <BNavbarBrand href="#">
+    <BNavbarBrand href="#navbar-brand-image-text">
       <img
         src="https://picsum.photos/30/30/?image=40"
         class="d-inline-block align-top"

--- a/apps/docs/src/docs/components/demo/NavbarBrandLink.vue
+++ b/apps/docs/src/docs/components/demo/NavbarBrandLink.vue
@@ -5,7 +5,7 @@
     v-b-color-mode="'dark'"
     variant="secondary"
   >
-    <BNavbarBrand href="#">BootstrapVueNext</BNavbarBrand>
+    <BNavbarBrand href="#navbar-brand-link">BootstrapVueNext</BNavbarBrand>
   </BNavbar>
   <!-- #endregion template -->
 </template>

--- a/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
+++ b/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
@@ -10,17 +10,17 @@
         text="Lang"
         right
       >
-        <BDropdownItem href="#">EN</BDropdownItem>
-        <BDropdownItem href="#">ES</BDropdownItem>
-        <BDropdownItem href="#">RU</BDropdownItem>
-        <BDropdownItem href="#">FA</BDropdownItem>
+        <BDropdownItem>EN</BDropdownItem>
+        <BDropdownItem>ES</BDropdownItem>
+        <BDropdownItem>RU</BDropdownItem>
+        <BDropdownItem>FA</BDropdownItem>
       </BNavItemDropdown>
       <BNavItemDropdown
         text="User"
         right
       >
-        <BDropdownItem href="#">Account</BDropdownItem>
-        <BDropdownItem href="#">Settings</BDropdownItem>
+        <BDropdownItem>Account</BDropdownItem>
+        <BDropdownItem>Settings</BDropdownItem>
       </BNavItemDropdown>
     </BNavbarNav>
   </BNavbar>

--- a/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
+++ b/apps/docs/src/docs/components/demo/NavbarItemDropdown.vue
@@ -5,7 +5,7 @@
     variant="dark"
   >
     <BNavbarNav>
-      <BNavItem href="#">Home</BNavItem>
+      <BNavItem href="#navbar-item-dropdown">Home</BNavItem>
       <BNavItemDropdown
         text="Lang"
         right

--- a/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
@@ -27,18 +27,18 @@
           text="Lang"
           right
         >
-          <BDropdownItem href="#">EN</BDropdownItem>
-          <BDropdownItem href="#">ES</BDropdownItem>
-          <BDropdownItem href="#">RU</BDropdownItem>
-          <BDropdownItem href="#">FA</BDropdownItem>
+          <BDropdownItem>EN</BDropdownItem>
+          <BDropdownItem>ES</BDropdownItem>
+          <BDropdownItem>RU</BDropdownItem>
+          <BDropdownItem>FA</BDropdownItem>
         </BNavItemDropdown>
         <BNavItemDropdown right>
           <!-- Using 'button-content' slot -->
           <template #button-content>
             <em>User</em>
           </template>
-          <BDropdownItem href="#">Profile</BDropdownItem>
-          <BDropdownItem href="#">Sign Out</BDropdownItem>
+          <BDropdownItem>Profile</BDropdownItem>
+          <BDropdownItem>Sign Out</BDropdownItem>
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">

--- a/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOffcanvas.vue
@@ -5,7 +5,7 @@
     :toggleable="true"
     variant="primary"
   >
-    <BNavbarBrand href="#">NavBar</BNavbarBrand>
+    <BNavbarBrand href="#navbar-offcanvas">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-offcanvas" />
     <BOffcanvas
       id="nav-offcanvas"
@@ -14,9 +14,9 @@
       is-nav
     >
       <BNavbarNav>
-        <BNavItem href="#">Link</BNavItem>
+        <BNavItem href="#navbar-offcanvas">Link</BNavItem>
         <BNavItem
-          href="#"
+          href="#navbar-offcanvas"
           disabled
           >Disabled</BNavItem
         >

--- a/apps/docs/src/docs/components/demo/NavbarOverview.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOverview.vue
@@ -5,16 +5,16 @@
     toggleable="lg"
     variant="primary"
   >
-    <BNavbarBrand href="#">NavBar</BNavbarBrand>
+    <BNavbarBrand href="#navbar-overview">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-collapse" />
     <BCollapse
       id="nav-collapse"
       is-nav
     >
       <BNavbarNav>
-        <BNavItem href="#">Link</BNavItem>
+        <BNavItem href="#navbar-overview">Link</BNavItem>
         <BNavItem
-          href="#"
+          href="#navbar-overview"
           disabled
           >Disabled</BNavItem
         >

--- a/apps/docs/src/docs/components/demo/NavbarOverview.vue
+++ b/apps/docs/src/docs/components/demo/NavbarOverview.vue
@@ -25,18 +25,18 @@
           text="Lang"
           right
         >
-          <BDropdownItem href="#">EN</BDropdownItem>
-          <BDropdownItem href="#">ES</BDropdownItem>
-          <BDropdownItem href="#">RU</BDropdownItem>
-          <BDropdownItem href="#">FA</BDropdownItem>
+          <BDropdownItem>EN</BDropdownItem>
+          <BDropdownItem>ES</BDropdownItem>
+          <BDropdownItem>RU</BDropdownItem>
+          <BDropdownItem>FA</BDropdownItem>
         </BNavItemDropdown>
         <BNavItemDropdown right>
           <!-- Using 'button-content' slot -->
           <template #button-content>
             <em>User</em>
           </template>
-          <BDropdownItem href="#">Profile</BDropdownItem>
-          <BDropdownItem href="#">Sign Out</BDropdownItem>
+          <BDropdownItem>Profile</BDropdownItem>
+          <BDropdownItem>Sign Out</BDropdownItem>
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">

--- a/apps/docs/src/docs/components/demo/NavbarScroll.vue
+++ b/apps/docs/src/docs/components/demo/NavbarScroll.vue
@@ -6,16 +6,16 @@
     variant="primary"
     class="navbar-nav-scroll"
   >
-    <BNavbarBrand href="#">NavBar</BNavbarBrand>
+    <BNavbarBrand href="#navbar-scroll">NavBar</BNavbarBrand>
     <BNavbarToggle target="nav-scroll" />
     <BCollapse
       id="nav-scroll"
       is-nav
     >
       <BNavbarNav>
-        <BNavItem href="#">Link</BNavItem>
+        <BNavItem href="#navbar-scroll">Link</BNavItem>
         <BNavItem
-          href="#"
+          href="#navbar-scroll"
           disabled
           >Disabled</BNavItem
         >

--- a/apps/docs/src/docs/components/demo/NavbarScroll.vue
+++ b/apps/docs/src/docs/components/demo/NavbarScroll.vue
@@ -26,18 +26,18 @@
           text="Lang"
           right
         >
-          <BDropdownItem href="#">EN</BDropdownItem>
-          <BDropdownItem href="#">ES</BDropdownItem>
-          <BDropdownItem href="#">RU</BDropdownItem>
-          <BDropdownItem href="#">FA</BDropdownItem>
+          <BDropdownItem>EN</BDropdownItem>
+          <BDropdownItem>ES</BDropdownItem>
+          <BDropdownItem>RU</BDropdownItem>
+          <BDropdownItem>FA</BDropdownItem>
         </BNavItemDropdown>
         <BNavItemDropdown right>
           <!-- Using 'button-content' slot -->
           <template #button-content>
             <em>User</em>
           </template>
-          <BDropdownItem href="#">Profile</BDropdownItem>
-          <BDropdownItem href="#">Sign Out</BDropdownItem>
+          <BDropdownItem>Profile</BDropdownItem>
+          <BDropdownItem>Sign Out</BDropdownItem>
         </BNavItemDropdown>
       </BNavbarNav>
       <BNavForm class="d-flex">

--- a/apps/docs/src/docs/components/demo/NavbarToggle.vue
+++ b/apps/docs/src/docs/components/demo/NavbarToggle.vue
@@ -4,7 +4,7 @@
     toggleable
     variant="dark"
   >
-    <BNavbarBrand href="#">NavBar</BNavbarBrand>
+    <BNavbarBrand href="#navbar-toggle">NavBar</BNavbarBrand>
     <BNavbarToggle target="navbar-toggle-collapse">
       <template #default="{expanded}">
         <ChevronBarUpIcon v-if="expanded" />
@@ -19,10 +19,10 @@
       is-nav
     >
       <BNavbarNav class="ms-auto">
-        <BNavItem href="#">Link 1</BNavItem>
-        <BNavItem href="#">Link 2</BNavItem>
+        <BNavItem href="#navbar-toggle">Link 1</BNavItem>
+        <BNavItem href="#navbar-toggle">Link 2</BNavItem>
         <BNavItem
-          href="#"
+          href="#navbar-toggle"
           disabled
           >Disabled</BNavItem
         >

--- a/apps/docs/src/docs/components/demo/PopoverCustomClass.vue
+++ b/apps/docs/src/docs/components/demo/PopoverCustomClass.vue
@@ -7,7 +7,7 @@
     >
       <template #target>
         <BButton
-          href="#"
+          href="#popover-custom-class"
           tabindex="0"
           >Button</BButton
         >

--- a/apps/docs/src/docs/components/demo/TabsEmpty.vue
+++ b/apps/docs/src/docs/components/demo/TabsEmpty.vue
@@ -4,7 +4,7 @@
     <!-- Add your b-tab components here -->
     <template #tabs-end>
       <BNavItem
-        href="#"
+        href="#tabs-empty"
         role="presentation"
         @click="() => {}"
         >Another tab</BNavItem

--- a/apps/docs/src/docs/components/demo/TooltipCustomClass.vue
+++ b/apps/docs/src/docs/components/demo/TooltipCustomClass.vue
@@ -4,7 +4,7 @@
     <BTooltip body-class="my-tooltip-body-class">
       <template #target>
         <BButton
-          href="#"
+          href="#tooltip-custom-class"
           tabindex="0"
           >Button</BButton
         >
@@ -17,7 +17,7 @@
     >
       <template #target>
         <BButton
-          href="#"
+          href="#tooltip-custom-class"
           tabindex="1"
           >Button</BButton
         >

--- a/apps/docs/src/docs/migration-guide.md
+++ b/apps/docs/src/docs/migration-guide.md
@@ -575,6 +575,16 @@ Bootstrap Vue used `Vue Router 3`, BootstrapVueNext uses [`Vue Router 4`](https:
 
 `BLink` no longer supresses the scroll to top default behavior when `href='#'`.
 
+::: tip Handling href="#" Links in Documentation
+In our documentation site, we addressed the scroll-to-top behavior by cleaning up unnecessary `href="#"` attributes:
+
+1. **Remove unnecessary hrefs**: We removed `href="#"` from demo components where it wasn't providing any functional value (just styling).
+
+2. **Use contextual anchors**: Where navigation is actually needed, we replaced `href="#"` with meaningful anchor links that point to their demo containers (e.g., `href="#navbar-overview"`). This provides better user experience by allowing users to navigate directly to specific examples.
+
+This approach maintains component functionality while eliminating the unwanted scroll-to-top behavior.
+:::
+
 #### append
 
 Vue router deprecated the `append` prop in `<router-link>`, BootstrapVueNext has followed suit and deprecated the `append`


### PR DESCRIPTION
# Describe the PR

Fixes #2796

We’re using `href=”#”` throughout the docs. This causes the page to scroll to the top - see #2796 for details.

This removes the use of `href="#"` where it’s not needed and replaces the “#” with an id representing the demo container when it is. The latter results in a scroll to the top of the demo container when first clicked,  but the user stays in context and additional clicks (without explicit scrolling) will stay in place.

I feel like this is a much cleaner solution than #2859 

## Small replication

Easily replicated anywhere this pattern is used in the docs. BDropdown is a good example.

## PR checklist

<!-- (Update “[ ]“ to “[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(…)`
- [ ] Feature - `feat(…)`
- [ ] ARIA accessibility - `fix(…)`
- [x] Documentation update - `docs(…)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**
