### PR TITLE
fix(BOrchestrator): map toast position through positionClasses

### DIFF
--- a/packages/bootstrap-vue-next/src/components/BApp/BOrchestrator.vue
+++ b/packages/bootstrap-vue-next/src/components/BApp/BOrchestrator.vue
@@ -65,6 +65,7 @@
 import {computed, inject, watch} from 'vue'
 import {warn} from '../../utils/console'
 import {orchestratorRegistryKey, type OrchestratorStoreObject} from '../../utils/keys'
+import {positionClasses} from '../../utils/positionClasses'
 import type {BvTriggerableEvent} from '../../utils'
 import type {BOrchestratorProps, ContainerPosition} from '../../types'
 import ConditionalTeleport from '../ConditionalTeleport.vue'
@@ -138,7 +139,7 @@ const positionedItems = computed<
   const toastDefaultPosition: ContainerPosition = 'bottom-start'
   const toastDefaults = (cls: ContainerPosition) =>
     ({
-      class: `${cls} toast-container position-fixed p-3`,
+      class: `${positionClasses[cls]} toast-container position-fixed p-3`,
       style: 'width: calc(var(--bs-toast-max-width, 350px) + var(--bs-toast-padding-x, 1rem) * 2)',
       transitionGroupName: 'b-list',
     }) satisfies Partial<ItemObject>

--- a/packages/bootstrap-vue-next/src/components/BApp/orchestrator.spec.ts
+++ b/packages/bootstrap-vue-next/src/components/BApp/orchestrator.spec.ts
@@ -7,6 +7,7 @@ import type {
   ModalOrchestratorArrayValue,
   ToastOrchestratorArrayValue,
 } from '../../types/ComponentOrchestratorTypes'
+import type {ContainerPosition} from '../../types/Alignment'
 
 const DummyComponent = markRaw(
   defineComponent({
@@ -51,9 +52,9 @@ const buildRegistry = (overrides: {
   }
 }
 
-describe('BOrchestrator TransitionGroup name conditional behavior', () => {
-  enableAutoUnmount(afterEach)
+enableAutoUnmount(afterEach)
 
+describe('BOrchestrator TransitionGroup name conditional behavior', () => {
   it('applies b-list transition name only when toast items are present', () => {
     const registry = buildRegistry({
       modal: [buildItem<ModalOrchestratorArrayValue>('modal1', {modelValue: false})],
@@ -129,5 +130,60 @@ describe('BOrchestrator TransitionGroup name conditional behavior', () => {
     // The modal position should not have b-list transition
     const modalTransition = transitionGroups.find((tg) => tg.props('name') === undefined)
     expect(modalTransition).toBeDefined()
+  })
+})
+
+describe('BOrchestrator toast container position classes', () => {
+  const mountWithToast = (position?: ContainerPosition) => {
+    const registry = buildRegistry({
+      toast: [
+        buildItem<ToastOrchestratorArrayValue>('toast1', {
+          modelValue: false,
+          ...(position ? {position} : {}),
+        }),
+      ],
+    })
+
+    return mount(BOrchestrator, {
+      global: {
+        provide: {
+          [orchestratorRegistryKey]: registry,
+        },
+      },
+    })
+  }
+
+  // The semantic position must be mapped to Bootstrap position utilities. Emitting the raw
+  // value instead yields e.g. `bottom-end`, which matches no stylesheet rule, leaving the
+  // fixed container with auto offsets in the top-left corner.
+  it.each([
+    ['top-start', 'top-0 start-0'],
+    ['top-center', 'top-0 start-50 translate-middle-x'],
+    ['top-end', 'top-0 end-0'],
+    ['middle-start', 'top-50 start-0 translate-middle-y'],
+    ['middle-center', 'top-50 start-50 translate-middle'],
+    ['middle-end', 'top-50 end-0 translate-middle-y'],
+    ['bottom-start', 'bottom-0 start-0'],
+    ['bottom-center', 'bottom-0 start-50 translate-middle-x'],
+    ['bottom-end', 'bottom-0 end-0'],
+  ] satisfies [ContainerPosition, string][])(
+    'renders position %s as the utility classes %s',
+    (position, expected) => {
+      const wrapper = mountWithToast(position)
+
+      const container = wrapper.find('.toast-container')
+      expect(container.exists()).toBe(true)
+      expect(container.attributes('class')).toBe(`${expected} toast-container position-fixed p-3`)
+    }
+  )
+
+  it('falls back to the bottom-start utility classes when no position is given', () => {
+    const wrapper = mountWithToast()
+
+    const container = wrapper.find('.toast-container')
+    expect(container.exists()).toBe(true)
+    expect(container.attributes('class')).toBe(
+      'bottom-0 start-0 toast-container position-fixed p-3'
+    )
   })
 })


### PR DESCRIPTION
# Describe the PR

Fixes #3283 — `BToast` has ignored its `position` since 0.46.0, always rendering in the top-left corner.

`BOrchestrator` builds the toast container's class list from the raw `ContainerPosition` value:

```ts
const toastDefaults = (cls: ContainerPosition) =>
  ({
    class: `${cls} toast-container position-fixed p-3`,
    ...
```

That emits `class="bottom-end toast-container position-fixed p-3"`. No stylesheet defines `.bottom-end` (nor any of the other eight position names), so the container is left `position-fixed` with every offset at `auto` and lands in the top-left.

**Root cause — an orphaned util.** `src/utils/positionClasses.ts` still maps each `ContainerPosition` to the matching Bootstrap utility classes, and is still typed `as const satisfies Record<ContainerPosition, string>` — it had simply stopped being imported anywhere. Through 0.45.x the value was mapped first (`${positionClasses[position]} toast-container ...`); that mapping was lost, leaving the util dead code.

The mismatch is invisible to the compiler because the parameter is typed as a *semantic position* and then consumed as a *CSS class name* — two different vocabularies that happen to share a type. So it fails silently: no console warning, no type error, no test failure.

This PR re-imports the util and maps through it. The grouping key stays the semantic position (`Record<ContainerPosition, ItemObject>` is unchanged); only the emitted class string changes:

```
bottom-end  ->  class="bottom-0 end-0 toast-container position-fixed p-3"
```

Affects every position value, including the orchestrator's own `bottom-start` default. Present in 0.46.0 through 0.46.3 and on `main`; last good release was 0.45.10.

## Small replication

The reproduction in #3283 is the docs site itself — [useToast docs](https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/composables/useToast.html), under "Programmatically Hiding a Toast": clicking **Show the Toast** requests `bottom-center` but the toast appears in the upper left.

## Tests

Added coverage to `orchestrator.spec.ts` asserting the rendered container class — precisely what regressed:

- all nine `ContainerPosition` values map to their utility classes (e.g. `bottom-end` -> `bottom-0 end-0 toast-container position-fixed p-3`)
- the `bottom-start` fallback applies when a toast omits `position`

Verified these fail against the current code (all 10 report e.g. `expected 'bottom-end toast-container…' to be 'bottom-0 end-0 toast-container…'`) and pass with the fix.

`enableAutoUnmount(afterEach)` was hoisted to file scope so it covers both `describe` blocks — Vue Test Utils throws if it is called a second time.

Lint (eslint + oxlint), `vue-tsc` type-check, the full unit suite (155 files / 5536 tests) and the package build all pass.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [x] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toast container positioning so notifications now appear in the correct location across all supported placement options.
  * Added a reliable default placement when no position is specified.
  * Improved consistency with the framework’s layout and spacing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->