### PR TITLE
fix(BFormSpinbutton): apply the ariaControls prop to the output

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormSpinbutton/BFormSpinbutton.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormSpinbutton/BFormSpinbutton.vue
@@ -40,6 +40,7 @@
       role="spinbutton"
       aria-live="off"
       :aria-label="props.ariaLabel || undefined"
+      :aria-controls="props.ariaControls || undefined"
       :aria-invalid="
         props.state === false || (!modelValue !== null && props.required) ? true : undefined
       "

--- a/packages/bootstrap-vue-next/src/components/BFormSpinbutton/form-spinbutton.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormSpinbutton/form-spinbutton.spec.ts
@@ -472,6 +472,11 @@ describe('form-spinbutton', () => {
       expect(wrapper.attributes('title')).toBe('Volume')
     })
 
+    it('sets aria-controls on the output from the ariaControls prop', () => {
+      const wrapper = mount(BFormSpinbutton, {props: {ariaControls: 'my-target'}})
+      expect(wrapper.find('output').attributes('aria-controls')).toBe('my-target')
+    })
+
     it('buttons have aria-controls matching output id with ariaControls fallback', () => {
       const wrapper = mount(BFormSpinbutton, {props: {id: 'spin1'}})
       const buttons = wrapper.findAll('button')


### PR DESCRIPTION
# Describe the PR

`BFormSpinbutton` has an `ariaControls` prop - typed, defaulted, listed in the docs - but nothing in the template reads it, so the attribute never makes it into the DOM. Hit it wiring a spinbutton to a total it updates further down the page.

The `aria-controls` thats already in the component is on the +/- buttons, pointing at the output's own id. Different relationship, still fine. BootstrapVue v2 put the prop on the `<output role="spinbutton">` next to `aria-label` ([form-spinbutton.js#L224](https://github.com/bootstrap-vue/bootstrap-vue/blob/dev/src/components/form-spinbutton/form-spinbutton.js#L224)), and `BPagination` here already reads its own copy of the prop, so I've matched both.

## Small replication

```vue
<BFormSpinbutton v-model="qty" aria-controls="order-total" />
```

Nothing on the `<output>`, and it doesnt land on the root div either, since Vue keeps declared props out of `$attrs`. The added test fails on `main` with `expected undefined to be 'my-target'`.

Ran the package's `vitest run` (5519 passing) plus `type-check` and `test:lint`. Only checked the rendered DOM, not agaisnt a real screen reader.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)` (one binding, so barely that)
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * The spinbutton now exposes the `aria-controls` attribute when configured, improving assistive technology support.
* **Bug Fixes**
  * Corrected the spinbutton output so `aria-controls` is omitted when no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->