### PR TITLE
fix(BFormValidFeedback): read global defaults from its own key

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BForm/BFormValidFeedback.vue
+++ b/packages/bootstrap-vue-next/src/components/BForm/BFormValidFeedback.vue
@@ -28,7 +28,7 @@ const _props = withDefaults(defineProps<BFormValidFeedbackProps>(), {
   text: undefined,
   tooltip: false,
 })
-const props = useDefaults(_props, 'BFormInvalidFeedback')
+const props = useDefaults(_props, 'BFormValidFeedback')
 defineSlots<BFormValidFeedbackSlots>()
 
 const computedShow = computed(() => props.forceShow === true || props.state === true)

--- a/packages/bootstrap-vue-next/src/components/BForm/form-valid-feedback.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BForm/form-valid-feedback.spec.ts
@@ -1,6 +1,7 @@
 import {enableAutoUnmount, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it} from 'vitest'
 import BFormValidFeedback from './BFormValidFeedback.vue'
+import {createBootstrap} from '../../plugins'
 
 describe('form-valid-feedback', () => {
   enableAutoUnmount(afterEach)
@@ -116,5 +117,21 @@ describe('form-valid-feedback', () => {
       props: {text: 'props'},
     })
     expect(wrapper.text()).toBe('slots')
+  })
+
+  it('reads global defaults from its own key', () => {
+    const wrapper = mount(BFormValidFeedback, {
+      global: {
+        plugins: [
+          createBootstrap({
+            components: {
+              BFormValidFeedback: {tag: 'span'},
+              BFormInvalidFeedback: {tag: 'p'},
+            },
+          }),
+        ],
+      },
+    })
+    expect(wrapper.element.tagName).toBe('SPAN')
   })
 })


### PR DESCRIPTION
# Describe the PR

`BFormValidFeedback` looks its global defaults up under the `BFormInvalidFeedback` key, so anything you set for it in `createBootstrap` is silently ignored and whatever you set for `BFormInvalidFeedback` gets applied to it as well. Noticed it trying to give valid feedback its own `tag` app-wide.

Looks like a copy-paste from the sibling file when `useDefaults` went in (#1889). Both strings satisfy `keyof BvnComponentProps` so TS was never going to catch it, and nothing in the specs covered per-component defaults keys.

## Small replication

```ts
createBootstrap({
  components: {
    BFormValidFeedback: {tag: 'span'},
    BFormInvalidFeedback: {tag: 'p'},
  },
})
```

`<BFormValidFeedback />` renders a `<p>`, should be a `<span>`. The added test fails on `main` and passes with the change.

Ran `test:unit:ci` (5518 passing), `test:lint` and the package build locally.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)` (about as small as they come, one string literal)
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration handling for valid form feedback components.
  * Valid feedback now uses its own global defaults instead of inheriting invalid feedback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->