### PR TITLE
fix(BFormTextarea): keep typed text visible with debounce and max-rows

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormInput/BFormInput.vue
@@ -2,7 +2,7 @@
   <input
     :id="computedId"
     ref="_input"
-    :value="modelValue"
+    :value="computedValue"
     :class="computedClasses"
     :name="props.name || undefined"
     :form="props.form || undefined"
@@ -76,6 +76,7 @@ const inInputGroup = inject(inputGroupKey, false)
 const {
   computedId,
   computedAriaInvalid,
+  computedValue,
   onInput,
   onChange,
   onBlur,

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/BFormTextarea.vue
@@ -5,7 +5,7 @@
     :class="computedClasses"
     :name="props.name || undefined"
     :form="props.form || undefined"
-    :value="modelValue ?? undefined"
+    :value="computedValue"
     :disabled="isDisabled"
     :placeholder="props.placeholder"
     :required="props.required || undefined"
@@ -78,6 +78,7 @@ const input = useTemplateRef('_input')
 const {
   computedId,
   computedAriaInvalid,
+  computedValue,
   onInput,
   stateClass,
   onChange,

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
@@ -570,6 +570,12 @@ describe('form-textarea', () => {
       await wrapper.setProps({modelValue: 'from parent'})
       await nextTick()
       expect(wrapper.element.value).toBe('from parent')
+      // The superseded edit must not fire once its debounce elapses, which
+      // would push the stale value back onto the parent.
+      vi.advanceTimersByTime(200)
+      await nextTick()
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      expect(wrapper.element.value).toBe('from parent')
       vi.useRealTimers()
     })
   })

--- a/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormTextarea/form-textarea.spec.ts
@@ -537,6 +537,41 @@ describe('form-textarea', () => {
       expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['debounced'])
       vi.useRealTimers()
     })
+
+    // maxRows makes the auto-resize composable write an inline height on every
+    // input, which re-renders the textarea while the debounced model update is
+    // still pending. The re-render used to re-patch `value` from the stale model
+    // and swallow what had just been typed.
+    it('keeps typed text visible with debounce and maxRows together', async () => {
+      vi.useFakeTimers()
+      const wrapper = mount(BFormTextarea, {
+        props: {modelValue: '', debounce: 200, maxRows: 5},
+        attachTo: document.body,
+      })
+      wrapper.element.value = 'a'
+      await wrapper.trigger('input')
+      await nextTick()
+      await nextTick()
+      expect(wrapper.element.value).toBe('a')
+      vi.advanceTimersByTime(200)
+      await nextTick()
+      expect(wrapper.emitted('update:modelValue')![0]).toEqual(['a'])
+      vi.useRealTimers()
+    })
+
+    it('lets a new modelValue from the parent override a pending edit', async () => {
+      vi.useFakeTimers()
+      const wrapper = mount(BFormTextarea, {
+        props: {modelValue: '', debounce: 200, maxRows: 5},
+        attachTo: document.body,
+      })
+      wrapper.element.value = 'typed'
+      await wrapper.trigger('input')
+      await wrapper.setProps({modelValue: 'from parent'})
+      await nextTick()
+      expect(wrapper.element.value).toBe('from parent')
+      vi.useRealTimers()
+    })
   })
 
   describe('extra attributes pass-through', () => {

--- a/packages/bootstrap-vue-next/src/composables/useFormInput.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormInput.ts
@@ -70,8 +70,11 @@ export const useFormInput = (
   }
 
   // A model change from anywhere else (most often the parent assigning a new
-  // value) takes precedence over an in-flight edit.
+  // value) takes precedence over an in-flight edit. Dropping the pending value
+  // is not enough on its own: the debounced write is still scheduled, and left
+  // alone it would fire later and push the superseded edit back onto the model.
   watch(modelValue, () => {
+    internalUpdateModelValue.cancel()
     pendingValue.value = null
   })
 

--- a/packages/bootstrap-vue-next/src/composables/useFormInput.ts
+++ b/packages/bootstrap-vue-next/src/composables/useFormInput.ts
@@ -1,5 +1,15 @@
 import type {Numberish} from '../types/CommonTypes'
-import {computed, inject, nextTick, onActivated, onMounted, type Ref, type ShallowRef} from 'vue'
+import {
+  computed,
+  inject,
+  nextTick,
+  onActivated,
+  onMounted,
+  ref,
+  watch,
+  type Ref,
+  type ShallowRef,
+} from 'vue'
 import {useAriaInvalid} from './useAriaInvalid'
 import {useId} from './useId'
 import {useFocus, useToNumber} from '@vueuse/core'
@@ -30,9 +40,19 @@ export const useFormInput = (
   const computedAriaInvalid = useAriaInvalid(() => props.ariaInvalid, computedState)
   const stateClass = useStateClass(computedState)
 
+  // Holds what the user has typed while a debounced model update is still in
+  // flight, during which the model itself still has the previous value. Vue
+  // re-patches the `value` DOM prop on every re-render, so an unrelated
+  // re-render inside that window resets the field to the stale model and
+  // swallows the keystroke. BFormTextarea's auto-resize does exactly that: it
+  // writes an inline height on each input, so `debounce` + `max-rows` together
+  // dropped characters as you typed.
+  const pendingValue = ref<Numberish | null>(null)
+
   const internalUpdateModelValue = useDebounceFn(
     (value: Numberish) => {
       modelValue.value = value
+      pendingValue.value = null
     },
     () => (modelModifiers.lazy === true ? 0 : debounceNumber.value),
     {maxWait: () => (modelModifiers.lazy === true ? Number.NaN : debounceMaxWaitNumber.value)}
@@ -41,11 +61,23 @@ export const useFormInput = (
   const updateModelValue = (value: Numberish, force = false, immediate = false) => {
     if (modelModifiers.lazy === true && force === false) return
     if (immediate) {
+      pendingValue.value = null
       modelValue.value = value
     } else {
+      pendingValue.value = value
       internalUpdateModelValue(value)
     }
   }
+
+  // A model change from anywhere else (most often the parent assigning a new
+  // value) takes precedence over an in-flight edit.
+  watch(modelValue, () => {
+    pendingValue.value = null
+  })
+
+  // What the control should actually display: the in-flight value when there is
+  // one, otherwise the model.
+  const computedValue = computed(() => pendingValue.value ?? modelValue.value ?? undefined)
 
   const {focused} = useFocus(input, {
     initialValue: props.autofocus,
@@ -125,8 +157,11 @@ export const useFormInput = (
 
     const nextModel = modelModifiers.trim ? formattedValue.trim() : formattedValue
 
-    // Cancel before modelValue.value comparison and update
+    // Cancel before modelValue.value comparison and update. The cancelled
+    // update will never land, so the in-flight value must be dropped too --
+    // otherwise it would keep shadowing the model after blur.
     internalUpdateModelValue.cancel()
+    pendingValue.value = null
     if (modelValue.value !== nextModel) {
       updateModelValue(nextModel, true, true)
     }
@@ -155,6 +190,7 @@ export const useFormInput = (
     input,
     computedId,
     computedAriaInvalid,
+    computedValue,
     onInput,
     onChange,
     onBlur,


### PR DESCRIPTION
Fixes #2873

## The problem

Using `debounce` together with `max-rows` on `BFormTextarea` means characters do not appear as you type — they only show up once the debounce delay elapses. Either prop on its own behaves correctly.

## Cause

While a debounced update is in flight, the model still holds the *previous* value. Vue re-patches the `value` DOM prop on every re-render (`value` is special-cased and patched even when the vnode prop is unchanged), so any re-render inside that window resets the field to the stale model and swallows the keystroke.

`max-rows` is what supplies the re-render: `useTextareaResize` probes the content height on every `input` event, writing `height` to `'auto'` and back. That inline style is only a render dependency when `maxRows`/`noAutoShrink` is set — which is exactly why the two props only misbehave in combination.

## The fix

`useFormInput` now tracks the in-flight value and exposes `computedValue`, which renders what the user typed until the debounced write lands. Once it does, the value is released and the model takes over again.

- A `modelValue` change from the parent still takes precedence over a pending edit.
- The pending value is dropped when `onBlur` cancels an in-flight update, so it cannot shadow the model afterwards.
- `BFormInput` binds `:value` through the same composable and had the same latent bug (it just lacks a per-keystroke re-render to trigger it), so it moves to `computedValue` too.

## Tests

Added two cases to `form-textarea.spec.ts`:

- `keeps typed text visible with debounce and maxRows together` — reproduces the report. It fails on `main` with `expected '' to be 'a'` and passes with this change.
- `lets a new modelValue from the parent override a pending edit` — guards the precedence rule above.

Verified locally against a clean baseline: the full suite reports the same 5550 passed / 7 failed before and after this change (those 7 are `@bootstrap-vue-next/nuxt` e2e tests that need Playwright browsers, unrelated to this patch). `pnpm type-check` and `pnpm test:lint` are both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved debounced form input behavior so typed values remain visible while updates are pending.
  - Ensured completed debounced edits are emitted reliably for text inputs and textareas.
  - Parent value changes now correctly override pending edits.
  - Blurring a field consistently cancels pending input.
- **Tests**
  - Added regression coverage for debounced textarea updates, including dynamic row sizing and external value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->