### PR TITLE
feat(useToast): add `hide` and `hideAll`, matching `useModal`

### DIFF
--- a/apps/docs/src/docs/composables/demo/UseToastGlobalHide.vue
+++ b/apps/docs/src/docs/composables/demo/UseToastGlobalHide.vue
@@ -1,0 +1,39 @@
+<template>
+  <BButtonGroup>
+    <BButton variant="success" @click="notify"> Show Toasts </BButton>
+    <BButton variant="warning" @click="hide('user-request', 'session-expiring')">
+      Hide Session Toast
+    </BButton>
+    <BButton variant="danger" @click="hideAll('route-change')"> Hide All </BButton>
+  </BButtonGroup>
+</template>
+
+<script setup lang="ts">
+import { BButton, BButtonGroup } from 'bootstrap-vue-next/components/BButton'
+import { useToast } from 'bootstrap-vue-next/composables/useToast'
+
+const { create, hide, hideAll } = useToast()
+
+// Shows the toast, then disposes of it once it has been hidden
+const show = async (payload: Parameters<typeof create>[0]) => {
+  await using toast = create(payload)
+  await toast.show()
+}
+
+const notify = () => {
+  void show({
+    id: 'session-expiring',
+    title: 'Session expiring',
+    body: 'You will be signed out soon',
+    variant: 'warning',
+    position: 'bottom-center',
+  })
+  void show({
+    id: 'sync-complete',
+    title: 'Sync complete',
+    body: 'Everything is up to date',
+    variant: 'success',
+    position: 'bottom-center',
+  })
+}
+</script>

--- a/apps/docs/src/docs/composables/useToast.md
+++ b/apps/docs/src/docs/composables/useToast.md
@@ -70,12 +70,14 @@ Toasts can also be hidden from anywhere in the app, without holding on to the co
 
 - `hideAll: (trigger?: string) => void`
 
-  Hides every toast
+  Hides every toast that was created through the composable
 
-Both functions hide toasts that were created through the composable, as well as `BToast` components
-declared in a template that were given a matching `id`. A toast that the orchestrator has not
-rendered yet is hidden through its store entry, so it never becomes visible. Those toasts report
-`modelValue` as their `trigger`, since there is no component to run the hide cycle through.
+`hide(trigger, id)` also hides a `BToast` that was declared in a template with a matching `id`.
+`hideAll` and `hide` without an `id` only cover the toasts that were created through the composable.
+
+A toast that the orchestrator has not rendered yet is hidden through its store entry, so it never
+becomes visible. Such a toast reports `modelValue` as its `trigger`, since there is no component to
+run the hide cycle through. The same applies to a toast rendered through a custom `component`.
 
 Hiding a toast does not remove it from the orchestrator store, see
 [Lifecycle and disposal](#lifecycle-and-disposal).

--- a/apps/docs/src/docs/composables/useToast.md
+++ b/apps/docs/src/docs/composables/useToast.md
@@ -55,6 +55,31 @@ Hiding a `Toast` programmatically is simple. The controller returned by `create`
 
 <<< DEMO ./demo/UseToastProgrammatic.vue
 
+## Globally Hiding Toasts
+
+Toasts can also be hidden from anywhere in the app, without holding on to the controller that
+`create` returned. Give the toast an `id`, then hide it by that `id`:
+
+<<< DEMO ./demo/UseToastGlobalHide.vue
+
+- `hide: (trigger?: string, id?: ControllerKey) => void`
+
+  Hides the toast with the given `id`. The `trigger` is passed to the `trigger` property of the
+  `hide` event and of the resolved `show` promise. When no `id` is given, every toast is hidden,
+  just like `hideAll`
+
+- `hideAll: (trigger?: string) => void`
+
+  Hides every toast
+
+Both functions hide toasts that were created through the composable, as well as `BToast` components
+declared in a template that were given a matching `id`. A toast that the orchestrator has not
+rendered yet is hidden through its store entry, so it never becomes visible. Those toasts report
+`modelValue` as their `trigger`, since there is no component to run the hide cycle through.
+
+Hiding a toast does not remove it from the orchestrator store, see
+[Lifecycle and disposal](#lifecycle-and-disposal).
+
 ## Lifecycle and disposal
 
 Created toast instances persist until you explicitly dispose them. Hiding a toast does not remove it from the orchestrator store.

--- a/packages/bootstrap-vue-next/src/composables/useToast/index.ts
+++ b/packages/bootstrap-vue-next/src/composables/useToast/index.ts
@@ -105,20 +105,28 @@ export const useToast = () => {
    * Hides a mounted BToast that registered itself under `id`. Going through the component, rather
    * than through the store, is what lets the trigger flow through the regular hide cycle
    *
-   * @returns whether an instance was found
+   * @returns whether a toast was found
    */
   const hideRegisteredInstance = (id: ControllerKey, trigger?: string): boolean => {
     // The show/hide registry is keyed by the html id, symbols never reach it
     if (typeof id !== 'string') return false
-    const instance = showHideRegistry?.values.value.get(id)?.getActive()
-    if (!instance) return false
-    instance.hide(trigger, true)
-    return true
+    const instances = showHideRegistry?.values.value.get(id)?.instances
+    if (!instances) return false
+    // Every show/hide component shares this registry, so an id may resolve to a BCollapse or a
+    // BModal. Only toasts are ours to hide. Newest first, the way the registry's getActive does
+    for (let i = instances.length - 1; i >= 0; i--) {
+      const instance = instances[i]
+      if (instance?.component.type !== BToast) continue
+      instance.hide(trigger, true)
+      return true
+    }
+    return false
   }
 
   /**
    * Hides a toast that lives in the orchestrator store. Prefers the mounted instance, falling back
    * to the store entry itself, which also covers toasts that the orchestrator has yet to render
+   * and toasts rendered through a custom `component`
    */
   const hideStoreItem = (item: Ref<ToastOrchestratorArrayValue>, trigger?: string): void => {
     if (hideRegisteredInstance(item.value.props.id ?? item.value.id, trigger)) return

--- a/packages/bootstrap-vue-next/src/composables/useToast/index.ts
+++ b/packages/bootstrap-vue-next/src/composables/useToast/index.ts
@@ -9,10 +9,15 @@ import {
   ref,
   type Ref,
 } from 'vue'
-import {orchestratorRegistryKey, type OrchestratorStoreObject} from '../../utils/keys'
+import {
+  orchestratorRegistryKey,
+  type OrchestratorStoreObject,
+  showHideRegistryKey,
+} from '../../utils/keys'
 import type {ContainerPosition} from '../../types/Alignment'
 import type {
   ComponentController,
+  ControllerKey,
   ToastOrchestratorArrayValue,
   ToastOrchestratorCreateParamBase,
 } from '../../types'
@@ -28,6 +33,7 @@ export const useToast = () => {
       'useToast() must be called within setup(), and BApp, useRegistry or plugin must be installed/provided.'
     )
   const {store, _isToastAppend, _isOrchestratorInstalled} = orchestratorRegistry
+  const showHideRegistry = inject(showHideRegistryKey, null)
 
   /**
    * @returns {ComponentController<typeof BToast, ToastOrchestratorParam>}
@@ -37,7 +43,8 @@ export const useToast = () => {
   // `useToast()`'s inferred return object.
   function create<
     ComponentProps extends Record<string, unknown> = Record<string, unknown>,
-    T extends ToastOrchestratorCreateParamBase<ComponentProps> = ToastOrchestratorCreateParamBase<ComponentProps>,
+    T extends ToastOrchestratorCreateParamBase<ComponentProps> =
+      ToastOrchestratorCreateParamBase<ComponentProps>,
   >(
     obj: MaybeRef<T> = {} as T
   ): ComponentController<typeof BToast, Ref<ToastOrchestratorArrayValue>> {
@@ -94,10 +101,71 @@ export const useToast = () => {
     return controller
   }
 
+  /**
+   * Hides a mounted BToast that registered itself under `id`. Going through the component, rather
+   * than through the store, is what lets the trigger flow through the regular hide cycle
+   *
+   * @returns whether an instance was found
+   */
+  const hideRegisteredInstance = (id: ControllerKey, trigger?: string): boolean => {
+    // The show/hide registry is keyed by the html id, symbols never reach it
+    if (typeof id !== 'string') return false
+    const instance = showHideRegistry?.values.value.get(id)?.getActive()
+    if (!instance) return false
+    instance.hide(trigger, true)
+    return true
+  }
+
+  /**
+   * Hides a toast that lives in the orchestrator store. Prefers the mounted instance, falling back
+   * to the store entry itself, which also covers toasts that the orchestrator has yet to render
+   */
+  const hideStoreItem = (item: Ref<ToastOrchestratorArrayValue>, trigger?: string): void => {
+    if (hideRegisteredInstance(item.value.props.id ?? item.value.id, trigger)) return
+    item.value = {
+      ...item.value,
+      props: {
+        ...item.value.props,
+        modelValue: false,
+      },
+    }
+  }
+
+  /**
+   * Hide all toasts
+   * @param trigger - The trigger to hide all toasts
+   */
+  const hideAll = (trigger?: string): void => {
+    for (const item of store.value.toast.values()) {
+      hideStoreItem(item, trigger)
+    }
+  }
+
+  /**
+   * Hide a toast
+   * @param trigger - The trigger to hide the toast
+   * @param id - The id of the toast to hide, when omitted every toast is hidden
+   */
+  const hide = (trigger?: string, id?: ControllerKey): void => {
+    if (id === undefined) {
+      hideAll(trigger)
+      return
+    }
+    const item = store.value.toast.get(id)
+    if (item) {
+      hideStoreItem(item, trigger)
+      return
+    }
+    // Not created through the composable, it could still be a BToast declared in a template
+    hideRegisteredInstance(id, trigger)
+  }
+
   return {
     _isToastAppend,
     _isOrchestratorInstalled,
     store,
     create,
+    hide,
+    hideAll,
   }
 }

--- a/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
+++ b/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
@@ -2,7 +2,14 @@ import {describe, expect, it} from 'vitest'
 import {computed, defineComponent, h, nextTick, ref, watchEffect} from 'vue'
 import {mount} from '@vue/test-utils'
 import BApp from '../../components/BApp/BApp.vue'
+import BToast from '../../components/BToast/BToast.vue'
+import type {BvTriggerableEvent} from '../../utils'
 import {useToast} from './index'
+
+// BOrchestrator binds the create payload's `onHide` on the component and re-invokes it from its
+// own `@hide` handler, so an orchestrated toast reports the same event object twice. Compare
+// events by identity to count hide cycles rather than listener calls
+const uniqueEvents = (events: readonly BvTriggerableEvent[]) => [...new Set(events)]
 
 describe('useToast', () => {
   it('create accepts a plain object and reads back the initial props', async () => {
@@ -132,5 +139,177 @@ describe('useToast', () => {
 
     await toastRef?.destroy()
     expect(toastStore?.value.toast.has(toastId)).toBe(false)
+  })
+
+  describe('hide', () => {
+    it('hides a toast by id and passes the trigger along', async () => {
+      const hideEvents: BvTriggerableEvent[] = []
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hide} = useToast()
+          toastHide = hide
+          create({
+            id: 'hide-by-id',
+            title: 'Hide By Id',
+            modelValue: true,
+            onHide: (e: BvTriggerableEvent) => {
+              hideEvents.push(e)
+            },
+          })
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHide?.('clear', 'hide-by-id')
+      await nextTick()
+
+      expect(uniqueEvents(hideEvents)).toHaveLength(1)
+      expect(hideEvents[0].trigger).toBe('clear')
+    })
+
+    it('hides a toast created without an id through its store entry', async () => {
+      let toastRef: ReturnType<ReturnType<typeof useToast>['create']> | undefined
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hide} = useToast()
+          toastHide = hide
+          toastRef = create({title: 'Symbol Keyed Toast', modelValue: true})
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      expect(toastRef?.get()?.value.props.modelValue).toBe(true)
+
+      toastHide?.('clear', toastRef?.id)
+      await nextTick()
+
+      expect(toastRef?.get()?.value.props.modelValue).toBe(false)
+    })
+
+    it('hides a toast declared in a template', async () => {
+      const hideEvents: BvTriggerableEvent[] = []
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {hide} = useToast()
+          toastHide = hide
+          return () =>
+            h(BToast, {
+              id: 'template-toast',
+              modelValue: true,
+              title: 'Template Toast',
+              onHide: (e: BvTriggerableEvent) => {
+                hideEvents.push(e)
+              },
+            })
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHide?.('clear', 'template-toast')
+      await nextTick()
+
+      expect(hideEvents).toHaveLength(1)
+      expect(hideEvents[0].trigger).toBe('clear')
+    })
+
+    it('does nothing when no toast matches the id', async () => {
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {hide} = useToast()
+          toastHide = hide
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      expect(() => toastHide?.('clear', 'not-a-toast')).not.toThrow()
+    })
+  })
+
+  describe('hideAll', () => {
+    it('hides every toast in the store', async () => {
+      const hideEvents: BvTriggerableEvent[] = []
+      let toastHideAll: ReturnType<typeof useToast>['hideAll'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hideAll} = useToast()
+          toastHideAll = hideAll
+          const onHide = (e: BvTriggerableEvent) => {
+            hideEvents.push(e)
+          }
+          create({id: 'hide-all-1', title: 'One', modelValue: true, onHide})
+          create({id: 'hide-all-2', title: 'Two', modelValue: true, onHide})
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHideAll?.('route-change')
+      await nextTick()
+
+      expect(uniqueEvents(hideEvents)).toHaveLength(2)
+      expect(uniqueEvents(hideEvents).map((e) => e.trigger)).toEqual([
+        'route-change',
+        'route-change',
+      ])
+    })
+
+    it('is what hide falls back to when no id is given', async () => {
+      const hideEvents: BvTriggerableEvent[] = []
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hide} = useToast()
+          toastHide = hide
+          const onHide = (e: BvTriggerableEvent) => {
+            hideEvents.push(e)
+          }
+          create({id: 'hide-no-id-1', title: 'One', modelValue: true, onHide})
+          create({id: 'hide-no-id-2', title: 'Two', modelValue: true, onHide})
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHide?.('route-change')
+      await nextTick()
+
+      expect(uniqueEvents(hideEvents)).toHaveLength(2)
+    })
+
+    it('hides toasts the orchestrator has not rendered yet', async () => {
+      let toastRef: ReturnType<ReturnType<typeof useToast>['create']> | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hideAll} = useToast()
+          toastRef = create({id: 'not-rendered-yet', title: 'Pending Toast', modelValue: true})
+          hideAll('route-change')
+          return () => h('div')
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      expect(toastRef?.get()?.value.props.modelValue).toBe(false)
+    })
   })
 })

--- a/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
+++ b/packages/bootstrap-vue-next/src/composables/useToast/useToast.spec.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest'
 import {computed, defineComponent, h, nextTick, ref, watchEffect} from 'vue'
 import {mount} from '@vue/test-utils'
 import BApp from '../../components/BApp/BApp.vue'
+import BCollapse from '../../components/BCollapse/BCollapse.vue'
 import BToast from '../../components/BToast/BToast.vue'
 import type {BvTriggerableEvent} from '../../utils'
 import {useToast} from './index'
@@ -221,6 +222,71 @@ describe('useToast', () => {
 
       expect(hideEvents).toHaveLength(1)
       expect(hideEvents[0].trigger).toBe('clear')
+    })
+
+    it('leaves other show/hide components that share the id alone', async () => {
+      const collapseHideEvents: BvTriggerableEvent[] = []
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {hide} = useToast()
+          toastHide = hide
+          return () =>
+            h(BCollapse, {
+              id: 'shared-id',
+              modelValue: true,
+              onHide: (e: BvTriggerableEvent) => {
+                collapseHideEvents.push(e)
+              },
+            })
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHide?.('clear', 'shared-id')
+      await nextTick()
+
+      expect(collapseHideEvents).toHaveLength(0)
+    })
+
+    it('hides the toast, not the component that shares its id', async () => {
+      const hideEvents: BvTriggerableEvent[] = []
+      const collapseHideEvents: BvTriggerableEvent[] = []
+      let toastHide: ReturnType<typeof useToast>['hide'] | undefined
+      const TestComponent = defineComponent({
+        setup() {
+          const {create, hide} = useToast()
+          toastHide = hide
+          create({
+            id: 'shared-id',
+            title: 'Shared Id Toast',
+            modelValue: true,
+            onHide: (e: BvTriggerableEvent) => {
+              hideEvents.push(e)
+            },
+          })
+          return () =>
+            h(BCollapse, {
+              id: 'shared-id',
+              modelValue: true,
+              onHide: (e: BvTriggerableEvent) => {
+                collapseHideEvents.push(e)
+              },
+            })
+        },
+      })
+
+      mount(BApp, {slots: {default: () => h(TestComponent)}})
+      await nextTick()
+
+      toastHide?.('clear', 'shared-id')
+      await nextTick()
+
+      expect(uniqueEvents(hideEvents)).toHaveLength(1)
+      expect(hideEvents[0].trigger).toBe('clear')
+      expect(collapseHideEvents).toHaveLength(0)
     })
 
     it('does nothing when no toast matches the id', async () => {


### PR DESCRIPTION
## Describe the PR

Adds `hide` and `hideAll` to `useToast`, covering the first half of #3327. A toast can now be dismissed by id from anywhere in the app, without the caller keeping the `ComponentController` that `create` returned.

```ts
const {hide, hideAll} = useToast()

hide('clear', 'session-expiring') // dismiss one toast by id
hideAll('route-change') // dismiss every toast
```

The `create()`-before-mount half of the issue is deliberately left out of this PR.

### How it resolves a toast

`hide(trigger, id)` tries, in order:

1. the mounted `BToast` registered under that id in the show/hide registry — going through the component is what lets `trigger` flow through the regular hide cycle, and it also picks up a plain `<BToast id="...">` declared in a template. That registry is shared by every show/hide component, so the lookup walks the id's instances newest-first (the way the registry's own `getActive` does) and takes the first `BToast`, leaving a `BCollapse` or `BModal` that carries the same id alone
2. the orchestrator store entry, setting `modelValue: false` the way `useModal.hide` does — the only path for a toast the orchestrator has yet to render (so a toast can be dismissed before it ever becomes visible), for toasts created without an id (symbols never reach the registry), and for a toast rendered through a custom `component`, which is not a `BToast` instance
3. nothing, if neither matches

Calling `hide(trigger)` with no id hides every toast, matching `$bvToast.hide()` in BootstrapVue. `hideAll(trigger)` walks the store and hides each entry through the same path.

Two known edges, both documented on the composable page:

- a toast hidden through its store entry reports `modelValue` as its `trigger`, since there is no component to run the hide cycle through. `useModal` has the same limitation on its store branch. Fixing it properly would mean exposing `hide` on the store entry's `fns`, which is a type shared with modal/popover/tooltip — happy to do that here instead if you would prefer it
- `hideAll` covers the store and not template-declared toasts. An orchestrated toast created without an id cannot be correlated with its registry entry, so including the registry in `hideAll` would hide some toasts twice

## PR checklist

- [x] Tests — `useToast.spec.ts` gains hide by id with trigger propagation, hide by symbol id through the store, hide of a template-declared toast, unknown-id no-op, two id-collision cases (a `BCollapse` sharing the id is left alone, and the toast is the one hidden when both exist), `hideAll` over two toasts, `hide()` with no id, and hiding a toast the orchestrator has not rendered yet
- [x] Docs — new "Globally Hiding Toasts" section plus a `UseToastGlobalHide.vue` demo
- [x] `pnpm --filter bootstrap-vue-next run test:lint`, `test:unit:ci` (5556 pass), `build`, `type-check`, and the docs build/lint all pass

## Unrelated notes

- The pre-commit hook runs `prettier --write` on library files while the package's `format` script uses `oxfmt`; the two disagree on `useToast/index.ts`, so the hook re-wrapped one pre-existing generic default. That is the 2-line deletion in the diff
- Separately, `BOrchestrator` binds the create payload's `onHide` via `v-bind="componentProps"` **and** re-invokes it from its own `@hide` handler, so a consumer's `onHide`/`onHidden` fires twice for orchestrated items. Pre-existing and untouched here; the new tests compare hide events by identity to work around it. Happy to file it separately

Closes part of #3327

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added global toast controls through `useToast`, allowing individual toasts to be hidden by ID or all composable-created toasts to be hidden at once.
  - Hiding supports programmatically created and template-declared toasts, including toasts that have not yet rendered.
  - Added a documentation demo showing how to display and dismiss sample toasts.

- **Documentation**
  - Documented global toast hiding, including ID-based and hide-all behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
