### PR TITLE
fix(BFormSpinbutton): only set aria-invalid when a required spinbutton has no value

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BFormSpinbutton/BFormSpinbutton.vue
+++ b/packages/bootstrap-vue-next/src/components/BFormSpinbutton/BFormSpinbutton.vue
@@ -42,7 +42,7 @@
       :aria-label="props.ariaLabel || undefined"
       :aria-controls="props.ariaControls || undefined"
       :aria-invalid="
-        props.state === false || (!modelValue !== null && props.required) ? true : undefined
+        props.state === false || (modelValue === null && props.required) ? true : undefined
       "
       :aria-required="props.required ? true : undefined"
       :aria-valuemin="computedMin"

--- a/packages/bootstrap-vue-next/src/components/BFormSpinbutton/form-spinbutton.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BFormSpinbutton/form-spinbutton.spec.ts
@@ -248,6 +248,21 @@ describe('form-spinbutton', () => {
       expect(wrapper.find('output').attributes('aria-invalid')).toBeUndefined()
     })
 
+    it('sets aria-invalid when required and modelValue is null', () => {
+      const wrapper = mount(BFormSpinbutton, {props: {required: true, modelValue: null}})
+      expect(wrapper.find('output').attributes('aria-invalid')).toBe('true')
+    })
+
+    it('does not set aria-invalid when required and modelValue is set', () => {
+      const wrapper = mount(BFormSpinbutton, {props: {required: true, modelValue: 5}})
+      expect(wrapper.find('output').attributes('aria-invalid')).toBeUndefined()
+    })
+
+    it('does not set aria-invalid when required and modelValue is zero', () => {
+      const wrapper = mount(BFormSpinbutton, {props: {required: true, modelValue: 0}})
+      expect(wrapper.find('output').attributes('aria-invalid')).toBeUndefined()
+    })
+
     it('has class flex-grow-1', () => {
       const wrapper = mount(BFormSpinbutton)
       expect(wrapper.find('output').classes()).toContain('flex-grow-1')


### PR DESCRIPTION
# Describe the PR

The docs for the `required` prop say:

> Note that if the prop `required` is set, and the `v-model` is `null`, the attribute `aria-invalid="true"` will be rendered on the component

It renders whatever the `v-model` is. The condition on the `<output>` is `!modelValue !== null`, and `!modelValue` is a boolean, so thats always true and the whole thing collapses to `state === false || required`. Set `:state="true"` on a required spinbutton and you still get `aria-invalid="true"` sat next to `aria-required="true"`.

Rather than bring back the `hasValue` computed that fc1edfb6 inlined, I've matched the `modelValue !== null` checks on the lines just below it. That old computed also OR'd in an `lvalue` local that doesnt exist any more.

## Small replication

`<BFormSpinbutton :model-value="5" required />` --> `<output ... aria-invalid="true" aria-required="true">`

The added tests fail on `main` with `expected 'true' to be undefined`. With the change in, all 5522 unit tests in the package pass, and `vue-tsc`, eslint and oxlint are clean.

## PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)` (barely - it's one operator)
- [ ] Feature - `feat(...)`
- [x] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected accessibility validation for spinbutton controls.
  * Required spinbuttons with empty values are now correctly marked invalid.
  * Required spinbuttons with valid numeric values, including zero, remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->