### PR TITLE
fix(BApp): wrap our test app in BApp in main.ts to enable easy verification of useModal, etc.

### DIFF
--- a/packages/bootstrap-vue-next/src/App.vue
+++ b/packages/bootstrap-vue-next/src/App.vue
@@ -1,15 +1,13 @@
 <template>
-  <BApp>
-    <BContainer>
-      <BRow>
-        <BCol> Hello World! </BCol>
-      </BRow>
-    </BContainer>
-  </BApp>
+  <BContainer>
+    <BRow>
+      <BCol> Hello World! </BCol>
+    </BRow>
+  </BContainer>
 </template>
 
 <script setup lang="ts">
 // You can use this file as a development spot to test your changes
 // Please do not commit this file
-import {BApp, BCol, BContainer, BRow} from './components'
+import {BCol, BContainer, BRow} from './components'
 </script>

--- a/packages/bootstrap-vue-next/src/main.ts
+++ b/packages/bootstrap-vue-next/src/main.ts
@@ -2,7 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import {createApp, h} from 'vue'
 import {createRouter, createWebHistory, useRoute} from 'vue-router'
 import App from './App.vue'
-import {Directives} from './index'
+import {BApp, Directives} from './index'
 import './styles/styles.scss'
 const router = createRouter({
   history: createWebHistory(),
@@ -43,7 +43,14 @@ const router = createRouter({
   ],
 })
 
-const app = createApp(App)
+const Wrapper = {
+  name: 'AppWrapper',
+  render() {
+    return h(BApp, null, {default: () => h(App)})
+  },
+}
+
+const app = createApp(Wrapper)
 app.use(router)
 for (const name in Directives) {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Describe the PR

While investigating #2860 I noticed that the way we have our test app structured doesn’t work if you wanted to import `useModal` or and of the other composables that depend on being contained by the `BApp`

This is one way to fix the issue. Another would be to add a component below our App and do the testing in the component (that’s basically what our template for bug reports does).

This seemed a little easier for day-to-day work, but happy to implement the other if anyone has a strong preference.

## Small replication

Import `useModal` in our test app and you’ll see an error that it must be contained.

## PR checklist

<!-- (Update “[ ]“ to “[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(…)`
- [ ] Feature - `feat(…)`
- [ ] ARIA accessibility - `fix(…)`
- [ ] Documentation update - `docs(…)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated app initialization to wrap the root component with the application container, improving consistency of global layout and directives.
  * Moved the application wrapper from the internal app component to the bootstrap layer for cleaner composition and easier maintenance.
  * No user-facing behavior changes; existing routing and features continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->