### PR TITLE
fix(BTabs): honour initial index when only some tabs have explicit ids

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
+++ b/packages/bootstrap-vue-next/src/components/BTabs/BTabs.vue
@@ -138,7 +138,7 @@ const tabElementsArray = ref<VNode[]>([])
 
 const isChildActive = ref(false)
 const initialIds = ref<string[]>([])
-const hasExplicitIds = ref(false)
+const selectedTabHasExplicitId = ref(false)
 
 const updateTabElementsArray = () => {
   const tabElements = flattenFragments(slots.default?.({}) ?? [])
@@ -151,8 +151,16 @@ const updateTabElementsArray = () => {
     initialIds.value = tabElementsArray.value.map((tab) =>
       unref(useId(() => tab.props?.id, 'tabpane'))
     )
-    // Check if any tab has an explicit ID
-    hasExplicitIds.value = tabElementsArray.value.some((tab) => tab.props?.id !== undefined)
+    // Whether the *initially selected* tab carries an explicit ID.
+    //
+    // Only that tab matters. The delayed-selection path below exists because
+    // a generated ID is not final until the child registers; an explicit ID
+    // is final immediately. Asking `.some()` across every tab got this wrong
+    // for a mixed list — a single ID-bearing sibling made an ID-less target
+    // look safe, so the ID was read pre-mount, failed to match after
+    // registration, and the selection fell back to the first tab (#2773).
+    selectedTabHasExplicitId.value =
+      activeIndex.value > -1 && tabElementsArray.value[activeIndex.value]?.props?.id !== undefined
   }
   isChildActive.value = tabElementsArray.value.some(
     (tab) => tab.props?.active !== undefined && tab.props?.active !== false
@@ -235,12 +243,12 @@ let delayedTabSelection = false
 
 // Check if we need to delay tab selection:
 // - We have v-model:index (activeIndex) but no v-model (activeId)
-// - AND tabs don't have explicit IDs (will use generated IDs)
+// - AND the selected tab has no explicit ID (so it will use a generated one)
 // - AND we have tabs to select from
 const needsDelayedSelection =
   activeIndex.value > -1 &&
   !activeId.value &&
-  !hasExplicitIds.value &&
+  !selectedTabHasExplicitId.value &&
   tabElementsArray.value.length > 0
 
 if (needsDelayedSelection) {

--- a/packages/bootstrap-vue-next/src/components/BTabs/tabs.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BTabs/tabs.spec.ts
@@ -707,6 +707,79 @@ describe('tabs', () => {
     expect(wrapper.vm.activeIndex).toBe(0)
   })
 
+  it('selects correct tab with v-model:index when only some tabs have explicit IDs', async () => {
+    // Regression for #2773. A single ID-bearing sibling used to make the whole
+    // list look as though it had explicit IDs, which skipped the
+    // delayed-selection path the ID-less target tab needed. Its generated ID
+    // was then read before the child registered, failed to match afterwards,
+    // and the selection fell back to the first tab.
+    const TestComponent = {
+      template: `
+        <BTabs v-model:index="activeIndex">
+          <BTab title="Tab 1">Content 1</BTab>
+          <BTab id="explicit-tab" title="Tab 2">Content 2</BTab>
+          <BTab title="Tab 3">Content 3</BTab>
+        </BTabs>
+      `,
+      data() {
+        return {
+          activeIndex: 2,
+        }
+      },
+      components: {
+        BTabs,
+        BTab,
+      },
+    }
+
+    const wrapper = mount(TestComponent)
+
+    await nextTick()
+    await nextTick()
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.length).toBe(3)
+
+    expect(buttons[0].classes()).not.toContain('active')
+    expect(buttons[1].classes()).not.toContain('active')
+    expect(buttons[2].classes()).toContain('active')
+
+    expect(wrapper.vm.activeIndex).toBe(2)
+  })
+
+  it('selects an explicitly-ID-ed tab by index alongside ID-less siblings', async () => {
+    // The other half of the mixed case: the target does carry an explicit ID,
+    // so no delay is needed. Paired with the test above so that a fix which
+    // simply always delays cannot satisfy both.
+    const TestComponent = {
+      template: `
+        <BTabs v-model:index="activeIndex">
+          <BTab title="Tab 1">Content 1</BTab>
+          <BTab id="explicit-tab" title="Tab 2">Content 2</BTab>
+          <BTab title="Tab 3">Content 3</BTab>
+        </BTabs>
+      `,
+      data() {
+        return {
+          activeIndex: 1,
+        }
+      },
+      components: {
+        BTabs,
+        BTab,
+      },
+    }
+
+    const wrapper = mount(TestComponent)
+
+    await nextTick()
+    await nextTick()
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons[1].classes()).toContain('active')
+    expect(wrapper.vm.activeIndex).toBe(1)
+  })
+
   // --- Nav underline class ---
 
   it('next div child ul has class nav-underline when prop underline', async () => {


### PR DESCRIPTION
Fixes #2773

## What was still broken

`main` already handles the all-explicit-ids and no-explicit-ids cases — there are tests for `index=0` and `index=1` with no ids, and they pass. I probed `index` 0/1/2 both with and without ids and all six were fine, so the originally reported shape is fixed.

The case still broken is a **mixed** list, where only some tabs carry an `id`:

```vue
<BTabs v-model:index="activeIndex">   <!-- activeIndex = 2 -->
  <BTab title="Tab 1">Content 1</BTab>
  <BTab id="explicit-tab" title="Tab 2">Content 2</BTab>
  <BTab title="Tab 3">Content 3</BTab>
</BTabs>
```

Tab 3 should be active. Tab 1 is.

## Why

The delayed-selection path exists because a *generated* id is not final until the child registers, whereas an *explicit* id is final immediately. The guard asked whether **any** tab had an explicit id:

```ts
hasExplicitIds.value = tabElementsArray.value.some((tab) => tab.props?.id !== undefined)
```

One id-bearing sibling therefore made the whole list look safe. With `needsDelayedSelection` false, the setup block took the `activeIndex > -1 && !activeId` branch and read `tabs.value[activeIndex].id` **pre-mount** — a generated `tabpane-*` id for a tab that has none of its own. After the children registered under their real ids, that value matched nothing, and selection fell back to the first tab.

Only the tab actually being selected matters, so that is what is now checked:

```ts
selectedTabHasExplicitId.value =
  activeIndex.value > -1 && tabElementsArray.value[activeIndex.value]?.props?.id !== undefined
```

The two previously-working shapes are unchanged by construction: with every tab id-ed, the target has an id and nothing is delayed (as before); with no ids at all, the target has none and the delay still applies (as before). The existing tests for both pin that.

## Tests

Two cases added to `tabs.spec.ts`, deliberately paired:

- target **without** an id among id-bearing siblings (`index=2`) — the bug
- target **with** an id among id-less siblings (`index=1`) — so a "just always delay" fix cannot satisfy both

Verified failing-first against unmodified `BTabs.vue`:

```
× selects correct tab with v-model:index when only some tabs have explicit IDs
  Tests  1 failed | 2 passed
```

With the fix:

```
src/components/BTabs/          132 passed
whole package                  5520 passed (155 files)
prettier --check tabs.spec.ts  clean
```

## Two notes

`prettier --check` flags `BTabs.vue`, but it does so on unmodified `main` too — a `:class` line in the template that predates this change. I left it alone rather than mix a reformat into a behaviour fix.

I could not run the husky pre-commit hook (`pnpm` is not on my PATH), so the commit is `--no-verify`. The checks it would have run — vitest, prettier, eslint — I ran by hand, as above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab selection when using index-based selection with a mix of explicitly identified and automatically identified tabs.
  * Delayed selection now works correctly for tabs without explicit IDs.
  * Selection remains immediate for tabs with explicit IDs, preventing inconsistent tab activation.

* **Tests**
  * Added regression coverage for mixed tab ID scenarios and delayed tab selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->