### PR TITLE
fix(toast): skip setting modelValue when value is already truthy in s…

### DIFF
--- a/packages/bootstrap-vue-next/src/composables/orchestratorShared/index.spec.ts
+++ b/packages/bootstrap-vue-next/src/composables/orchestratorShared/index.spec.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it} from 'vitest'
-import {ref, type Ref} from 'vue'
+import {describe, expect, it, vi} from 'vitest'
+import {type ComponentPublicInstance, ref, type Ref} from 'vue'
 import {buildController} from '.'
 import type {ControllerKey, ModalOrchestratorArrayValue} from '../../types/ComponentOrchestratorTypes'
 import {BvTriggerableEvent} from '../../utils'
@@ -113,6 +113,40 @@ describe('buildController', () => {
     expect(result).toBeInstanceOf(BvTriggerableEvent)
     expect(result.trigger).toBe('ok')
     expect(result.ok).toBe(true)
+  })
+
+  it('show does not overwrite numeric truthy modelValue when already showing', async () => {
+    const store = newStore()
+    const _self = Symbol('test-modal')
+
+    const {controller, resolve} = buildController<unknown, ModalStore>(_self, store)
+    pushItem(store, _self, {modelValue: 5000})
+
+    const showPromise = controller.show()
+    resolve(new BvTriggerableEvent('hidden'))
+    await showPromise
+
+    expect(store.value.get(_self)?.value.props.modelValue).toBe(5000)
+  })
+
+  it('show does not call component show when modelValue is already truthy', async () => {
+    const store = newStore()
+    const _self = Symbol('test-modal')
+    const showMock = vi.fn<() => void>()
+
+    const {controller, resolve} = buildController<unknown, ModalStore>(_self, store)
+    pushItem(store, _self, {modelValue: true})
+    controller.ref = {show: showMock} as unknown as ComponentPublicInstance<unknown> & {
+      show?: () => void
+      hide?: (trigger?: string, noEmit?: boolean) => void
+      toggle?: () => void
+    }
+
+    const showPromise = controller.show()
+    resolve(new BvTriggerableEvent('hidden'))
+    await showPromise
+
+    expect(showMock).not.toHaveBeenCalled()
   })
 
   it('show result has Symbol.asyncDispose that calls destroy', async () => {

--- a/packages/bootstrap-vue-next/src/composables/orchestratorShared/index.ts
+++ b/packages/bootstrap-vue-next/src/composables/orchestratorShared/index.ts
@@ -31,6 +31,13 @@ export const buildController = <
     id,
     ref: null as RefWithMethods | null,
     async show() {
+      const currentModelValue = controller.get()?.value.props.modelValue
+      if (currentModelValue) {
+        const event = await basePromise
+        return Object.assign(Object.create(event), {
+          [Symbol.asyncDispose]: controller.destroy,
+        })
+      }
       const refWithMethods = controller.ref
       if (
         refWithMethods !== null &&

--- a/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
+++ b/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
@@ -90,6 +90,24 @@ describe('useToast', () => {
     expect(toastRef?.get()?.value.props.title).toBe('World')
   })
 
+  it('preserves numeric modelValue when show is called immediately after create', async () => {
+    let toastRef: ReturnType<ReturnType<typeof useToast>['create']> | undefined
+    const TestComponent = defineComponent({
+      setup() {
+        const {create} = useToast()
+        toastRef = create({title: 'Countdown Toast', modelValue: 10000})
+        void toastRef.show()
+        return () => h('div')
+      },
+    })
+
+    mount(BApp, {slots: {default: () => h(TestComponent)}})
+    await nextTick()
+
+    expect(toastRef?.get()?.value.props.modelValue).toBe(10000)
+    toastRef?.hide('test')
+  })
+
   it('keeps instances in the store after hide and removes them only on destroy', async () => {
     let toastRef: ReturnType<ReturnType<typeof useToast>['create']> | undefined
     let toastStore: ReturnType<typeof useToast>['store'] | undefined


### PR DESCRIPTION
…how() composable method

# Describe the PR

A clear and concise description of what the pull request does.

## Small replication

A small replication or video walkthrough can help demonstrate the changes made. This is optional, but can help observe the intended changes. A mentioned issue that contains a replication also works.

## PR checklist

<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix :bug: - `fix(...)`
- [ ] Feature - `feat(...)`
- [ ] ARIA accessibility - `fix(...)`
- [ ] Documentation update - `docs(...)`
- [ ] Other (please describe)

**The PR fulfills these requirements:**

- [ ] Pull request title and all commits follow the [**Conventional Commits**](https://www.conventionalcommits.org/) convention or has an [**override**](https://github.com/googleapis/release-please#how-can-i-fix-release-notes) in this pull request body **This is very important, as the `CHANGELOG` is generated from these messages, and determines the next version type. Pull requests that do not follow conventional commits or do not have an override will be denied**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented visible modals and toasts from being shown a second time when already active.
  * Preserved numeric visibility values, ensuring components remain correctly displayed.
  * Improved handling of existing show events and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->